### PR TITLE
chore(knowledge): split out process concepts and enforce upkeep

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 
 Goal: leave the repo materially healthier and closer to release-ready, with evidence.
 
-This skill implements [`knowledge/specs/maintenance.md`](../../../knowledge/specs/maintenance.md). Keep operational guidance here. Keep design intent and constraints in the spec.
+This skill implements [`knowledge/processes/maintenance.md`](../../../knowledge/processes/maintenance.md). Keep operational guidance here. Keep design intent and constraints in the spec.
 
 This skill is outcome-oriented. Choose the smallest set of actions that closes the real maintenance risk in front of you.
 

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -11,7 +11,7 @@ user-invocable: true
 Goal: cut a new tuika release and verify every crate it was meant to publish
 lands on crates.io with documentation built.
 
-This skill implements [`knowledge/specs/release.md`](../../../knowledge/specs/release.md). Keep
+This skill implements [`knowledge/processes/release.md`](../../../knowledge/processes/release.md). Keep
 operational guidance here. Keep design intent in the spec.
 
 ## When To Use
@@ -151,7 +151,7 @@ dependency bumps, internal refactors, a docs-only patch.
 * fix(scope): description by @contributor
 ```
 
-Three rules carry the format ([spec](../../../knowledge/specs/release.md#changelog-format)):
+Three rules carry the format ([spec](../../../knowledge/processes/release.md#changelog-format)):
 
 - **The embed is pinned to `vX.Y.Z`, not `main`.** It 404s until `release.yml`
   creates the tag — expected, and it resolves before anyone reads the notes.
@@ -319,7 +319,7 @@ Declare **shipped** only when crates.io reports `X.Y.Z` for every crate the
 release was meant to publish and docs.rs has built. If a workflow fails, inspect
 logs (`gh run view <id> --log-failed`) and either re-run (transient — network or
 registry propagation) or open a hotfix PR (packaging bug — see
-[`knowledge/specs/release.md`](../../../knowledge/specs/release.md) § Hotfix
+[`knowledge/processes/release.md`](../../../knowledge/processes/release.md) § Hotfix
 Releases).
 
 ## Common Pitfalls
@@ -357,6 +357,6 @@ Releases).
 ## Authentication
 
 Required repo secret — set up once, see
-[`knowledge/specs/release.md`](../../../knowledge/specs/release.md) § Authentication.
+[`knowledge/processes/release.md`](../../../knowledge/processes/release.md) § Authentication.
 
 - `CARGO_REGISTRY_TOKEN` — crates.io publish scope.

--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -10,7 +10,7 @@ user-invocable: true
 
 Goal: land the requested change safely, with evidence, and merge only after CI is green.
 
-This skill implements [`knowledge/specs/shipping.md`](../../../knowledge/specs/shipping.md). Keep operational guidance here. Keep the shipping success bar and constraints in the spec.
+This skill implements [`knowledge/processes/shipping.md`](../../../knowledge/processes/shipping.md). Keep operational guidance here. Keep the shipping success bar and constraints in the spec.
 
 This skill is outcome-oriented. Do not blindly walk a fixed checklist. Start from the goal and changed risk surface, then choose the smallest path that proves the change is ready.
 

--- a/.github/workflows/nightly-terminals.yml
+++ b/.github/workflows/nightly-terminals.yml
@@ -5,7 +5,7 @@ name: Nightly Terminals
 # `gallery` example inside *real* terminal emulators nightly to check how they
 # actually interpret those bytes.
 #
-# Maturity differs by leg (see knowledge/specs/release.md § Manual Terminal Matrix):
+# Maturity differs by leg (see knowledge/processes/release.md § Manual Terminal Matrix):
 #   - tmux (Linux): text-capture via `capture-pane`, asserted — a regression
 #     here fails the nightly.
 #   - kitty / iTerm2 / Windows Terminal: GPU- or OS-locked GUI terminals driven

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,7 +395,7 @@ git log --format='%h %G? %s' origin/main..HEAD
   anyway when a change is risky, wants a second opinion, or needs the CI matrix
   before it lands — but routine maintainer work does not need one.
 - Direct-to-`main` work carries the same bar as a PR: signed commits, green CI,
-  and the artifacts in [Shipping](knowledge/specs/shipping.md) kept in sync.
+  and the artifacts in [Shipping](knowledge/processes/shipping.md) kept in sync.
 - **A change lands on `main` as one commit**, whichever path it took: a PR is
   squash-merged, and direct work is squashed locally before it is pushed. The
   work-in-progress history of a branch — fixups, re-recordings, review
@@ -420,13 +420,13 @@ Use `gh` directly for GitHub commands.
   exercises it, gather evidence, perform a security review, open a mergeable PR,
   address every review comment, and merge only after CI is green.
 - When asked to ship, follow [`.agents/skills/ship/SKILL.md`](.agents/skills/ship/SKILL.md)
-  and [`knowledge/specs/shipping.md`](knowledge/specs/shipping.md).
+  and [`knowledge/processes/shipping.md`](knowledge/processes/shipping.md).
 - When asked for maintenance or release readiness, follow
   [`.agents/skills/maintenance/SKILL.md`](.agents/skills/maintenance/SKILL.md)
-  and [`knowledge/specs/maintenance.md`](knowledge/specs/maintenance.md).
+  and [`knowledge/processes/maintenance.md`](knowledge/processes/maintenance.md).
 - When asked to release, cut a version, or publish to crates.io, follow
   [`.agents/skills/release/SKILL.md`](.agents/skills/release/SKILL.md) and
-  [`knowledge/specs/release.md`](knowledge/specs/release.md). `tuika` and
+  [`knowledge/processes/release.md`](knowledge/processes/release.md). `tuika` and
   `tuika-codeformatters` are versioned independently and published in dependency
   order.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,13 @@ recordings, and the documentation references stay in sync, and it runs in CI.
   changes are testable without a terminal.
 - tuika is a published library: adding, renaming, or removing a `pub` item is an
   API change. Call it out in the pull request so it lands in the changelog.
+- The template's **Knowledge** section refers to `knowledge/`, this repository's
+  durable record of *why* things are the way they are. A change that alters
+  behavior, intent, architecture, or a project policy updates the affected
+  concept in the same pull request; start from
+  [`knowledge/index.md`](./knowledge/index.md). Most changes need nothing there
+  — answer `No knowledge update required — <reason>` and that is a complete
+  answer, not a skipped step.
 - Pull requests are squash-merged after CI is green.
 
 ## Community

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -12,6 +12,25 @@ Concepts are split by what they describe: `specs/` defines the product — what
 tuika is and how it is built — while `processes/` defines how maintainers and
 agents work on it.
 
+## Maintaining this bundle
+
+The bundle is written by the work it describes, not swept up afterwards. When a
+change alters durable behavior, intent, architecture, policy, constraints,
+terminology, or maintainer process, update the affected concepts **in the same
+change**. A concept that no longer matches the code is a defect, not debt — and
+the reason for a decision is cheapest to write down while it is still at hand.
+
+- Adding, removing, renaming, or reclassifying a concept updates this index.
+  `scripts/validate_okf.py` fails on a concept the index does not list, so a
+  moved file cannot quietly become unreachable.
+- Significant changes get an entry in [the log](log.md); routine wording,
+  formatting, and link fixes do not.
+- Concepts capture **why** and **what**. Transient plans, task status, test
+  output, and exhaustive source-level detail belong outside the bundle.
+- Not every change needs one. When none applies, say so and why rather than
+  leaving the question unanswered — [Shipping](processes/shipping.md) makes that
+  an explicit outcome.
+
 ## Product direction
 
 - [Product goal](specs/goal.md) — what tuika is for, and the boundary it defends.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -8,6 +8,10 @@ Read this index first, then open only the concepts relevant to the task and
 follow their links. Public documentation lives in [`README.md`](../README.md)
 and [`docs/`](../docs/); it must not link back into this internal bundle.
 
+Concepts are split by what they describe: `specs/` defines the product — what
+tuika is and how it is built — while `processes/` defines how maintainers and
+agents work on it.
+
 ## Product direction
 
 - [Product goal](specs/goal.md) — what tuika is for, and the boundary it defends.
@@ -23,8 +27,8 @@ and [`docs/`](../docs/); it must not link back into this internal bundle.
 
 ## Engineering processes
 
-- [Testing](specs/testing.md) — hermetic rendering tests and the benchmark gates.
-- [Shipping](specs/shipping.md) — requirements for landing a change.
-- [Maintenance](specs/maintenance.md) — repository health and release readiness.
-- [Release](specs/release.md) — publishing tuika and tuika-codeformatters.
+- [Testing](processes/testing.md) — hermetic rendering tests and the benchmark gates.
+- [Shipping](processes/shipping.md) — requirements for landing a change.
+- [Maintenance](processes/maintenance.md) — repository health and release readiness.
+- [Release](processes/release.md) — publishing tuika and tuika-codeformatters.
 - [Documentation](specs/documentation.md) — public/internal documentation contract.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,7 +1,30 @@
 # Knowledge Log
 
-Significant changes to tuika's durable knowledge are recorded here. Routine
-wording, formatting, and link fixes do not need entries.
+Significant changes to tuika's durable knowledge are recorded here, in the same
+change that makes them — an entry says why the knowledge moved, and that reason
+is rarely recoverable later. Routine wording, formatting, and link fixes do not
+need entries.
+
+## 2026-07-25 — The bundle now states and enforces its own upkeep
+
+- The rule that concepts are updated by the change that invalidates them lived in
+  `AGENTS.md`, three skills, and the pull-request template — everywhere except
+  the bundle it governs. `index.md` read as consumption-only, so an agent that
+  arrived by a grep hit or a link, rather than through `AGENTS.md`, got the read
+  contract and no write contract. The index now carries the maintenance rule
+  itself, which also gives the concepts a single stated update trigger instead of
+  twelve unstated ones.
+- `scripts/validate_okf.py` fails on a concept the index does not list. This
+  enforces only the mechanical half — a moved or added file cannot become
+  unreachable — deliberately leaving "did this change need a concept update?" to
+  review, because a diff-shaped check for it would fire on the majority of
+  changes that legitimately need nothing and train people to ignore it.
+- `CONTRIBUTING.md` explains the template's Knowledge section; before, an
+  external contributor met that checkbox with no explanation anywhere in their
+  path. [Documentation](specs/documentation.md) now classifies `CONTRIBUTING.md`
+  as contributor material and states that the no-internal-links rule covers
+  `README.md` and `docs/` and nothing else — previously that scope was only
+  discoverable by reading the CI grep.
 
 ## 2026-07-25 — Process concepts split out of `specs/`
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -3,22 +3,23 @@
 Significant changes to tuika's durable knowledge are recorded here. Routine
 wording, formatting, and link fixes do not need entries.
 
-<<<<<<< HEAD
-## 2026-07-24 — Demo recordings can no longer be silently clipped
+## 2026-07-25 — Process concepts split out of `specs/`
 
-- Six gallery GIFs (`qr`, `ascii_font`, `diff`, `slider`, `timeline`,
-  `hyperlink`) shipped with content cut off: each scene's recorded height is a
-  hand-picked number in the `DEMOS` registry, and outgrowing it clips the
-  recording without failing anything.
-- Root cause: the tape heights were computed from a cell size the recorder did
-  not actually use, so a scene's `rows` was never the number of rows it got. The
-  harness now pins each scene to a fixed frame and the tapes ask for slightly
-  more room than that, making font metrics irrelevant to what a demo shows.
-- `demo -- check` now asserts a scene fits the frame it records into, and scenes
-  that overflow by design declare it in the registry. `--dump` renders at the
-  scene's recorded geometry, so the pre-record preview shows the real framing
-  instead of a roomier one. See [Documentation](specs/documentation.md).
-=======
+- The bundle mixed two kinds of knowledge under one directory: what tuika *is*
+  (goal, architecture, and the capability concepts) and how maintainers *work on
+  it*. The frontmatter already said so — four concepts carried
+  `type: Process Specification` — but the directory did not, so an agent reading
+  `knowledge/specs/` had no way to tell a product invariant from a workflow
+  requirement without opening each file.
+- [Testing](processes/testing.md), [Shipping](processes/shipping.md),
+  [Maintenance](processes/maintenance.md), and [Release](processes/release.md)
+  now live in `knowledge/processes/`. `specs/` holds product and architecture
+  concepts only, plus the [Documentation](specs/documentation.md) policy, which
+  governs the published surface rather than a maintainer workflow.
+- Content is unchanged; this is a reclassification. The OKF validator walks the
+  bundle recursively and does not care about directory names, so the split is a
+  readability contract rather than a tooling one.
+
 ## 2026-07-25 — Codegen shifts the instruction-count gate
 
 - Landing `ItemScroll` and the composer token seams turned the `iai` gate red on
@@ -30,9 +31,9 @@ wording, formatting, and link fixes do not need entries.
   took it to ~4.5%. Growing the crate re-partitions its codegen units, so
   unrelated modules change what gets inlined on a hot path. The `scroll.rs`
   refactor in the same change cost one instruction.
-- Recorded the isolation procedure in [Testing](specs/testing.md) so the next red
-  gate is diagnosed rather than blessed on a hunch — a shift that survives the
-  isolation is a real regression.
+- Recorded the isolation procedure in [Testing](processes/testing.md) so the
+  next red gate is diagnosed rather than blessed on a hunch — a shift that
+  survives the isolation is a real regression.
 
 ## 2026-07-24 — Element viewports and composer token seams
 
@@ -49,7 +50,21 @@ wording, formatting, and link fixes do not need entries.
   whenever the bar is enabled, and `measure_height` takes the same `scrollbar`
   flag — otherwise a host's clamp and the paint would disagree about content
   height.
->>>>>>> da4f9d8 (feat(components): add ItemScroll and composer token seams)
+
+## 2026-07-24 — Demo recordings can no longer be silently clipped
+
+- Six gallery GIFs (`qr`, `ascii_font`, `diff`, `slider`, `timeline`,
+  `hyperlink`) shipped with content cut off: each scene's recorded height is a
+  hand-picked number in the `DEMOS` registry, and outgrowing it clips the
+  recording without failing anything.
+- Root cause: the tape heights were computed from a cell size the recorder did
+  not actually use, so a scene's `rows` was never the number of rows it got. The
+  harness now pins each scene to a fixed frame and the tapes ask for slightly
+  more room than that, making font metrics irrelevant to what a demo shows.
+- `demo -- check` now asserts a scene fits the frame it records into, and scenes
+  that overflow by design declare it in the registry. `--dump` renders at the
+  scene's recorded geometry, so the pre-record preview shows the real framing
+  instead of a roomier one. See [Documentation](specs/documentation.md).
 
 ## 2026-07-24 — Showcases
 
@@ -107,7 +122,7 @@ wording, formatting, and link fixes do not need entries.
   guard — windowed render is O(viewport), paging is O(1) per event — hold at the
   new counts; only the constants moved.
 - Recorded two constraints the extraction exposed: snapshot grids are LF-only
-  (see [Testing](specs/testing.md)), and the PTY smoke needs the `gallery`
+  (see [Testing](processes/testing.md)), and the PTY smoke needs the `gallery`
   example built inside the coverage run's instrumented target directory.
 
 ## 2026-07-24 — Extraction from yolop

--- a/knowledge/processes/maintenance.md
+++ b/knowledge/processes/maintenance.md
@@ -40,7 +40,7 @@ That skill is user-invocable so maintenance can be requested directly as
 - Maintenance is risk-proportional, not sweep-proportional.
 - The selected scope must be explained, including what was skipped and why.
 - If maintenance changes code or behavior, affected artifacts must stay in sync:
-  `README.md`, `docs/`, rustdoc, `AGENTS.md`, `knowledge/specs/`, and generated
+  `README.md`, `docs/`, rustdoc, `AGENTS.md`, `knowledge/`, and generated
   demo assets.
 - Maintenance prefers concrete fixes over ceremonial audits when a safe local fix
   exists.
@@ -74,7 +74,7 @@ Deferred items are not failures. Untracked ones are.
 
 A capability is not complete merely because the code exists. tuika's surfaces are
 the public API, rustdoc, `README.md`, the guides in `docs/`, the demo scene
-registry, `knowledge/specs/`, and the test suite. Maintenance should catch:
+registry, `knowledge/`, and the test suite. Maintenance should catch:
 
 - `pub` items with no rustdoc, or rustdoc that no longer matches behavior
   (`#![warn(missing_docs)]` catches absence, not staleness)

--- a/knowledge/processes/maintenance.md
+++ b/knowledge/processes/maintenance.md
@@ -92,7 +92,7 @@ debt" note.
 ## Dependency Discipline
 
 The small dependency set is a designed property, not an accident
-([goal.md](./goal.md)). Maintenance defends it:
+([goal.md](../specs/goal.md)). Maintenance defends it:
 
 - **No new runtime dependency without an explicit justification in the PR.** The
   default answer for a heavy concern is a trait the host implements, or a place
@@ -130,7 +130,7 @@ credentials, so the surface is narrow and specific:
 
 - **Escape emission** — every out-of-band sequence must come from tuika's own
   encoder, never from interpolated caller text. Maintenance verifies that
-  property still holds ([out-of-band.md](./out-of-band.md)).
+  property still holds ([out-of-band.md](../specs/out-of-band.md)).
 - **Untrusted content** — markdown and code passed to `Markdown`/`CodeBlock` must
   degrade rather than panic or allocate unboundedly. The property tests and size
   sweeps are the standing defense; keep them running over the parsers.
@@ -182,5 +182,5 @@ details readable from code. Maintenance should:
 
 - [shipping.md](./shipping.md)
 - [release.md](./release.md)
-- [documentation.md](./documentation.md)
+- [documentation.md](../specs/documentation.md)
 - [testing.md](./testing.md)

--- a/knowledge/processes/release.md
+++ b/knowledge/processes/release.md
@@ -223,7 +223,7 @@ confirm the link is clickable **and** that surrounding text, colors, and wrappin
 are undamaged.
 
 **Graphics protocols** are the exception to "unknown escapes are harmless" and
-are gated on capability detection ([images.md](./images.md)); re-check the
+are gated on capability detection ([images.md](../specs/images.md)); re-check the
 `image` example on any terminal whose detection changed.
 
 ### Nightly cross-terminal job

--- a/knowledge/processes/shipping.md
+++ b/knowledge/processes/shipping.md
@@ -21,7 +21,7 @@ is user-invocable so shipping can be requested directly as `/ship`.
 1. Reach the requested goal, not just perform rituals around it.
 2. Match validation depth to the actual risk surface.
 3. Keep affected artifacts in sync (`README.md`, `docs/`, rustdoc, `AGENTS.md`,
-   `knowledge/specs/`, generated demo assets).
+   `knowledge/`, generated demo assets).
 4. Land only from a safe branch state with green CI.
 5. Keep the published history attributable: every commit signed and verified.
 

--- a/knowledge/processes/shipping.md
+++ b/knowledge/processes/shipping.md
@@ -137,6 +137,6 @@ Use the smallest set that gives high confidence.
 ## Related
 
 - [testing.md](./testing.md)
-- [documentation.md](./documentation.md)
+- [documentation.md](../specs/documentation.md)
 - [maintenance.md](./maintenance.md)
 - [release.md](./release.md)

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -141,5 +141,5 @@ side effect of reaching for a new language feature.
 ## Related
 
 - [shipping.md](./shipping.md)
-- [architecture.md](./architecture.md)
-- [out-of-band.md](./out-of-band.md)
+- [architecture.md](../specs/architecture.md)
+- [out-of-band.md](../specs/out-of-band.md)

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -32,17 +32,22 @@ terminal UI with tuika without requiring knowledge of repository internals.
   is what docs.rs renders as the front page; component demos are embedded inline
   on the relevant type via `raw.githubusercontent.com` URLs so they resolve
   there.
-- `knowledge/specs/` is internal durable memory: intent, constraints, tradeoffs,
-  and architectural decisions for maintainers.
-- `.agents/` and `AGENTS.md` contain contributor and agent workflows, not user
-  guidance.
+- `knowledge/` is internal durable memory: intent, constraints, tradeoffs, and
+  architectural decisions for maintainers, split into `specs/` (the product) and
+  `processes/` (working on it).
+- `.agents/`, `AGENTS.md`, and `CONTRIBUTING.md` are contributor and agent
+  workflow material, not user guidance. `CONTRIBUTING.md` addresses someone
+  changing tuika rather than using it, so it is the one contributor-facing file
+  a reader arrives at without being sent, and it may name internal machinery
+  where a contributor would otherwise be asked for something unexplained.
 
 ## Direction of links
 
 The public documentation boundary is one-way:
 
 - `README.md` and files below `docs/` MUST NOT link to internal documents below
-  `knowledge/` or `.agents/`, or require users to read them.
+  `knowledge/` or `.agents/`, or require users to read them. These two paths are
+  the whole of the restriction, and CI checks exactly them.
 - Public pages MAY link to other public pages, docs.rs, external standards, and
   source files when those links help complete a task.
 - Specs MAY link to public documentation to identify the user-facing surface.

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -84,7 +84,7 @@ staged by hand. The rule is that the *scene registry is the source of truth*:
 - The image demo is rendered directly by `examples/image_demo.rs` rather than
   recorded, because VHS captures through `ttyd` + `xterm.js`, which implements
   no graphics protocol and would only ever show the text fallback.
-- Release notes embed demos too — see [Release](./release.md#changelog-format) —
+- Release notes embed demos too — see [Release](../processes/release.md#changelog-format) —
   and they reuse the same `DEMOS` scenes rather than adding one-off assets. They
   are the one place that pins the raw URL to a release tag instead of `main`, so
   a later re-recording cannot rewrite what a past release appeared to ship. That

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -65,7 +65,7 @@ optional feature so tuika's dependency tree cannot grow by accident.
 
 tuika is pre-1.0 but published: every `pub` item is public API. Minor releases
 may make deliberate breaking changes, which must be called out in the changelog;
-patch releases may not. See [release.md](./release.md).
+patch releases may not. See [release.md](../processes/release.md).
 
 ## Public surface
 

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -76,7 +76,7 @@ host that restyles headings restyles them in markdown too. See
 - The streaming path is benchmarked (`benches/markdown.rs`,
   `benches/markdown_iai.rs`); the instruction-count baseline is a CI gate, so a
   change that re-tokenizes settled blocks fails the build rather than quietly
-  regressing. See [testing.md](./testing.md).
+  regressing. See [testing.md](../processes/testing.md).
 
 ## Non-goals
 

--- a/knowledge/specs/out-of-band.md
+++ b/knowledge/specs/out-of-band.md
@@ -85,4 +85,4 @@ see [`SECURITY.md`](../../SECURITY.md).
 
 - [images.md](./images.md)
 - [architecture.md](./architecture.md)
-- [testing.md](./testing.md)
+- [testing.md](../processes/testing.md)

--- a/scripts/test_validate_okf.py
+++ b/scripts/test_validate_okf.py
@@ -39,6 +39,46 @@ class ValidateOkfTests(unittest.TestCase):
             self.assertEqual(concepts, 0)
             self.assertEqual(messages, ["index.md: broken link -> specs/missing.md"])
 
+    def test_rejects_concept_the_index_does_not_list(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "index.md").write_text("# Index\n\n[Listed](specs/listed.md)\n")
+            (root / "specs").mkdir()
+            (root / "specs" / "listed.md").write_text("---\ntype: Policy\n---\n")
+            (root / "specs" / "orphan.md").write_text("---\ntype: Policy\n---\n")
+            messages, concepts = validate(root)
+            self.assertEqual(concepts, 2)
+            self.assertEqual(messages, ["specs/orphan.md: concept is not listed in index.md"])
+
+    def test_moving_a_concept_without_updating_the_index_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            # The index still points at the old location after the move.
+            (root / "index.md").write_text("# Index\n\n[Shipping](specs/shipping.md)\n")
+            (root / "processes").mkdir()
+            (root / "processes" / "shipping.md").write_text("---\ntype: Process\n---\n")
+            messages, _ = validate(root, check_links=True)
+            self.assertIn("processes/shipping.md: concept is not listed in index.md", messages)
+            self.assertIn("index.md: broken link -> specs/shipping.md", messages)
+
+    def test_bundle_without_an_index_skips_the_coverage_check(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "concept.md").write_text("---\ntype: Policy\n---\n")
+            messages, concepts = validate(root)
+            self.assertEqual(concepts, 1)
+            self.assertEqual(messages, [])
+
+    def test_log_entries_do_not_count_as_index_listings(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "index.md").write_text("# Index\n")
+            (root / "log.md").write_text("# Log\n\n[Concept](specs/concept.md)\n")
+            (root / "specs").mkdir()
+            (root / "specs" / "concept.md").write_text("---\ntype: Policy\n---\n")
+            messages, _ = validate(root)
+            self.assertEqual(messages, ["specs/concept.md: concept is not listed in index.md"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate_okf.py
+++ b/scripts/validate_okf.py
@@ -5,6 +5,11 @@ Usage: python3 scripts/validate_okf.py <bundle-dir> [--strict] [--check-links]
 
 --strict requires title, description, and timestamp in addition to OKF's
 required type field. --check-links validates local Markdown link targets.
+
+Every concept must also be reachable from the bundle index, so adding, moving,
+or renaming one without updating `index.md` fails rather than leaving a concept
+nobody is routed to. This is the mechanical half of keeping the bundle current;
+whether a change *needed* a concept update is a judgement review still owns.
 """
 
 from __future__ import annotations
@@ -13,7 +18,8 @@ import re
 import sys
 from pathlib import Path
 
-RESERVED = {"index.md", "log.md"}
+INDEX = "index.md"
+RESERVED = {INDEX, "log.md"}
 FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 LINK_RE = re.compile(r"\]\(([^)\s]+)(?:\s+['\"][^)]*['\"])?\)")
 SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
@@ -51,13 +57,34 @@ def local_link_target(root: Path, source: Path, target: str) -> Path | None:
     return source.parent / target
 
 
+def indexed_concepts(root: Path) -> set[str] | None:
+    """Bundle-relative paths the index links to, or None when there is no index."""
+    index = root / INDEX
+    if not index.is_file():
+        return None
+    linked: set[str] = set()
+    text = index.read_text(encoding="utf-8", errors="replace")
+    for target in LINK_RE.findall(text):
+        local = local_link_target(root, index, target)
+        if local is None:
+            continue
+        try:
+            linked.add(local.resolve().relative_to(root.resolve()).as_posix())
+        except ValueError:
+            continue  # links out of the bundle are not concept listings
+    return linked
+
+
 def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> tuple[list[str], int]:
     messages: list[str] = []
     concepts = 0
+    linked = indexed_concepts(root)
     for path in sorted(root.rglob("*.md")):
         rel = path.relative_to(root).as_posix()
         text = path.read_text(encoding="utf-8", errors="replace")
         if path.name not in RESERVED:
+            if linked is not None and rel not in linked:
+                messages.append(f"{rel}: concept is not listed in {INDEX}")
             frontmatter, error = parse_frontmatter(text)
             if error:
                 messages.append(f"{rel}: {error}")

--- a/src/image.rs
+++ b/src/image.rs
@@ -27,7 +27,7 @@
 //! Graphics protocols do not degrade as harmlessly as an unknown OSC — an
 //! unsupported terminal may paint the payload as garbage — so this is the first
 //! tuika feature to gate on real capability detection ([`ImageSupport::detect`]).
-//! See `knowledge/specs/tuika-images.md` for the full design and phased plan.
+//! See `knowledge/specs/images.md` for the full design and phased plan.
 
 use std::cell::RefCell;
 use std::io::{self, Write};

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -334,7 +334,7 @@ impl<'a> Builder<'a> {
     /// is never silently dropped. Actually painting the pixels in markdown
     /// (resolving the URL to [`ImageData`](crate::image::ImageData) and emitting
     /// through an [`ImageLayer`](crate::image::ImageLayer)) is a later phase; see
-    /// `knowledge/specs/tuika-images.md`.
+    /// `knowledge/specs/images.md`.
     fn push_image_placeholder(&mut self, url: &str, alt: &str) {
         let label = if alt.trim().is_empty() { url } else { alt };
         self.inline.push(RichSpan::styled(

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -10,7 +10,7 @@
 //!
 //! This covers the *protocol* a terminal receives. Whether a specific emulator
 //! paints those bytes correctly is the cross-terminal nightly plus the manual
-//! matrix in `knowledge/specs/release.md`.
+//! matrix in `knowledge/processes/release.md`.
 #![cfg(unix)]
 
 use std::io::{Read, Write};


### PR DESCRIPTION
## What changed

**Process concepts moved out of `specs/`.** All twelve concepts lived under `knowledge/specs/`, but four carried `type: Process Specification` in their frontmatter. Those four — testing, shipping, maintenance, release — now live in `knowledge/processes/`. `specs/` keeps the product and architecture concepts, plus the documentation policy, which governs the published surface rather than a maintainer workflow. Content is unchanged; the directory now matches what the frontmatter always said, so a reader can tell a product invariant from a workflow requirement without opening each file.

**The bundle states its own upkeep rule.** The rule that a change updates the concepts it invalidates was written in `AGENTS.md`, three skills, and this template — everywhere except the bundle it governs. `knowledge/index.md` read as consumption-only, so anyone arriving by a grep hit or a link rather than through `AGENTS.md` got the read contract and no write contract. The index now carries the rule, which also gives the concepts one stated update trigger instead of twelve unstated ones.

**`validate_okf.py` enforces the mechanical half.** A concept the index does not list is now a failure, so a moved or added file cannot become unreachable — the exact mistake this move was one slip away from making. Deliberately *only* the mechanical half: a diff-shaped check for "did this change need a concept update?" would fire on the majority of changes that legitimately need nothing, and a warning everyone learns to dismiss is worse than none. That judgement stays with review.

**Contributor path.** `CONTRIBUTING.md` explains what the template's Knowledge section asks for; an external contributor previously met that checkbox with no explanation anywhere in their path. This needed a boundary decision, so it is now stated rather than implied: `documentation.md` classifies `CONTRIBUTING.md` as contributor material and records that the no-internal-links rule covers `README.md` and `docs/` **and nothing else** — scope that was previously only discoverable by reading the CI grep.

### Unrelated fix folded in, deliberately

`main` currently has **unresolved conflict markers committed in `knowledge/log.md`**, introduced by 25247e4:

```
6:<<<<<<< HEAD
21:=======
37:>>>>>>> da4f9d8 (feat(components): add ItemScroll and composer token seams)
```

Rebasing onto `main` meant resolving that exact region, so this branch fixes it — both log entries are kept, ordered newest first. Calling it out because it is not part of the stated scope and should not look incidental.

## Why

The bundle mixed two kinds of knowledge under one directory, and the rule keeping it current lived only in the documents pointing *at* it. Both are discoverability problems that get worse as the bundle grows.

## Before / After

No user-visible or rendering change. The one behavior change is the validator, shown against a real unlisted concept:

**Before** — a concept absent from the index passes:
```
12 concept(s) checked in knowledge — 0 error(s)
```

**After**:
```
FAIL: specs/_probe.md: concept is not listed in index.md

13 concept(s) checked in knowledge — 1 error(s)
```

Evidence on the rebased branch:

```
cargo fmt --all -- --check                                    OK
cargo clippy --all-targets --all-features -- -D warnings      clean
cargo test --all-features                                     350 + 3 + 4 + 30 passed, 0 failed
python3 scripts/validate_okf.py knowledge --check-links       12 concepts, 0 errors
python3 scripts/test_validate_okf.py                          7 passed (3 pre-existing + 4 new)
cargo run --example demo -- check                             27 scenes, recordings, references in sync
docs boundary grep over README.md + docs                      clean
```

## Risk

- **Low.** Documentation and repository machinery. No library code changes beyond two rustdoc path strings.
- What can break: an inbound link to a moved concept. All 10 were updated and verified — `AGENTS.md`, the three `.agents/skills/`, `nightly-terminals.yml`, `tests/pty_smoke.rs`, and the in-bundle cross-links. The OKF link check covers links inside the bundle; the ones outside it were verified by resolving each path.
- The new validator rule could block an unrelated PR that adds a concept without indexing it. That is the intended behavior, and the failure message names the fix.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

**API change:** none. No `pub` item added, renamed, removed, or resignatured; no dependency added. `validate_okf.py` gains the module-level `indexed_concepts()`, which is a repository script, not published surface.

## Knowledge

Updated: `knowledge/index.md` (the split, plus the new maintenance section), `knowledge/log.md` (two entries), `knowledge/specs/documentation.md` (information architecture and link-direction scope), and the four moved concepts. Three prose references reading `knowledge/specs/` when they meant the whole bundle were corrected in `shipping.md`, `maintenance.md`, and `documentation.md`.

## Security

No security-relevant code changes. Reviewed against the repository's threat model and none of the categories are touched: no escape sequence is emitted or encoded (TM-ESC), no terminal enter/restore path changes (TM-STATE), no parser or layout path handles untrusted content differently (TM-PARSE), no buffer writes or clipping change (TM-CLIP), and no dependency is added (TM-DEP). The two `src/` edits are rustdoc comment strings.

The one executable change is `scripts/validate_okf.py`, a CI-only, standard-library-only script. `indexed_concepts()` reads `index.md` and resolves link targets to compare paths; it never executes, imports, or renders file content, and `relative_to()` failures are caught so a link pointing outside the bundle is skipped rather than raising.

## Follow-ups

- **`main` is red on `iai-callgrind`, unrelated to this PR.** Run 30138803415 fails at "Check against committed baseline": 25247e4 shifted instruction counts via `ItemScroll` and the `textinput` changes without re-blessing `iai-baseline.json`. Every other job on that run passed. This PR touches no `*.rs`, `Cargo.toml`, or baseline file, so the `rust` path filter is false and the `iai` job is skipped here — this change can neither cause nor fix that failure. Re-blessing the baseline needs Valgrind and a version-matched runner and belongs with whoever owns that change.
- `--strict` mode still fails for all twelve concepts on the missing `timestamp` field. Pre-existing and not enforced by CI, which runs the non-strict form; left alone rather than stamping twelve files in a reclassification PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_017d3APohspz3oEpu1nq8Thf)_