### PR TITLE
feat(themes): inherit the terminal's palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ preference:
 | --- | --- |
 | `tuika::` | the framework spine — `View`, `Element`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
 | `tuika::components` | every widget |
-| `tuika::term` | everything out-of-band: `clipboard`, `hyperlink`, `progress`, `pointer`, `image`, `capabilities` |
+| `tuika::term` | everything out-of-band: `clipboard`, `hyperlink`, `progress`, `pointer`, `image`, `capabilities`, `palette` |
 | `tuika::prelude` | the spine and the components in one glob import |
 
 - **New**: `tuika::prelude` — `use tuika::prelude::*;` replaces most import
@@ -27,6 +27,29 @@ preference:
   test, snapshot, and benchmark passes unchanged apart from its imports, and
   `tests/public_api.rs` now pins the layout from outside the crate, the way a
   host sees it.
+
+**A theme can be inherited from the terminal.** An application can adopt the
+palette the user already configured instead of imposing its own — opt-in and
+host-initiated, so nothing changes for an app that does not ask.
+
+- **New**: `themes::TERMINAL` (also `Theme::terminal()`, and a `terminal` entry
+  in `themes::PRESETS`) — a `const Theme` whose every slot is `Color::Reset` or a
+  `Color::Indexed` ANSI slot, so the terminal resolves the palette. No query, no
+  timeout, no failure mode.
+- **New**: `tuika::term::palette` — `TerminalPalette` with `parse`/`query`, plus
+  `QUERY_FOREGROUND`, `QUERY_BACKGROUND`, and `query_sequence()`. Asks the
+  terminal for its colors with the xterm queries (OSC 10 / 11 / 4), fenced by the
+  Device Attributes request so an unsupported query costs a round-trip rather
+  than a timeout.
+- **New**: `Theme::from_terminal(&TerminalPalette)` derives a full theme from the
+  reply — reported foreground and background verbatim, in-between tones blended
+  and contrast-guarded, hues from the ANSI palette.
+- **New**: `Capabilities::query_with_palette(timeout)` answers "what can this
+  terminal do" and "what colors is it using" in one round-trip.
+- **New example**: `cargo run --example inherit` (and `-- --probe` to print what
+  your terminal answers without taking over the screen).
+
+Additive only — nothing moved or was renamed by this change.
 
 ### Breaking Changes
 
@@ -91,3 +114,4 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 * refactor(tests): move the crate's test scaffolding under `src/tests`
 * test: pin the public module layout from outside the crate (`tests/public_api.rs`)
 * docs: add `knowledge/specs/api-surface.md` and a crate-layout section to the README
+* feat(themes): inherit the terminal's palette

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Four places, so you can guess where something is:
 | --- | --- |
 | `tuika::` | the framework spine — `View`, `Element`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
 | `tuika::components` | every widget: `Flex`, `Boxed`, `Text`, `Scroll`, `Markdown`, `Table`, … |
-| `tuika::term` | everything out-of-band: `clipboard` (OSC 52), `hyperlink` (OSC 8), `progress` (OSC 9;4), `pointer` (OSC 22), `image`, `capabilities` |
+| `tuika::term` | everything out-of-band: `clipboard` (OSC 52), `hyperlink` (OSC 8), `progress` (OSC 9;4), `pointer` (OSC 22), `image`, `capabilities`, `palette` (the terminal's own colors) |
 | `tuika::prelude` | the spine and the components in one glob import |
 
 Application code usually wants the prelude:
@@ -254,6 +254,13 @@ let c = tuika::themes::by_name("gruvbox-dark").unwrap(); // config / --theme
 See the [theme gallery](docs/themes.md) for a screenshot of each bundled
 palette, or `themes::PRESETS` to enumerate them for a picker.
 
+An app can also inherit the palette the user already configured in their
+terminal, rather than bringing its own — either implicitly with `themes::TERMINAL`
+(ANSI slots, no I/O) or by asking the terminal for its actual colors and deriving
+a full theme from the reply. It is opt-in: tuika never probes unless a host asks
+it to. The query lives with the other out-of-band escapes, in `term::palette`. See
+[inheriting the terminal's colors](docs/features.md#inheriting-the-terminals-colors).
+
 Where a `Theme` is the color *tokens*, a `StyleSheet` is the *rules* — a mapping
 from a semantic role (heading, link, inline code, a panel's border and fill, …)
 onto the style it draws with. Override a role in one place and every element with
@@ -275,6 +282,7 @@ Each enters the alternate screen; press `q` (or `esc`) to quit.
 | [`async_dashboard`](examples/async_dashboard.rs) | `cargo run --example async_dashboard --features async` | `AsyncRunner` polling on a Tokio runtime, no shared state |
 | [`mouse`](examples/mouse.rs)     | `cargo run --example mouse`      | drag-to-select + highlight + OSC 52 copy, clickable buttons |
 | [`image`](examples/image.rs)     | `cargo run --example image`      | `Image` over reserved cells (Kitty/iTerm2/Sixel), alt-text fallback |
+| [`inherit`](examples/inherit.rs) | `cargo run --example inherit`    | adopting the terminal's own palette — probe, derive, and the no-I/O fallback |
 | [`codex`](examples/codex)        | `cargo run --example codex`      | a whole coding-agent TUI — [demo](docs/showcases.md#codex-cli-replica-in-repo-example) (a UI replica, see below): streaming transcript, composer, `@`/`/` pickers, approval prompt |
 
 Each of the single-topic examples above quits on `q`/`esc`. [`codex`](examples/codex)

--- a/docs/features.md
+++ b/docs/features.md
@@ -42,6 +42,94 @@ raw mode, before the event loop reads stdin (Unix ttys only; elsewhere it is jus
 round-trip itself. Kitty and iTerm2 keep their reliable environment detection
 (DA1 doesn't report them).
 
+## Inheriting the terminal's colors
+
+The user already chose a palette — in Ghostty, kitty, WezTerm, wherever they
+work. An application can adopt it instead of imposing its own, so it looks like
+it belongs in the terminal it was launched from.
+[API](https://docs.rs/tuika/latest/tuika/term/palette/index.html)
+
+**This never happens on its own.** tuika ships a default theme and changes it for
+nobody; inheriting is something a host asks for, explicitly, with one of the two
+calls below. Nothing here runs unless you call it.
+
+There are two ways, and they trade accuracy against cost.
+
+### Without asking the terminal anything
+
+`themes::TERMINAL` is a `const Theme` whose every slot is `Color::Reset` or a
+`Color::Indexed` ANSI slot, so the terminal resolves the palette itself:
+
+```rust
+use tuika::themes;
+
+let theme = themes::TERMINAL;   // that's it — no I/O, no timeout, no failure
+```
+
+It cannot be wrong about the user's setup and cannot fail — it works on a
+terminal that answers nothing at all, and on a light background as readily as a
+dark one. The limit is that ANSI has no tone *between* two slots, so tuika's
+raised and faint roles collapse: `surface` and the code background come out as
+the plain background, and `dim`, `border`, and `muted` all land on bright black.
+Panels and rules read flatter than a designed palette.
+
+### By asking
+
+For real 24-bit values — and therefore real in-between tones — ask the terminal
+what its colors are and derive a theme from the answer:
+
+```rust
+use std::time::Duration;
+use tuika::{Theme, themes};
+use tuika::term::capabilities::Capabilities;
+
+// In raw mode, at startup, before the event loop reads stdin:
+let (caps, palette) = Capabilities::query_with_palette(Duration::from_millis(100));
+let theme = Theme::from_terminal(&palette).unwrap_or(themes::TERMINAL);
+```
+
+The queries are the xterm ones: `OSC 10` for the default foreground, `OSC 11` for
+the background, `OSC 4` per ANSI entry. Ghostty, kitty, WezTerm, foot, alacritty,
+contour, iTerm2, and xterm answer them; others answer nothing, and
+`from_terminal` returns `None` so you fall back.
+
+`Theme::from_terminal` uses the reported foreground and background **verbatim** —
+that is the whole point — and derives everything the terminal has no notion of:
+
+- The in-between tones (`surface`, `muted`, `dim`, `border`, the code
+  background) are blends between the foreground and the background, so a light
+  palette and a dark one both work without a special case.
+- The hues (`accent`, and the syntax roles) come from the ANSI palette, taking
+  the bright half on a dark background and the normal half on a light one. Blue
+  leads and cyan follows: a terminal reports no notion of a *brand* color, so
+  tuika takes the conventional interactive hue rather than inventing one.
+- Every derived color is held to a minimum contrast against the background. A
+  user's palette is free to put two colors on top of each other; a UI built out
+  of it is not.
+
+Any ANSI slot the terminal does not report falls back to xterm's default for that
+slot, so a terminal that answers `OSC 10` and `OSC 11` but not `OSC 4` still
+yields a complete theme.
+
+### Why the query is fenced
+
+A terminal that does not implement `OSC 11` does not say so — it stays quiet, and
+a reader cannot tell *not yet* from *never*. So tuika appends the Device
+Attributes request (`DA1_REQUEST`), which every terminal answers, as a **fence**:
+once its reply arrives, every color reply that was ever coming has arrived. The
+probe therefore costs one round-trip rather than one timeout, and because that is
+the same request the capability probe already makes,
+`Capabilities::query_with_palette` answers both questions at once.
+
+Call it **once at startup, in raw mode, before the event loop reads stdin** — the
+replies arrive on stdin, and a running event loop would deliver them to your
+application as keystrokes. The read stops exactly at the fence, so input typed
+behind the replies is left for the application.
+
+The [`inherit`](../examples/inherit.rs) example does all of this end to end —
+including `cargo run --example inherit -- --probe`, which prints what your
+terminal actually answers without taking over the screen.
+
 ## Hyperlinks (OSC 8)
 
 Turn a bare `http(s)` URL — or a markdown `[label](url)` whose visible text is

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -70,6 +70,27 @@ The widely-ported dark theme — purple/pink accents on a slate background.
 
 <img src="themes/theme-dracula.gif" width="880" alt="Dracula theme">
 
+## `terminal`
+
+The one preset with no colors of its own. Every slot is `Color::Reset` or a
+`Color::Indexed` ANSI slot, so the **terminal** resolves the palette — the app
+adopts whatever the user already configured, with no query and no failure mode.
+[struct](https://docs.rs/tuika/latest/tuika/themes/constant.TERMINAL.html)
+
+It has no recording here for the same reason it has no colors: what it looks like
+is whatever terminal you run it in, so a GIF of it would only ever be a picture
+of the recorder's palette. Run it yourself instead:
+
+```text
+cargo run --example inherit
+```
+
+Because ANSI has no tone between two slots, the raised and faint roles collapse
+(`surface` reads as the background; `dim`, `border`, and `muted` all land on
+bright black). To keep those distinct, ask the terminal for its actual colors and
+derive them — `Theme::from_terminal` — which is covered in
+[terminal features](features.md#inheriting-the-terminals-colors).
+
 ## Rolling your own
 
 The bundled palettes are a starting point, not a ceiling. Construct a `Theme`

--- a/examples/inherit.rs
+++ b/examples/inherit.rs
@@ -1,0 +1,172 @@
+//! Inherit the terminal's own colors. Run with `cargo run --example inherit`
+//! (`q`/`esc` quits).
+//!
+//! Two ways to make a tuika app look like it belongs in the terminal the user
+//! configured, and this example shows both plus the fallback between them:
+//!
+//! - Ask the terminal for its palette ([`Capabilities::query_with_palette`]) and
+//!   derive a full theme from the answer ([`Theme::from_terminal`]). Real 24-bit
+//!   colors, so the in-between tones — panels, rules, selection bands — can be
+//!   blended and contrast-checked.
+//! - Fall back to [`themes::TERMINAL`], which needs no query at all: every slot
+//!   is an ANSI index or `Reset`, so the terminal resolves it.
+//!
+//! The probe is the interesting part. It must run **in raw mode, before the
+//! event loop reads stdin** — the replies arrive on stdin, and an event loop
+//! already running would swallow them as keystrokes. That is the whole reason
+//! this example enters raw mode itself, probes, leaves raw mode, and only then
+//! starts the runner.
+//!
+//! `--probe` does just the query and prints what came back, without taking over
+//! the screen — the fastest way to see what your terminal actually answers:
+//!
+//! ```text
+//! cargo run --example inherit -- --probe
+//! ```
+
+use std::io;
+use std::ops::ControlFlow;
+use std::time::Duration;
+
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span};
+
+use tuika::components::{Flex, Rule, Text};
+use tuika::term::capabilities::Capabilities;
+use tuika::{Event, KeyCode, Padding, Runner, RunnerConfig, Theme, themes, view};
+
+/// How long to wait for the terminal to answer. A real tty replies to the
+/// Device Attributes fence immediately, so this is only reached on a terminal
+/// that ignores the query entirely.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Where the running theme came from, so the UI can say so.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Source {
+    /// The terminal answered; every color below is derived from its palette.
+    Probed,
+    /// The terminal said nothing, so the ANSI-slot theme inherits implicitly.
+    AnsiSlots,
+}
+
+impl Source {
+    fn label(self) -> &'static str {
+        match self {
+            Source::Probed => "probed — derived from the colors this terminal reported",
+            Source::AnsiSlots => "themes::TERMINAL — the terminal answered nothing, ANSI slots",
+        }
+    }
+}
+
+/// Enter raw mode, ask the terminal for its palette, and leave raw mode.
+///
+/// The raw-mode enable and disable are paired here rather than left to the
+/// runner: a probe that returns early must not strand the terminal.
+fn probe() -> io::Result<(Theme, Source)> {
+    crossterm::terminal::enable_raw_mode()?;
+    let (_caps, palette) = Capabilities::query_with_palette(PROBE_TIMEOUT);
+    crossterm::terminal::disable_raw_mode()?;
+
+    Ok(match Theme::from_terminal(&palette) {
+        Some(theme) => (theme, Source::Probed),
+        None => (themes::TERMINAL, Source::AnsiSlots),
+    })
+}
+
+/// `#rrggbb` for a derived color, or the ANSI slot's own name when the theme is
+/// the one the terminal resolves for itself.
+fn describe(color: Color) -> String {
+    match color {
+        Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+        Color::Reset => "terminal default".to_string(),
+        Color::Indexed(i) => format!("ansi {i}"),
+        other => format!("{other:?}"),
+    }
+}
+
+/// The theme slots worth showing, in the order the UI lists them.
+fn slots(theme: &Theme) -> Vec<(&'static str, Color)> {
+    vec![
+        ("background", theme.background),
+        ("surface", theme.surface),
+        ("text", theme.text),
+        ("muted", theme.muted),
+        ("dim", theme.dim),
+        ("accent", theme.accent),
+        ("accent_alt", theme.accent_alt),
+        ("border", theme.border),
+        ("selection_bg", theme.selection_bg),
+        ("code.keyword", theme.code.keyword),
+        ("code.string", theme.code.string),
+        ("code.comment", theme.code.comment),
+    ]
+}
+
+fn build(theme: &Theme, source: Source) -> tuika::Element {
+    // Each row paints its own color, so the swatch is the color itself rather
+    // than a description of it.
+    let rows: Vec<tuika::Element> = slots(theme)
+        .into_iter()
+        .map(|(name, color)| {
+            let line = Line::from(vec![
+                Span::styled("████", Style::default().fg(color)),
+                Span::styled(
+                    format!(" {name:<13} {}", describe(color)),
+                    Style::default().fg(theme.text),
+                ),
+            ]);
+            tuika::element(Text::new(vec![line]))
+        })
+        .collect();
+
+    let mut palette = Flex::column();
+    for row in rows {
+        palette = palette.fixed(1, row);
+    }
+
+    view! {
+        col(padding = Padding::all(1), gap = 1,
+            background = Style::default().bg(theme.background)) {
+            fixed(3) {
+                boxed(title = Line::from(Span::styled(" inherited theme ", theme.accent_style()))) {
+                    text(source.label().to_string())
+                }
+            }
+            fixed(14) {
+                boxed(title = Line::from(Span::styled(" slots ", theme.accent_style()))) {
+                    node(palette)
+                }
+            }
+            fixed(1) { node(Rule::new()) }
+            fixed(1) {
+                text("q / esc to quit".to_string())
+            }
+        }
+    }
+}
+
+fn main() -> io::Result<()> {
+    let probe_only = std::env::args().any(|a| a == "--probe");
+    let (theme, source) = probe()?;
+
+    if probe_only {
+        // Plain text, no alternate screen: usable over a pipe and in a test.
+        println!("source: {}", source.label());
+        for (name, color) in slots(&theme) {
+            println!("{name}: {}", describe(color));
+        }
+        return Ok(());
+    }
+
+    let runner = Runner::new(RunnerConfig::default());
+    runner.run(
+        &theme,
+        |_frame| build(&theme, source),
+        |event| match event {
+            Event::Key(key) if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) => {
+                ControlFlow::Break(())
+            }
+            _ => ControlFlow::Continue(()),
+        },
+    )
+}

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,29 @@ change that makes them — an entry says why the knowledge moved, and that reaso
 is rarely recoverable later. Routine wording, formatting, and link fixes do not
 need entries.
 
+## 2026-07-25 — A theme can be inherited from the terminal
+
+- Added a third source for a `Theme`, beside the bundled presets and a host's own
+  literal: the terminal the application was launched in. [Styling](specs/styling.md)
+  now states where the line falls between what an inherited theme *reports* and
+  what it *derives* — reported colors verbatim, derived tones blended and
+  contrast-guarded, invented hues by convention — because that boundary is the
+  whole design and is not recoverable from the code.
+- Recorded the constraint that reading a terminal's configuration file is out of
+  scope. The escape query is the supported interface; parsing Ghostty's or
+  kitty's config would couple tuika to another project's format and its
+  theme-resolution rules.
+- [Out-of-band escapes](specs/out-of-band.md) gained a third family, and
+  `term::palette` alongside `term::capabilities` to hold it. The other five
+  capabilities *tell* the terminal something; a query is *asked*, and its answer
+  arrives on stdin among the user's keystrokes. That difference carries two rules
+  worth keeping: a probe is fenced by the Device Attributes request so an
+  unsupported query costs a round-trip rather than a timeout, and it must run
+  once at startup and stop reading at the fence so it cannot eat input.
+- Restated a term that now means two things in this repository. The styling
+  non-goal "no cascade, inheritance, or selectors" was about the *rule* layer;
+  terminal inheritance produces a plain `Theme` and involves no cascade.
+
 ## 2026-07-25 — The crate root becomes a decision, not an accumulation
 
 - The public tree had grown by accretion: 30 flat public modules plus 167 names

--- a/knowledge/specs/out-of-band.md
+++ b/knowledge/specs/out-of-band.md
@@ -20,7 +20,7 @@ the renderer did not expect.
 
 ## What
 
-Five out-of-band capabilities, in two families:
+Six out-of-band capabilities, in three families:
 
 | Capability | Sequence | Module | Emission point |
 | --- | --- | --- | --- |
@@ -29,14 +29,19 @@ Five out-of-band capabilities, in two families:
 | Native progress | OSC 9;4 | `term::progress` | host-initiated, any time |
 | Pointer shape | OSC 22 | `term::pointer` | host-initiated, any time |
 | Images | Kitty / iTerm2 / Sixel | `term::image` | after `terminal.draw()` returns |
+| Terminal queries | DA1, OSC 10 / 11 / 4 | `term::capabilities`, `term::palette` | host-initiated, once at startup, in raw mode |
 
 They live together under `term` because they are one kind of thing, and a reader
 who has understood one has understood the shape of all of them. Each exposes a
 pure `encode` that builds the sequence without touching I/O — that is what makes
 the wire format unit-testable without a terminal — plus a thin writer over
 `impl Write`. A capability that needs per-frame state owns a driver instead
-(`term::progress::TerminalProgress`), and `term::capabilities` answers what the
-terminal supports for the one family that must ask before it emits.
+(`term::progress::TerminalProgress`).
+
+The last row is the third family, and the one that breaks the shared shape: the
+first five *tell* the terminal something, while a query *asks*, so it is the only
+one with a reply — and the reply lands on stdin. `term::capabilities` asks what
+the terminal supports; `term::palette` asks what colors it was configured with.
 
 Images are the exception that proves the grouping: the *protocol* half is here,
 but the `Image` view is a component like any other, because reserving cells is a
@@ -54,6 +59,29 @@ Graphics escapes are not cursor-neutral — Kitty places the image at the cursor
 so they cannot be spliced. They are emitted after the frame, wrapped in a cursor
 save/restore with an explicit CUP to each image's cell origin, leaving the net
 effect on ratatui's cursor model at nil. See [images.md](./images.md).
+
+### A query is answered on stdin, so it must be fenced and timed
+
+The escapes tuika *tells* the terminal are fire-and-forget. A query is not: the
+answer arrives on stdin, in band with the user's keystrokes, which creates two
+hazards a one-way escape does not have.
+
+The first is that a terminal implementing none of the query says nothing, and
+silence is indistinguishable from *not yet*. Every probe therefore ends with the
+Device Attributes request, which every terminal answers, as a **fence**: its
+reply terminates the read, so an unsupported query costs one round-trip instead
+of one timeout. This is also why the capability probe and the palette probe are
+one request — the fence they need is the same byte sequence.
+
+The second is that a reply read late is a reply delivered to the application as
+input. A probe must therefore run once, at startup, after raw mode is entered and
+before the event loop reads stdin — and it must stop reading exactly at the
+fence, so anything typed behind the replies still reaches the application. The
+PTY suite asserts that boundary directly, by sending a keystroke immediately
+after the replies and requiring the application to act on it.
+
+A probe is always host-initiated. tuika does not query a terminal, or vary a
+default by what terminal it finds itself in, unless a host asks it to.
 
 ### "Unknown escapes are swallowed" holds for three of the four
 

--- a/knowledge/specs/styling.md
+++ b/knowledge/specs/styling.md
@@ -46,6 +46,13 @@ not add required fields to `Theme`: downstream themes commonly use public
 struct literals, so adding fields would turn a semantic addition into a
 source-breaking migration.
 
+A third source sits beside the bundled palettes and the host's own literal: the
+**terminal itself**. A `Theme` can be inherited from the colors the user already
+configured, either implicitly (`themes::TERMINAL`, whose slots are ANSI indices
+and `Reset`) or by querying the terminal and deriving one (`Theme::from_terminal`,
+over `term::palette`). Both produce an ordinary `Theme`, so nothing downstream
+knows the difference.
+
 ## Design
 
 ### Bundles are partial overlays
@@ -62,6 +69,35 @@ down through view constructors. Styling is a cross-cutting policy; threading it
 through the tree would put a style parameter on every component and make "change
 all links" an N-call-site edit — precisely the problem the layer exists to
 remove.
+
+### Inheritance reports, then derives
+
+A terminal can report its foreground, its background, and sixteen ANSI entries.
+It has no notion of a raised panel, a rule, a selection band, or a *brand* color,
+so an inherited theme is necessarily part report and part invention, and the line
+between them is a policy worth stating:
+
+- **Reported colors are used verbatim.** The user's foreground is `text` and
+  their background is `background`, unmodified. Adjusting them would defeat the
+  purpose — the app would no longer match the terminal it is sitting in.
+- **Derived colors are blends, and are contrast-guarded.** The in-between tones
+  come from blending the reported foreground and background, which makes light
+  and dark palettes one code path instead of two. A user's palette may put two
+  colors on top of each other; a UI assembled from it may not, so every derived
+  color is held to a minimum contrast ratio against the background.
+- **Invented colors follow convention, not taste.** No terminal reports an
+  accent, so tuika takes the conventional interactive hue (blue, then cyan)
+  rather than picking a signature color on the user's behalf.
+
+Blending is a plain sRGB lerp. A perceptual space would be more correct in
+general, but every blend here is between two colors the user already chose to sit
+together, and the alternative is a color-science dependency in a toolkit that
+deliberately has none.
+
+The two mechanisms are not redundant: the ANSI-slot theme is the one that cannot
+fail, so it is also the fallback when a terminal answers nothing. What it cannot
+do is express a tone *between* two slots, which is exactly what the derived
+theme exists to supply.
 
 ### The gallery is the proof
 
@@ -80,10 +116,18 @@ existing in code. Regenerating them is `scripts/gen-theme-demos.sh` and
   slot, fails a test rather than merely looking wrong.
 - Themes are values, not configuration. Parsing a user's theme file is the
   host's job; tuika only accepts the resulting struct or a bundled name.
+- Inheriting the terminal's palette is **opt-in and host-initiated**. tuika never
+  probes a terminal, or changes a default, unless the host asks; the default
+  theme is unaffected by what terminal an application is launched in.
+- Reading a terminal's configuration *file* is out of scope in every case. The
+  escape query is the supported interface; parsing Ghostty's or kitty's config
+  would couple tuika to another project's format and its theme-resolution rules.
 
 ## Non-goals
 
-- No cascade, inheritance, or selectors — roles are flat and resolved directly.
+- No cascade or selectors in the rule layer — roles are flat and resolved
+  directly. (Distinct from *terminal inheritance* above, which produces a plain
+  `Theme` and involves no cascade.)
 - No runtime stylesheet *format*; a sheet is Rust data.
 - No per-component style overrides layered on top of the sheet, which would
   reintroduce the scattered-decision problem.

--- a/src/term/capabilities.rs
+++ b/src/term/capabilities.rs
@@ -35,8 +35,13 @@
 //! // event loop reads stdin (Unix ttys only; elsewhere this is just `from_env`).
 //! let caps = Capabilities::query(Duration::from_millis(100));
 //! ```
+//!
+//! The same round-trip can also carry the terminal's *colors*, so a host that
+//! wants both asks once — see [`Capabilities::query_with_palette`] and
+//! [`crate::term::palette`].
 
 use crate::term::image::ImageSupport;
+use crate::term::palette::TerminalPalette;
 
 /// The Primary Device Attributes request (`ESC [ c`). A terminal replies with
 /// `ESC [ ? <codes> c`; feed that reply to [`DeviceAttributes::parse`].
@@ -125,10 +130,39 @@ impl Capabilities {
     /// non-Unix platforms it is exactly [`from_env`](Self::from_env).
     pub fn query(timeout: std::time::Duration) -> Self {
         let caps = Self::from_env();
-        match probe_device_attributes(timeout) {
+        match probe_terminal(DA1_REQUEST, timeout)
+            .as_deref()
+            .and_then(DeviceAttributes::parse)
+        {
             Some(da) => caps.with_device_attributes(&da),
             None => caps,
         }
+    }
+
+    /// Detect capabilities *and* read the terminal's palette in a single
+    /// round-trip.
+    ///
+    /// [`query`](Self::query) and [`TerminalPalette::query`] each cost one
+    /// round-trip; this asks both questions at once, because the color queries
+    /// are fenced by the very Device Attributes request the capability probe
+    /// already makes (see [`crate::term::palette`]). Prefer it when a host wants both
+    /// — which is the usual case, since a host that inherits the terminal's
+    /// colors generally also wants to know what the terminal can draw.
+    ///
+    /// Same rules as [`query`](Self::query): **call once at startup, after
+    /// entering raw mode and before the event loop reads stdin.** On non-ttys
+    /// and non-Unix platforms the capabilities are [`from_env`](Self::from_env)
+    /// and the palette is empty.
+    pub fn query_with_palette(timeout: std::time::Duration) -> (Self, TerminalPalette) {
+        let caps = Self::from_env();
+        let Some(reply) = probe_terminal(&crate::term::palette::query_sequence(), timeout) else {
+            return (caps, TerminalPalette::default());
+        };
+        let caps = match DeviceAttributes::parse(&reply) {
+            Some(da) => caps.with_device_attributes(&da),
+            None => caps,
+        };
+        (caps, TerminalPalette::parse(&reply))
     }
 
     /// Fold a parsed Device Attributes reply into these capabilities: a reported
@@ -188,16 +222,35 @@ impl DeviceAttributes {
     }
 }
 
-/// Write [`DA1_REQUEST`] to the terminal and read the reply, returning the parsed
-/// attributes or `None` on a non-tty, a timeout, or an I/O error.
+/// The most a probe will read before giving up. One Device Attributes reply is
+/// a few dozen bytes, but a full palette query answers with eighteen colors
+/// (~30 bytes each), so the cap has to clear that with room for terminals that
+/// pad their replies — while still bounding what a hostile or broken terminal
+/// can make tuika buffer.
+const PROBE_LIMIT: usize = 1024;
+
+/// Write `request` to the terminal and read everything it answers, returning the
+/// raw reply bytes or `None` on a non-tty, a timeout, or an I/O error.
+///
+/// `request` **must end with [`DA1_REQUEST`]**. Every terminal answers Device
+/// Attributes, so its reply is what terminates the read: any query placed before
+/// it has either already been answered or never will be. Without that fence a
+/// request containing an unsupported query would block for the whole `timeout`.
 ///
 /// Unix only: reads raw bytes from fd 0 (which must be in raw mode) in a helper
 /// thread bounded by `timeout`. A real tty answers DA1 immediately, so the read
 /// completes at once; the timeout only guards exotic terminals that ignore the
-/// query. Borrows fd 0 without owning it, so it never closes stdin, and reads
-/// exactly up to the reply's terminating `c`, so it consumes no input beyond it.
+/// query. Borrows fd 0 without owning it, so it never closes stdin, and stops at
+/// the DA1 reply's terminating `c`, so it consumes no input beyond it.
+///
+/// One caveat, unchanged from when this only asked for Device Attributes: if the
+/// terminal never answers *DA1 itself*, the timeout returns but the reader
+/// thread is still blocked in `read`, and it will consume the next byte typed.
+/// Every terminal answers DA1, which is exactly why it is the fence — but a host
+/// that must be certain should skip the probe on a terminal it does not
+/// recognize rather than rely on the timeout.
 #[cfg(unix)]
-fn probe_device_attributes(timeout: std::time::Duration) -> Option<DeviceAttributes> {
+pub(crate) fn probe_terminal(request: &str, timeout: std::time::Duration) -> Option<Vec<u8>> {
     use std::fs::File;
     use std::io::{IsTerminal, Read, Write, stdin, stdout};
     use std::mem::ManuallyDrop;
@@ -208,9 +261,13 @@ fn probe_device_attributes(timeout: std::time::Duration) -> Option<DeviceAttribu
     if !stdin().is_terminal() || !stdout().is_terminal() {
         return None;
     }
+    debug_assert!(
+        request.ends_with(DA1_REQUEST),
+        "a probe request must end with the DA1 fence, or the read cannot terminate"
+    );
     {
         let mut out = stdout();
-        out.write_all(DA1_REQUEST.as_bytes()).ok()?;
+        out.write_all(request.as_bytes()).ok()?;
         out.flush().ok()?;
     }
 
@@ -221,12 +278,19 @@ fn probe_device_attributes(timeout: std::time::Duration) -> Option<DeviceAttribu
         let mut input = ManuallyDrop::new(unsafe { File::from_raw_fd(0) });
         let mut buf = Vec::new();
         let mut byte = [0u8; 1];
-        while buf.len() < 64 {
+        // Replies to the queries *before* the fence are OSC sequences, which end
+        // in ST or BEL and may legitimately contain a `c` (hex digits do). Only a
+        // `c` that closes a CSI frame is the fence, so track whether one is open
+        // rather than searching the whole buffer.
+        let mut in_csi = false;
+        while buf.len() < PROBE_LIMIT {
             match input.read(&mut byte) {
                 Ok(1) => {
-                    buf.push(byte[0]);
-                    // The reply ends at the `c` that closes the CSI frame.
-                    if byte[0] == b'c' && buf.contains(&b'[') {
+                    let b = byte[0];
+                    buf.push(b);
+                    if b == b'[' && buf.len() >= 2 && buf[buf.len() - 2] == 0x1b {
+                        in_csi = true;
+                    } else if b == b'c' && in_csi {
                         break;
                     }
                 }
@@ -236,13 +300,13 @@ fn probe_device_attributes(timeout: std::time::Duration) -> Option<DeviceAttribu
         let _ = tx.send(buf);
     });
 
-    let buf = rx.recv_timeout(timeout).ok()?;
-    DeviceAttributes::parse(&buf)
+    rx.recv_timeout(timeout).ok()
 }
 
-/// Non-Unix stub: no DA probe, so [`Capabilities::query`] is just `from_env`.
+/// Non-Unix stub: no terminal probe, so [`Capabilities::query`] is just
+/// `from_env` and a palette query comes back empty.
 #[cfg(not(unix))]
-fn probe_device_attributes(_timeout: std::time::Duration) -> Option<DeviceAttributes> {
+pub(crate) fn probe_terminal(_request: &str, _timeout: std::time::Duration) -> Option<Vec<u8>> {
     None
 }
 

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -21,14 +21,21 @@
 //! | [`progress`] | OSC 9;4 | lights its own progress bar or taskbar |
 //! | [`mod@pointer`] | OSC 22 | changes the mouse pointer shape |
 //! | [`capabilities`] | DA1 | answers what it supports |
+//! | [`palette`] | OSC 10 / 11 / 4 | reports the colors it was configured with |
 //!
 //! Terminals silently swallow an OSC they do not understand, so emitting one is
 //! safe everywhere; [`capabilities`] exists for the cases where the host wants to
 //! know before it commits to a richer rendering path (pixels versus text).
+//!
+//! The last two are a shape of their own: they *ask* rather than tell, so their
+//! answer arrives on stdin among the user's keystrokes. That is why both are
+//! host-initiated, run once at startup in raw mode, and share a single fenced
+//! round-trip — see [`capabilities::Capabilities::query_with_palette`].
 
 pub mod capabilities;
 pub mod clipboard;
 pub mod hyperlink;
 pub mod image;
+pub mod palette;
 pub mod pointer;
 pub mod progress;

--- a/src/term/palette.rs
+++ b/src/term/palette.rs
@@ -1,0 +1,701 @@
+//! Inheriting the terminal's own colors.
+//!
+//! A [`Theme`] is normally chosen by the application — one of the bundled
+//! presets, or a literal the host writes. This module covers the other case: the
+//! user already picked a palette *in their terminal*, and the application should
+//! look like it belongs there rather than imposing its own.
+//!
+//! There are two ways to do that, and they trade accuracy against cost:
+//!
+//! - [`themes::TERMINAL`](crate::themes::TERMINAL) — a `const` [`Theme`] built
+//!   entirely from [`Color::Reset`] and [`Color::Indexed`], so the terminal
+//!   resolves every color itself. No I/O, no timeout, no failure mode, works on
+//!   every terminal including ones that answer nothing. What it cannot do is
+//!   produce a tone *between* two ANSI slots, so panels, rules, and selection
+//!   bands are flatter than a designed palette.
+//! - **Querying the terminal** for its actual colors — [`TerminalPalette::query`]
+//!   — then deriving a full theme from them with [`Theme::from_terminal`]. This
+//!   yields real 24-bit values, so the in-between tones can be blended and
+//!   contrast-checked. It costs one round-trip at startup and degrades to
+//!   `None` on a terminal that stays silent.
+//!
+//! ```no_run
+//! use std::time::Duration;
+//! use tuika::{Theme, themes};
+//! use tuika::term::palette::TerminalPalette;
+//!
+//! // In raw mode, before the event loop reads stdin:
+//! let theme = Theme::from_terminal(&TerminalPalette::query(Duration::from_millis(100)))
+//!     .unwrap_or(themes::TERMINAL); // silent terminal → inherit via ANSI slots
+//! ```
+//!
+//! # The queries
+//!
+//! The terminal is asked with the xterm color-query escapes — [`QUERY_FOREGROUND`]
+//! (OSC 10), [`QUERY_BACKGROUND`] (OSC 11), and OSC 4 per palette entry — each
+//! answered with `OSC <n> ; rgb:RRRR/GGGG/BBBB ST`. Ghostty, kitty, WezTerm,
+//! foot, alacritty, contour, iTerm2, and xterm all implement them; others answer
+//! nothing at all.
+//!
+//! "Nothing at all" is the whole difficulty: a terminal that does not implement
+//! OSC 11 does not say so, it just stays quiet, and a reader cannot tell *not
+//! yet* from *never*. So [`query_sequence`] appends
+//! [`DA1_REQUEST`](crate::term::capabilities::DA1_REQUEST) — which every terminal
+//! answers — as a **fence**: once the DA1 reply arrives, every color reply that
+//! was ever coming has already arrived. That makes the probe cost one round-trip
+//! rather than one timeout, and it folds into the Device Attributes round-trip
+//! tuika already makes (see
+//! [`Capabilities::query_with_palette`](crate::term::capabilities::Capabilities::query_with_palette)).
+
+use ratatui_core::style::Color;
+
+use crate::style::{CodeTheme, Theme};
+
+/// Query the terminal's default foreground (OSC 10). The reply is
+/// `OSC 10 ; rgb:RRRR/GGGG/BBBB ST`.
+pub const QUERY_FOREGROUND: &str = "\x1b]10;?\x1b\\";
+
+/// Query the terminal's default background (OSC 11). The reply is
+/// `OSC 11 ; rgb:RRRR/GGGG/BBBB ST`.
+pub const QUERY_BACKGROUND: &str = "\x1b]11;?\x1b\\";
+
+/// The bytes to write to ask the terminal for its whole palette: the default
+/// foreground and background plus all 16 ANSI entries, fenced by
+/// [`DA1_REQUEST`](crate::term::capabilities::DA1_REQUEST) so the reply stream has a
+/// definite end even on a terminal that answers none of the color queries.
+///
+/// Feed everything read back to [`TerminalPalette::parse`].
+pub fn query_sequence() -> String {
+    let mut out = String::with_capacity(24 * 20);
+    out.push_str(QUERY_FOREGROUND);
+    out.push_str(QUERY_BACKGROUND);
+    for i in 0..16 {
+        out.push_str(&format!("\x1b]4;{i};?\x1b\\"));
+    }
+    // The fence must come last: it is what tells the reader the color replies
+    // are done (or were never coming).
+    out.push_str(crate::term::capabilities::DA1_REQUEST);
+    out
+}
+
+/// The colors a terminal reported for itself.
+///
+/// Every field is optional because a terminal may implement some queries and not
+/// others — or none. Build one from a reply stream with [`parse`](Self::parse),
+/// or from a live terminal with [`query`](Self::query), then turn it into a
+/// theme with [`Theme::from_terminal`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TerminalPalette {
+    /// The default foreground (OSC 10), if reported.
+    pub foreground: Option<Color>,
+    /// The default background (OSC 11), if reported.
+    pub background: Option<Color>,
+    /// The 16 ANSI palette entries (OSC 4), each if reported. Index 0–7 are the
+    /// normal colors, 8–15 the bright ones.
+    pub ansi: [Option<Color>; 16],
+}
+
+impl TerminalPalette {
+    /// Parse every color reply found in `bytes`, ignoring anything else.
+    ///
+    /// Tolerant by design: the buffer is whatever the terminal sent, which may
+    /// interleave the Device Attributes reply, hold only some of the answers, or
+    /// be truncated mid-sequence. Unrecognized, malformed, and partial replies
+    /// are skipped rather than failing the whole parse, so a terminal that
+    /// answers three queries out of eighteen still contributes three colors.
+    pub fn parse(bytes: &[u8]) -> Self {
+        let mut out = Self::default();
+        let mut i = 0;
+        while i + 1 < bytes.len() {
+            if bytes[i] != 0x1b || bytes[i + 1] != b']' {
+                i += 1;
+                continue;
+            }
+            let body_start = i + 2;
+            let Some((body, next)) = osc_body(bytes, body_start) else {
+                // An unterminated OSC is the last thing in the buffer; there is
+                // nothing after it to parse.
+                break;
+            };
+            out.absorb(body);
+            i = next;
+        }
+        out
+    }
+
+    /// Ask the terminal directly: write [`query_sequence`] and parse the reply.
+    ///
+    /// **Call once at startup, after entering raw mode and before the event loop
+    /// reads stdin** — the replies arrive on stdin and would otherwise be
+    /// delivered to the application as key events. On a non-tty, a non-Unix
+    /// platform, or a terminal that answers nothing, this returns an empty
+    /// palette, which [`Theme::from_terminal`] turns into `None`.
+    ///
+    /// `timeout` bounds the wait for the fence reply; a real tty answers Device
+    /// Attributes immediately, so this normally returns at once.
+    pub fn query(timeout: std::time::Duration) -> Self {
+        match crate::term::capabilities::probe_terminal(&query_sequence(), timeout) {
+            Some(bytes) => Self::parse(&bytes),
+            None => Self::default(),
+        }
+    }
+
+    /// Whether the terminal reported nothing at all.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// Record one OSC body (the bytes between `ESC ]` and the terminator).
+    fn absorb(&mut self, body: &[u8]) {
+        let mut parts = body.split(|&b| b == b';');
+        let Some(code) = parts.next() else { return };
+        match code {
+            b"10" => self.foreground = parts.next().and_then(parse_color_spec),
+            b"11" => self.background = parts.next().and_then(parse_color_spec),
+            b"4" => {
+                // `4;<index>;<spec>` — and a terminal may pack several pairs into
+                // one reply, so keep consuming them.
+                while let (Some(index), Some(spec)) = (parts.next(), parts.next()) {
+                    let Some(index) = std::str::from_utf8(index)
+                        .ok()
+                        .and_then(|s| s.parse::<usize>().ok())
+                    else {
+                        return;
+                    };
+                    if let Some(slot) = self.ansi.get_mut(index) {
+                        *slot = parse_color_spec(spec);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// ANSI entry `index`, falling back to xterm's default for that slot when
+    /// the terminal did not report one.
+    fn ansi_or_default(&self, index: usize) -> Rgb {
+        self.ansi
+            .get(index)
+            .copied()
+            .flatten()
+            .and_then(rgb_of)
+            .unwrap_or(XTERM_DEFAULTS[index.min(15)])
+    }
+}
+
+/// Find the body of an OSC sequence starting at `start`, plus the index just
+/// past its terminator. Accepts both terminators a terminal may use: `ESC \`
+/// (ST) and `BEL`. Returns `None` if the sequence is unterminated.
+fn osc_body(bytes: &[u8], start: usize) -> Option<(&[u8], usize)> {
+    let mut j = start;
+    while j < bytes.len() {
+        match bytes[j] {
+            0x07 => return Some((&bytes[start..j], j + 1)),
+            0x1b if bytes.get(j + 1) == Some(&b'\\') => return Some((&bytes[start..j], j + 2)),
+            // A bare ESC that is not ST starts a *different* sequence: the OSC
+            // was truncated. Stop rather than swallowing the next sequence.
+            0x1b => return None,
+            _ => j += 1,
+        }
+    }
+    None
+}
+
+/// Parse one X11 color spec into a [`Color::Rgb`].
+///
+/// Handles the `rgb:R/G/B` form every terminal replies with — components are 1
+/// to 4 hex digits each and are scaled to 8 bits — plus the `#RGB`-style forms
+/// and `rgba:` variants some terminals use.
+fn parse_color_spec(spec: &[u8]) -> Option<Color> {
+    let spec = std::str::from_utf8(spec).ok()?.trim();
+    if let Some(rest) = spec
+        .strip_prefix("rgb:")
+        .or_else(|| spec.strip_prefix("rgba:"))
+    {
+        // `rgba:` puts alpha first (`rgba:A/R/G/B`); tuika has no alpha, so drop it.
+        let mut fields: Vec<&str> = rest.split('/').collect();
+        if fields.len() == 4 {
+            fields.remove(0);
+        }
+        if fields.len() != 3 {
+            return None;
+        }
+        let r = scale_hex(fields[0])?;
+        let g = scale_hex(fields[1])?;
+        let b = scale_hex(fields[2])?;
+        return Some(Color::Rgb(r, g, b));
+    }
+    if let Some(hex) = spec.strip_prefix('#') {
+        // `#RGB`, `#RRGGBB`, `#RRRGGGBBB`, `#RRRRGGGGBBBB` — equal-width thirds.
+        if hex.len() % 3 != 0 || hex.is_empty() || hex.len() > 12 {
+            return None;
+        }
+        let w = hex.len() / 3;
+        let r = scale_hex(&hex[0..w])?;
+        let g = scale_hex(&hex[w..2 * w])?;
+        let b = scale_hex(&hex[2 * w..])?;
+        return Some(Color::Rgb(r, g, b));
+    }
+    None
+}
+
+/// Scale a 1–4 digit hex component to 8 bits, the way X11 widens color specs:
+/// the value is a fraction of its own maximum (`ff` → 255, `f` → 255, `8` → 136).
+fn scale_hex(field: &str) -> Option<u8> {
+    if field.is_empty() || field.len() > 4 || !field.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let value = u32::from_str_radix(field, 16).ok()?;
+    let max = (1u32 << (4 * field.len() as u32)) - 1;
+    // Round to nearest rather than truncating, so `rgb:8/8/8` is not off by one.
+    Some(((value * 255 + max / 2) / max) as u8)
+}
+
+// --- Color math -----------------------------------------------------------
+//
+// Blending is a plain lerp in sRGB rather than a perceptual space. The tones
+// tuika derives are all blends between two colors the *user* already chose to
+// sit together (their foreground, background, and accents), so the extra
+// machinery of Oklab buys accuracy the eye cannot spend here — and it would put
+// a color-science dependency into a toolkit that deliberately has none.
+
+/// A 24-bit color, used for the arithmetic between parsing and the [`Theme`].
+type Rgb = (u8, u8, u8);
+
+const BLACK: Rgb = (0, 0, 0);
+const WHITE: Rgb = (255, 255, 255);
+
+/// xterm's default 16-color palette, used for any ANSI slot the terminal did not
+/// report so a terminal that answers OSC 10/11 but not OSC 4 still yields a
+/// complete theme.
+const XTERM_DEFAULTS: [Rgb; 16] = [
+    (0, 0, 0),
+    (205, 0, 0),
+    (0, 205, 0),
+    (205, 205, 0),
+    (0, 0, 238),
+    (205, 0, 205),
+    (0, 205, 205),
+    (229, 229, 229),
+    (127, 127, 127),
+    (255, 0, 0),
+    (0, 255, 0),
+    (255, 255, 0),
+    (92, 92, 255),
+    (255, 0, 255),
+    (0, 255, 255),
+    (255, 255, 255),
+];
+
+/// The RGB triple behind a [`Color`], or `None` for anything that is not a
+/// literal 24-bit color (an indexed or named color has no value tuika can do
+/// arithmetic on without knowing the terminal's palette).
+fn rgb_of(color: Color) -> Option<Rgb> {
+    match color {
+        Color::Rgb(r, g, b) => Some((r, g, b)),
+        _ => None,
+    }
+}
+
+/// Blend `a` toward `b`; `t` of 0 is `a`, 1 is `b`.
+fn mix(a: Rgb, b: Rgb, t: f32) -> Rgb {
+    let t = t.clamp(0.0, 1.0);
+    let f = |x: u8, y: u8| {
+        (x as f32 + (y as f32 - x as f32) * t)
+            .round()
+            .clamp(0.0, 255.0) as u8
+    };
+    (f(a.0, b.0), f(a.1, b.1), f(a.2, b.2))
+}
+
+/// WCAG relative luminance.
+fn luminance(c: Rgb) -> f32 {
+    let channel = |v: u8| {
+        let v = v as f32 / 255.0;
+        if v <= 0.04045 {
+            v / 12.92
+        } else {
+            ((v + 0.055) / 1.055).powf(2.4)
+        }
+    };
+    0.2126 * channel(c.0) + 0.7152 * channel(c.1) + 0.0722 * channel(c.2)
+}
+
+/// WCAG contrast ratio between two colors, from 1.0 (identical) to 21.0.
+fn contrast_ratio(a: Rgb, b: Rgb) -> f32 {
+    let (la, lb) = (luminance(a), luminance(b));
+    let (hi, lo) = if la >= lb { (la, lb) } else { (lb, la) };
+    (hi + 0.05) / (lo + 0.05)
+}
+
+/// Whether text on `bg` reads better in white than in black — the test that
+/// decides which pole [`ensure_contrast`] pushes toward, and whether the bright
+/// or the normal half of the ANSI palette is the legible one.
+fn is_dark(bg: Rgb) -> bool {
+    contrast_ratio(WHITE, bg) >= contrast_ratio(BLACK, bg)
+}
+
+/// Push `color` away from `bg` until it clears `min` contrast, blending toward
+/// whichever pole `bg` is furthest from.
+///
+/// Colors the terminal *reported* are used verbatim — a user's own foreground is
+/// their choice. This guards the colors tuika **derives**, where a blend can
+/// otherwise land on top of the background and disappear. On a mid-gray
+/// background no color reaches a high ratio; the loop then returns the pole,
+/// which is the most legible answer available.
+fn ensure_contrast(color: Rgb, bg: Rgb, min: f32) -> Rgb {
+    if contrast_ratio(color, bg) >= min {
+        return color;
+    }
+    let pole = if is_dark(bg) { WHITE } else { BLACK };
+    for step in 1..=20 {
+        let candidate = mix(color, pole, step as f32 / 20.0);
+        if contrast_ratio(candidate, bg) >= min {
+            return candidate;
+        }
+    }
+    pole
+}
+
+impl Theme {
+    /// Derive a full theme from the colors a terminal reported, or `None` if it
+    /// did not report both a foreground and a background.
+    ///
+    /// The reported foreground and background are used **verbatim** as `text`
+    /// and `background`, so an inherited theme sits in the terminal rather than
+    /// beside it. Everything else is derived, because no terminal has a notion
+    /// of a raised panel, a rule, or a selection band:
+    ///
+    /// - The in-between tones (`surface`, `muted`, `dim`, `border`, the code
+    ///   background) are blends between the foreground and the background, so
+    ///   they follow a light palette and a dark one without a special case.
+    /// - The hues (`accent`, and the syntax roles) come from the ANSI palette,
+    ///   taking the bright half on a dark background and the normal half on a
+    ///   light one. Blue leads and cyan follows — a terminal reports no notion
+    ///   of a *brand* color, so tuika picks the conventional interactive hue
+    ///   rather than inventing one.
+    /// - Every derived color is held to a minimum contrast against the
+    ///   background. A user's palette is free to put two colors on top of each
+    ///   other; a UI built from it is not.
+    ///
+    /// Any ANSI slot the terminal did not report falls back to xterm's default
+    /// for that slot, so a terminal answering only OSC 10 and OSC 11 still
+    /// produces a complete theme.
+    pub fn from_terminal(palette: &TerminalPalette) -> Option<Theme> {
+        let fg = palette.foreground.and_then(rgb_of)?;
+        let bg = palette.background.and_then(rgb_of)?;
+        let dark = is_dark(bg);
+        // The legible half of the ANSI palette: bright on dark, normal on light.
+        let hue = |normal: usize| palette.ansi_or_default(if dark { normal + 8 } else { normal });
+        let color = |c: Rgb| Color::Rgb(c.0, c.1, c.2);
+        let guard = |c: Rgb, min: f32| ensure_contrast(c, bg, min);
+
+        // Text-weight roles clear WCAG AA for large text (3.0); structural roles
+        // that are lines rather than glyphs need only to be visible (1.6).
+        let muted = guard(mix(fg, bg, 0.40), 3.0);
+        let accent = guard(hue(4), 3.0); // blue
+        let accent_alt = guard(hue(6), 3.0); // cyan
+        let selection_bg = mix(bg, accent, 0.35);
+        // Whichever of the user's two colors reads better on the band we just built.
+        let selection_fg = if contrast_ratio(fg, selection_bg) >= contrast_ratio(bg, selection_bg) {
+            fg
+        } else {
+            bg
+        };
+
+        Some(Theme {
+            background: color(bg),
+            surface: color(mix(bg, fg, 0.10)),
+            text: color(fg),
+            muted: color(muted),
+            dim: color(guard(mix(fg, bg, 0.68), 1.6)),
+            accent: color(accent),
+            accent_alt: color(accent_alt),
+            border: color(guard(mix(fg, bg, 0.62), 1.6)),
+            border_focused: color(accent),
+            selection_bg: color(selection_bg),
+            selection_fg: color(ensure_contrast(selection_fg, selection_bg, 4.5)),
+            code: CodeTheme {
+                heading: color(fg),
+                link: color(accent),
+                background: color(mix(bg, fg, 0.06)),
+                text: color(fg),
+                label: color(muted),
+                keyword: color(guard(hue(5), 3.0)),   // magenta
+                function: color(guard(hue(4), 3.0)),  // blue
+                type_name: color(guard(hue(6), 3.0)), // cyan
+                constant: color(guard(hue(3), 3.0)),  // yellow
+                string: color(guard(hue(2), 3.0)),    // green
+                comment: color(guard(palette.ansi_or_default(8), 2.2)),
+                punctuation: color(muted),
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rgb(c: Option<Color>) -> Rgb {
+        rgb_of(c.expect("a color was parsed")).expect("a 24-bit color")
+    }
+
+    /// Ghostty's actual reply shape: OSC 11, four hex digits per channel, ST.
+    #[test]
+    fn parses_a_background_reply() {
+        let p = TerminalPalette::parse(b"\x1b]11;rgb:1a1a/1b1b/1e1e\x1b\\");
+        assert_eq!(p.background, Some(Color::Rgb(0x1a, 0x1b, 0x1e)));
+        assert_eq!(p.foreground, None);
+    }
+
+    #[test]
+    fn parses_both_terminators_and_all_component_widths() {
+        // BEL-terminated, one digit per channel: `f` is full-scale, not 0x0f.
+        let p = TerminalPalette::parse(b"\x1b]10;rgb:f/8/0\x07");
+        assert_eq!(rgb(p.foreground), (255, 136, 0));
+        // Two digits.
+        let p = TerminalPalette::parse(b"\x1b]10;rgb:ff/80/00\x1b\\");
+        assert_eq!(rgb(p.foreground), (255, 128, 0));
+        // Three digits.
+        let p = TerminalPalette::parse(b"\x1b]10;rgb:fff/800/000\x1b\\");
+        assert_eq!(rgb(p.foreground), (255, 128, 0));
+    }
+
+    #[test]
+    fn parses_hash_and_rgba_specs() {
+        let p = TerminalPalette::parse(b"\x1b]11;#102030\x1b\\");
+        assert_eq!(rgb(p.background), (0x10, 0x20, 0x30));
+        // `rgba:` leads with alpha, which tuika drops.
+        let p = TerminalPalette::parse(b"\x1b]11;rgba:ffff/1111/2222/3333\x1b\\");
+        assert_eq!(rgb(p.background), (0x11, 0x22, 0x33));
+    }
+
+    #[test]
+    fn parses_ansi_entries_by_index() {
+        let p = TerminalPalette::parse(
+            b"\x1b]4;0;rgb:0000/0000/0000\x1b\\\x1b]4;12;rgb:8888/aaaa/ffff\x1b\\",
+        );
+        assert_eq!(rgb(p.ansi[0]), (0, 0, 0));
+        assert_eq!(rgb(p.ansi[12]), (0x88, 0xaa, 0xff));
+        assert_eq!(p.ansi[1], None, "unreported slots stay empty");
+    }
+
+    #[test]
+    fn parses_multiple_pairs_packed_into_one_osc_4_reply() {
+        let p = TerminalPalette::parse(b"\x1b]4;1;rgb:1111/1111/1111;2;rgb:2222/2222/2222\x1b\\");
+        assert_eq!(rgb(p.ansi[1]), (0x11, 0x11, 0x11));
+        assert_eq!(rgb(p.ansi[2]), (0x22, 0x22, 0x22));
+    }
+
+    /// The real shape of a probe buffer: color replies, then the DA1 fence.
+    #[test]
+    fn parses_a_reply_stream_ending_in_the_da1_fence() {
+        let mut stream = Vec::new();
+        stream.extend_from_slice(b"\x1b]10;rgb:c5c5/c8c8/c6c6\x1b\\");
+        stream.extend_from_slice(b"\x1b]11;rgb:1d1d/1f1f/2121\x1b\\");
+        stream.extend_from_slice(b"\x1b[?62;4;22c");
+        let p = TerminalPalette::parse(&stream);
+        assert_eq!(rgb(p.foreground), (0xc5, 0xc8, 0xc6));
+        assert_eq!(rgb(p.background), (0x1d, 0x1f, 0x21));
+        // The same buffer still parses as Device Attributes — one round-trip
+        // answers both questions.
+        let da = crate::term::capabilities::DeviceAttributes::parse(&stream).expect("DA1 parses");
+        assert!(da.sixel());
+    }
+
+    #[test]
+    fn ignores_junk_malformed_and_out_of_range_replies() {
+        let p = TerminalPalette::parse(
+            b"noise\x1b]11;rgb:zz/00/00\x1b\\\x1b]4;99;rgb:1111/1111/1111\x1b\\\
+              \x1b]999;whatever\x1b\\\x1b]10;rgb:0000/1111/2222\x1b\\",
+        );
+        assert_eq!(p.background, None, "a bad spec is skipped, not fatal");
+        assert_eq!(
+            rgb(p.foreground),
+            (0, 0x11, 0x22),
+            "later replies still land"
+        );
+    }
+
+    /// A truncated stream is the realistic failure of a probe that timed out
+    /// mid-reply. It must not panic or read past the end.
+    #[test]
+    fn truncated_streams_never_panic() {
+        let full = b"\x1b]10;rgb:1111/2222/3333\x1b\\\x1b]4;3;rgb:aaaa/bbbb/cccc\x07\x1b[?62c";
+        for end in 0..=full.len() {
+            let _ = TerminalPalette::parse(&full[..end]);
+        }
+        // A bare ESC mid-OSC must not swallow the sequence after it.
+        let _ = TerminalPalette::parse(b"\x1b]11;rgb:11\x1b]10;rgb:2222/2222/2222\x1b\\");
+    }
+
+    #[test]
+    fn query_sequence_asks_for_everything_and_ends_with_the_fence() {
+        let q = query_sequence();
+        assert!(q.starts_with(QUERY_FOREGROUND));
+        assert!(q.contains(QUERY_BACKGROUND));
+        for i in 0..16 {
+            assert!(
+                q.contains(&format!("\x1b]4;{i};?")),
+                "missing OSC 4 for {i}"
+            );
+        }
+        assert!(
+            q.ends_with(crate::term::capabilities::DA1_REQUEST),
+            "the fence must be last, or it cannot terminate the read"
+        );
+    }
+
+    /// A palette built from a full reply stream, so this exercises the real
+    /// entry point rather than a hand-built struct.
+    fn gruvbox_replies() -> TerminalPalette {
+        // Gruvbox dark's background/foreground and its bright ANSI half.
+        let mut s =
+            String::from("\x1b]11;rgb:2828/2828/2828\x1b\\\x1b]10;rgb:ebeb/dbdb/b2b2\x1b\\");
+        let bright: [(usize, &str); 8] = [
+            (8, "9292/8383/7474"),
+            (9, "fbfb/4949/3434"),
+            (10, "b8b8/bbbb/2626"),
+            (11, "fafa/bdbd/2f2f"),
+            (12, "8383/a5a5/9898"),
+            (13, "d3d3/8686/9b9b"),
+            (14, "8e8e/c0c0/7c7c"),
+            (15, "ebeb/dbdb/b2b2"),
+        ];
+        for (i, spec) in bright {
+            s.push_str(&format!("\x1b]4;{i};rgb:{spec}\x1b\\"));
+        }
+        s.push_str("\x1b[?62;4;22c");
+        TerminalPalette::parse(s.as_bytes())
+    }
+
+    #[test]
+    fn derives_a_theme_that_keeps_the_terminal_fg_and_bg_verbatim() {
+        let theme = Theme::from_terminal(&gruvbox_replies()).expect("fg and bg were reported");
+        assert_eq!(theme.background, Color::Rgb(0x28, 0x28, 0x28));
+        assert_eq!(theme.text, Color::Rgb(0xeb, 0xdb, 0xb2));
+        assert_eq!(theme.code.text, theme.text);
+        // Blue leads: bright blue (index 12) is the accent, bright aqua the alt.
+        assert_eq!(theme.accent, Color::Rgb(0x83, 0xa5, 0x98));
+        assert_eq!(theme.accent_alt, Color::Rgb(0x8e, 0xc0, 0x7c));
+        assert_eq!(theme.border_focused, theme.accent);
+        // Syntax roles track the reported palette, not a hard-coded one.
+        assert_eq!(theme.code.string, Color::Rgb(0xb8, 0xbb, 0x26)); // bright green
+        assert_eq!(theme.code.keyword, Color::Rgb(0xd3, 0x86, 0x9b)); // bright purple
+    }
+
+    #[test]
+    fn requires_both_a_foreground_and_a_background() {
+        assert!(Theme::from_terminal(&TerminalPalette::default()).is_none());
+        let only_bg = TerminalPalette::parse(b"\x1b]11;rgb:0000/0000/0000\x1b\\");
+        assert!(Theme::from_terminal(&only_bg).is_none());
+        // An indexed color carries no value tuika can blend, so it is not enough.
+        let indexed = TerminalPalette {
+            foreground: Some(Color::Indexed(7)),
+            background: Some(Color::Rgb(0, 0, 0)),
+            ..Default::default()
+        };
+        assert!(Theme::from_terminal(&indexed).is_none());
+    }
+
+    #[test]
+    fn fills_unreported_ansi_slots_from_the_xterm_defaults() {
+        // OSC 10 and 11 only — the common case for a terminal without OSC 4.
+        let p = TerminalPalette::parse(
+            b"\x1b]11;rgb:0000/0000/0000\x1b\\\x1b]10;rgb:ffff/ffff/ffff\x1b\\",
+        );
+        let theme = Theme::from_terminal(&p).expect("a complete theme");
+        // Dark background → the bright half; xterm's bright blue is #5c5cff,
+        // which is too dark on black and gets lifted by the contrast guard.
+        let Color::Rgb(r, g, b) = theme.accent else {
+            panic!("accent is 24-bit")
+        };
+        assert!(b > r && b > g, "accent is still recognizably blue");
+        assert!(
+            contrast_ratio((r, g, b), (0, 0, 0)) >= 3.0,
+            "the guard lifted it clear of the background"
+        );
+    }
+
+    #[test]
+    fn light_and_dark_backgrounds_both_derive_readable_tones() {
+        for (name, bg_spec, fg_spec) in [
+            ("dark", "1d1d/1f1f/2121", "c5c5/c8c8/c6c6"),
+            ("light", "fdfd/f6f6/e3e3", "6565/7b7b/8383"),
+        ] {
+            let p = TerminalPalette::parse(
+                format!("\x1b]11;rgb:{bg_spec}\x1b\\\x1b]10;rgb:{fg_spec}\x1b\\").as_bytes(),
+            );
+            let theme = Theme::from_terminal(&p).expect("a complete theme");
+            let bg = rgb_of(theme.background).unwrap();
+            // Every glyph-bearing derived role clears its floor on both.
+            for (role, color, min) in [
+                ("muted", theme.muted, 3.0),
+                ("accent", theme.accent, 3.0),
+                ("keyword", theme.code.keyword, 3.0),
+                ("string", theme.code.string, 3.0),
+                ("comment", theme.code.comment, 2.2),
+            ] {
+                let c = rgb_of(color).unwrap();
+                assert!(
+                    contrast_ratio(c, bg) >= min - 0.01,
+                    "{name}: {role} at {:.2} is under its {min} floor",
+                    contrast_ratio(c, bg)
+                );
+            }
+            // `surface` is a raised panel, so it must differ from the base fill
+            // without becoming a second background.
+            assert_ne!(
+                theme.surface, theme.background,
+                "{name}: surface is distinct"
+            );
+            let surface = rgb_of(theme.surface).unwrap();
+            assert!(
+                contrast_ratio(surface, bg) < 1.5,
+                "{name}: surface stays a subtle raise"
+            );
+            // Selected text must be readable on the band it sits on.
+            let sel_bg = rgb_of(theme.selection_bg).unwrap();
+            let sel_fg = rgb_of(theme.selection_fg).unwrap();
+            assert!(
+                contrast_ratio(sel_fg, sel_bg) >= 4.4,
+                "{name}: selection is legible"
+            );
+        }
+    }
+
+    /// The degenerate palette: a terminal reporting the same color for both.
+    /// Nothing can be derived well, but nothing may panic or vanish either.
+    #[test]
+    fn survives_a_foreground_equal_to_the_background() {
+        let p = TerminalPalette::parse(
+            b"\x1b]11;rgb:0000/0000/0000\x1b\\\x1b]10;rgb:0000/0000/0000\x1b\\",
+        );
+        let theme = Theme::from_terminal(&p).expect("still derives");
+        assert_eq!(theme.text, theme.background, "the reported fg is respected");
+        let bg = rgb_of(theme.background).unwrap();
+        assert!(
+            contrast_ratio(rgb_of(theme.muted).unwrap(), bg) >= 3.0,
+            "derived roles are still lifted clear"
+        );
+    }
+
+    #[test]
+    fn scale_hex_widens_the_way_x11_does() {
+        assert_eq!(scale_hex("f"), Some(255));
+        assert_eq!(scale_hex("0"), Some(0));
+        assert_eq!(scale_hex("ffff"), Some(255));
+        assert_eq!(scale_hex("8000"), Some(128));
+        assert_eq!(scale_hex(""), None);
+        assert_eq!(scale_hex("fffff"), None);
+        assert_eq!(scale_hex("zz"), None);
+    }
+
+    #[test]
+    fn contrast_ratio_matches_the_wcag_extremes() {
+        assert!((contrast_ratio(WHITE, BLACK) - 21.0).abs() < 0.01);
+        assert!((contrast_ratio(WHITE, WHITE) - 1.0).abs() < 0.01);
+        assert!(is_dark(BLACK) && !is_dark(WHITE));
+    }
+}

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -14,6 +14,94 @@ use crate::surface::Surface;
 use crate::tests::support::{buffer, row};
 use crate::view::{RenderCtx, View, element};
 
+/// An inherited theme has to reach the *cells*, not just the `Theme` struct —
+/// which means going through a real component tree and reading the buffer back.
+///
+/// Two paths, and the assertions differ because the promises differ. A theme
+/// derived from a terminal's reply pins cells to concrete 24-bit values; the
+/// zero-I/O preset pins them to `Reset` and ANSI indices, because its whole
+/// point is that the *terminal* resolves them.
+#[test]
+fn an_inherited_theme_reaches_the_painted_cells() {
+    use ratatui_core::style::Color;
+
+    use crate::term::palette::TerminalPalette;
+    use crate::themes;
+
+    // A theme derived from what a terminal actually reported, alongside the
+    // preset that needs no report at all.
+    let palette = TerminalPalette::parse(
+        b"\x1b]11;rgb:1c1c/1e1e/2626\x1b\\\x1b]10;rgb:d5d5/d0d0/c8c8\x1b\\\
+          \x1b]4;12;rgb:5c5c/9f9f/ecec\x1b\\\x1b[?62c",
+    );
+    let derived = Theme::from_terminal(&palette).expect("a complete theme");
+
+    // A bordered panel pins the screen fill and the border…
+    let panel = element(Boxed::new(element(Text::raw("body"))));
+    let buf = crate::testing::render(panel.as_ref(), 12, 3, &derived);
+    assert_eq!(
+        buf[(5, 1)].bg,
+        Color::Rgb(0x1c, 0x1e, 0x26),
+        "the screen fill is the reported background, verbatim"
+    );
+    assert_eq!(buf[(0, 0)].fg, derived.border);
+    assert_ne!(
+        derived.border, derived.text,
+        "the border is a derived tone, not one of the two reported colors"
+    );
+
+    let buf = crate::testing::render(panel.as_ref(), 12, 3, &themes::TERMINAL);
+    assert_eq!(
+        buf[(5, 1)].bg,
+        Color::Reset,
+        "the terminal's own background shows through"
+    );
+    assert_eq!(
+        buf[(0, 0)].fg,
+        Color::Indexed(8),
+        "the border is an ANSI slot the terminal resolves"
+    );
+
+    // …and a console pins text, surface, and accent. It borrows its log, so it
+    // renders directly rather than through `element`.
+    let log = crate::components::ConsoleLog::new(8);
+    log.line("entry");
+    let console = crate::components::Console::new(&log).title("t");
+    let paint_console = |theme: &Theme| {
+        let mut buf = buffer(12, 3);
+        let area = buf.area;
+        let ctx = RenderCtx::new(theme);
+        let mut surface = Surface::new(&mut buf, area);
+        console.render(area, &mut surface, &ctx);
+        buf
+    };
+
+    let buf = paint_console(&derived);
+    assert_eq!(
+        buf[(0, 2)].fg,
+        Color::Rgb(0xd5, 0xd0, 0xc8),
+        "body text is the reported foreground, verbatim"
+    );
+    assert_eq!(
+        buf[(0, 0)].fg,
+        Color::Rgb(0x5c, 0x9f, 0xec),
+        "the accent is the bright blue it reported"
+    );
+    assert_eq!(buf[(0, 2)].bg, derived.surface);
+    assert_ne!(
+        derived.surface, derived.background,
+        "the raised fill is derived, and distinct from the base"
+    );
+
+    let buf = paint_console(&themes::TERMINAL);
+    assert_eq!(
+        buf[(0, 2)].fg,
+        Color::Reset,
+        "body text is the terminal's own foreground"
+    );
+    assert_eq!(buf[(0, 0)].fg, Color::Indexed(4), "so is the accent");
+}
+
 #[test]
 fn scroll_and_overlay_survive_tiny_screens() {
     use ratatui_core::layout::Rect;

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -61,6 +61,11 @@ pub const PRESETS: &[NamedTheme] = &[
         label: "Dracula",
         theme: DRACULA,
     },
+    NamedTheme {
+        name: "terminal",
+        label: "Terminal",
+        theme: TERMINAL,
+    },
 ];
 
 /// Look a bundled theme up by its [`NamedTheme::name`], case-insensitively.
@@ -239,6 +244,60 @@ pub const DRACULA: Theme = Theme {
     },
 };
 
+// --- Terminal (inherited) --------------------------------------------------
+// Not a palette at all: a mapping onto the slots the *terminal* resolves. Every
+// other preset names 24-bit colors; this one names ANSI indices and `Reset`, so
+// what the user sees is whatever their terminal was configured with.
+
+/// Terminal — inherit the user's own terminal colors, with no probe.
+///
+/// Every slot is either [`Color::Reset`] (the terminal's default foreground or
+/// background) or a [`Color::Indexed`] ANSI slot, so the terminal resolves the
+/// palette itself. That makes this the one theme that cannot be wrong about the
+/// user's setup and cannot fail: it needs no query, no timeout, and no
+/// capability — it works on a terminal that answers nothing.
+///
+/// The trade is that ANSI has no tone *between* two slots, so tuika's raised and
+/// faint roles collapse: `surface` and the code background are the plain
+/// background, and `dim`, `border`, and `muted` all land on bright black. For
+/// panels and rules that read as distinct, ask the terminal for its actual
+/// colors instead and derive them — see [`Theme::from_terminal`] and
+/// [`crate::term::palette`], which falls back to exactly this theme when the terminal
+/// stays silent.
+///
+/// [`Theme::from_terminal`]: crate::Theme::from_terminal
+pub const TERMINAL: Theme = Theme {
+    background: Color::Reset,
+    // ANSI cannot express a raised fill; a distinct one here would have to be a
+    // real color, which is precisely what this theme refuses to guess.
+    surface: Color::Reset,
+    text: Color::Reset,
+    muted: Color::Indexed(8),
+    dim: Color::Indexed(8),
+    accent: Color::Indexed(4),
+    accent_alt: Color::Indexed(6),
+    border: Color::Indexed(8),
+    border_focused: Color::Indexed(4),
+    // A selection has to paint a real background, so it uses the one pairing
+    // that reads on a light and a dark terminal alike.
+    selection_bg: Color::Indexed(4),
+    selection_fg: Color::Indexed(15),
+    code: CodeTheme {
+        heading: Color::Reset,
+        link: Color::Indexed(4),
+        background: Color::Reset,
+        text: Color::Reset,
+        label: Color::Indexed(8),
+        keyword: Color::Indexed(5),
+        function: Color::Indexed(4),
+        type_name: Color::Indexed(6),
+        constant: Color::Indexed(3),
+        string: Color::Indexed(2),
+        comment: Color::Indexed(8),
+        punctuation: Color::Indexed(8),
+    },
+};
+
 impl Theme {
     /// The [`SOLARIZED_DARK`] preset.
     pub const fn solarized_dark() -> Theme {
@@ -263,6 +322,11 @@ impl Theme {
     /// The [`DRACULA`] preset.
     pub const fn dracula() -> Theme {
         DRACULA
+    }
+
+    /// The [`TERMINAL`] preset — inherit the terminal's own colors.
+    pub const fn terminal() -> Theme {
+        TERMINAL
     }
 }
 
@@ -289,6 +353,45 @@ mod tests {
         assert_eq!(Theme::gruvbox_dark(), by_name("gruvbox-dark").unwrap());
         assert_eq!(Theme::light(), by_name("light").unwrap());
         assert_eq!(Theme::dracula(), by_name("dracula").unwrap());
+        assert_eq!(Theme::terminal(), by_name("terminal").unwrap());
+    }
+
+    /// Every other preset is a fixed palette; this one must resolve entirely at
+    /// the terminal, so a literal color anywhere in it would be a bug.
+    #[test]
+    fn the_terminal_preset_names_no_color_of_its_own() {
+        let t = TERMINAL;
+        let slots = [
+            t.background,
+            t.surface,
+            t.text,
+            t.muted,
+            t.dim,
+            t.accent,
+            t.accent_alt,
+            t.border,
+            t.border_focused,
+            t.selection_bg,
+            t.selection_fg,
+            t.code.heading,
+            t.code.link,
+            t.code.background,
+            t.code.text,
+            t.code.label,
+            t.code.keyword,
+            t.code.function,
+            t.code.type_name,
+            t.code.constant,
+            t.code.string,
+            t.code.comment,
+            t.code.punctuation,
+        ];
+        for slot in slots {
+            assert!(
+                matches!(slot, Color::Reset | Color::Indexed(0..=15)),
+                "{slot:?} is not something the terminal resolves"
+            );
+        }
     }
 
     #[test]

--- a/tests/pty_palette.rs
+++ b/tests/pty_palette.rs
@@ -1,0 +1,251 @@
+//! Terminal-palette probe smoke, with the test playing the terminal.
+//!
+//! `tests/pty_smoke.rs` watches what tuika *writes*. This does the inverse:
+//! tuika's color probe is a conversation, so the only way to prove it works is
+//! to answer it. The test spawns the `inherit` example under a pty, waits for
+//! the query bytes, replies with a palette of its own choosing, and checks that
+//! the theme the example resolved is the one implied by those replies.
+//!
+//! Three things are only observable here, never in a buffer test:
+//!
+//! - the queries actually reach the terminal, and the reply parses back into a
+//!   theme end-to-end;
+//! - the read stops at the Device Attributes fence and **consumes no input past
+//!   it** — a keystroke sent right behind the replies must still reach the
+//!   application, not be eaten by the probe;
+//! - a terminal that answers nothing does not hang the application, it falls
+//!   back.
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+
+/// The palette this fake terminal claims to have. Chosen so every value lands
+/// clear of tuika's contrast floors, which keeps the expected colors exact:
+/// nothing below is adjusted on its way into the theme.
+const BACKGROUND: &str = "#1c1e26";
+const FOREGROUND: &str = "#d5d0c8";
+const BRIGHT_BLUE: &str = "#5c9fec";
+const BRIGHT_GREEN: &str = "#88cc66";
+
+/// The replies a terminal supporting the color queries would send, ending with
+/// the Device Attributes answer that fences them.
+fn replies() -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"\x1b]10;rgb:d5d5/d0d0/c8c8\x1b\\");
+    out.extend_from_slice(b"\x1b]11;rgb:1c1c/1e1e/2626\x1b\\");
+    out.extend_from_slice(b"\x1b]4;10;rgb:8888/cccc/6666\x1b\\");
+    out.extend_from_slice(b"\x1b]4;12;rgb:5c5c/9f9f/ecec\x1b\\");
+    out.extend_from_slice(b"\x1b[?62;1;4;22c");
+    out
+}
+
+/// Locate the compiled `inherit` example, built beside this test binary.
+fn inherit_bin() -> PathBuf {
+    let test_bin = std::env::current_exe().expect("test binary path");
+    let profile_dir = test_bin
+        .parent()
+        .and_then(|deps| deps.parent())
+        .expect("target/<profile> directory");
+    let bin = profile_dir.join("examples").join("inherit");
+    assert!(
+        bin.is_file(),
+        "the `inherit` example was not built at {} — `cargo test` should build \
+         examples; run `cargo build --example inherit` if invoking the test \
+         binary directly",
+        bin.display()
+    );
+    bin
+}
+
+struct Run {
+    output: Vec<u8>,
+    exited_ok: bool,
+}
+
+impl Run {
+    fn text(&self) -> String {
+        String::from_utf8_lossy(&self.output).replace("\r\n", "\n")
+    }
+}
+
+/// Spawn `inherit` under a pty. Once it has asked its questions, send `answer`
+/// (if any), then wait for it to exit.
+///
+/// `answer` is written as a single burst so that anything after the Device
+/// Attributes reply is already sitting in the terminal's buffer when the probe
+/// stops reading — which is exactly the condition that catches a probe that
+/// reads too far.
+fn run_inherit(args: &[&str], answer: Option<Vec<u8>>) -> Run {
+    let pty = NativePtySystem::default();
+    let pair = pty
+        .openpty(PtySize {
+            rows: 30,
+            cols: 90,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("open pty");
+
+    let mut cmd = CommandBuilder::new(inherit_bin());
+    cmd.env("TERM", "xterm-256color");
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn inherit");
+    drop(pair.slave);
+
+    let reader = pair.master.try_clone_reader().expect("clone reader");
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let reader_buffer = Arc::clone(&buffer);
+    let reader_handle = thread::spawn(move || {
+        let mut reader = reader;
+        let mut chunk = [0u8; 8192];
+        while let Ok(n) = reader.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            reader_buffer
+                .lock()
+                .expect("lock read buffer")
+                .extend_from_slice(&chunk[..n]);
+        }
+    });
+
+    let mut writer = pair.master.take_writer().expect("pty writer");
+    if let Some(answer) = answer {
+        // Wait until the Device Attributes request arrives: that is the last
+        // thing the probe writes, so seeing it means every query is out.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let seen = buffer.lock().expect("lock read buffer").clone();
+            if seen.windows(3).any(|w| w == b"\x1b[c") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the probe never sent its Device Attributes request; saw: {:?}",
+                String::from_utf8_lossy(&seen)
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        writer.write_all(&answer).expect("send replies");
+        writer.flush().expect("flush replies");
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut exited_ok = false;
+    loop {
+        match child.try_wait().expect("poll child") {
+            Some(status) => {
+                exited_ok = status.success();
+                break;
+            }
+            None if Instant::now() > deadline => {
+                let _ = child.kill();
+                break;
+            }
+            None => thread::sleep(Duration::from_millis(50)),
+        }
+    }
+
+    drop(writer);
+    drop(pair.master);
+    let _ = reader_handle.join();
+    Run {
+        output: Arc::try_unwrap(buffer)
+            .expect("reader thread finished")
+            .into_inner()
+            .expect("read buffer"),
+        exited_ok,
+    }
+}
+
+#[test]
+fn the_probe_asks_for_the_palette_and_fences_with_device_attributes() {
+    let run = run_inherit(&["--probe"], Some(replies()));
+    let bytes = &run.output;
+    let has = |needle: &[u8]| bytes.windows(needle.len()).any(|w| w == needle);
+
+    assert!(has(b"\x1b]10;?"), "asked for the default foreground");
+    assert!(has(b"\x1b]11;?"), "asked for the default background");
+    for i in 0..16 {
+        let q = format!("\x1b]4;{i};?");
+        assert!(has(q.as_bytes()), "asked for ANSI slot {i}");
+    }
+    assert!(has(b"\x1b[c"), "fenced the queries with Device Attributes");
+}
+
+#[test]
+fn a_terminals_answer_becomes_the_theme() {
+    let run = run_inherit(&["--probe"], Some(replies()));
+    let text = run.text();
+    assert!(run.exited_ok, "clean exit; got:\n{text}");
+
+    assert!(
+        text.contains("source: probed"),
+        "the theme came from the probe, not the fallback; got:\n{text}"
+    );
+    // The reported foreground and background are used verbatim…
+    assert!(
+        text.contains(&format!("background: {BACKGROUND}")),
+        "background is the one this terminal reported; got:\n{text}"
+    );
+    assert!(
+        text.contains(&format!("text: {FOREGROUND}")),
+        "text is the reported foreground; got:\n{text}"
+    );
+    // …and the hues come from the ANSI slots it reported.
+    assert!(
+        text.contains(&format!("accent: {BRIGHT_BLUE}")),
+        "accent is the reported bright blue; got:\n{text}"
+    );
+    assert!(
+        text.contains(&format!("code.string: {BRIGHT_GREEN}")),
+        "the syntax palette follows the terminal; got:\n{text}"
+    );
+    // The in-between tones are derived, so they are *not* simply the background.
+    assert!(
+        !text.contains(&format!("surface: {BACKGROUND}")),
+        "surface is a derived raise, not the base fill; got:\n{text}"
+    );
+}
+
+/// The fence must stop the read exactly at the Device Attributes reply. A `q`
+/// sent immediately behind it belongs to the application: if the probe swallows
+/// it, the example never sees the quit key and this times out instead of
+/// exiting.
+#[test]
+fn the_probe_leaves_input_after_the_fence_for_the_application() {
+    let mut answer = replies();
+    answer.push(b'q');
+    let run = run_inherit(&[], Some(answer));
+    assert!(
+        run.exited_ok,
+        "the quit key sent behind the replies must survive the probe; got:\n{}",
+        run.text()
+    );
+}
+
+/// A terminal that implements none of this says nothing at all. The application
+/// must come up anyway, on the ANSI-slot theme.
+#[test]
+fn a_silent_terminal_falls_back_instead_of_hanging() {
+    let run = run_inherit(&["--probe"], None);
+    let text = run.text();
+    assert!(run.exited_ok, "clean exit; got:\n{text}");
+    assert!(
+        text.contains("themes::TERMINAL"),
+        "fell back to the ANSI-slot theme; got:\n{text}"
+    );
+    assert!(
+        text.contains("background: terminal default"),
+        "the fallback defers every color to the terminal; got:\n{text}"
+    );
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -134,7 +134,7 @@ fn component_modules_own_their_constants_and_free_functions() {
 /// same pure-`encode` shape.
 #[test]
 fn term_groups_the_out_of_band_escapes() {
-    use tuika::term::{capabilities, clipboard, hyperlink, image, pointer, progress};
+    use tuika::term::{capabilities, clipboard, hyperlink, image, palette, pointer, progress};
 
     assert_eq!(clipboard::encode("hi").unwrap(), "\x1b]52;c;aGk=\x1b\\");
     assert!(hyperlink::encode("https://example.com", "link").contains("\x1b]8;;"));
@@ -156,6 +156,16 @@ fn term_groups_the_out_of_band_escapes() {
     let _ = image::ImageLayer::new();
     let _ = image::ImageSupport::detect_from(None, None, None, None);
     let _ = capabilities::Capabilities::from_env();
+
+    // A query is out-of-band too, and the only one with a reply — so the pure
+    // half (build the request, parse the answer) has to be reachable from here.
+    assert!(palette::query_sequence().ends_with(capabilities::DA1_REQUEST));
+    let reported = palette::TerminalPalette::parse(
+        b"\x1b]11;rgb:1c1c/1e1e/2626\x1b\\\x1b]10;rgb:d5d5/d0d0/c8c8\x1b\\",
+    );
+    assert!(!reported.is_empty());
+    assert!(Theme::from_terminal(&reported).is_some());
+    let _ = tuika::themes::TERMINAL;
 }
 
 /// The paths that used to collide at the crate root now name one thing each.


### PR DESCRIPTION
## What changed

An application built on tuika can now adopt the palette the user already
configured in their terminal, instead of imposing its own. Two routes, and the
first is the fallback for the second:

- **`themes::TERMINAL`** — a `const Theme` whose every slot is `Color::Reset` or
  a `Color::Indexed` ANSI slot, so the *terminal* resolves the palette. No query,
  no timeout, no capability, no failure mode. It cannot express a tone between
  two ANSI slots, so the raised and faint roles collapse (`surface` reads as the
  background; `dim`/`border`/`muted` all land on bright black).
- **`term::palette::TerminalPalette::query` + `Theme::from_terminal`** — ask the
  terminal with the xterm color queries (OSC 10, OSC 11, OSC 4 per entry) and
  derive a full theme from the answer. Real 24-bit values, so the in-between
  tones exist.

The derivation draws one line and holds it: **reported colors are used verbatim**
(the user's foreground is `text`, their background is `background` — matching
them is the entire point), and **everything a terminal has no notion of is
derived**. In-between tones are blends between the two reported colors, which
makes light and dark palettes one code path rather than two. Hues come from the
ANSI palette — bright half on a dark background, normal half on a light one, blue
leading and cyan following, since no terminal reports a *brand* color. Every
derived color is held to a minimum contrast against the background: a user's
palette may put two colors on top of each other, a UI assembled from it may not.
Unreported ANSI slots fall back to xterm's defaults, so a terminal answering only
OSC 10 and OSC 11 still yields a complete theme.

**This is opt-in and host-initiated.** tuika never probes a terminal and never
varies a default by which terminal it finds itself in. The default theme is
unchanged, and nothing here runs unless a host calls it.

The queries are fenced by the Device Attributes request. A terminal implementing
none of them says *nothing*, and silence is indistinguishable from *not yet*, so
without a fence an unsupported query costs a full timeout rather than a
round-trip. DA1 is answered by everything, so its reply terminates the read — and
since that is the same request the capability probe already makes,
`Capabilities::query_with_palette` answers both questions in one trip. The read
stops exactly at the fence, so input typed behind the replies still reaches the
application.

Per `knowledge/specs/api-surface.md`, a query talks to the terminal rather than
the buffer, so `palette` lives under `term` beside `capabilities` and its types
are **not** flattened to the crate root. It is the third shape in that module:
the others tell the terminal something, this one asks.

## Why

The user picked their colors once, in Ghostty or kitty or wherever they work. An
app that ignores that choice looks like a guest. The escape query is the only
supported way to ask — parsing a terminal's config file would couple tuika to
another project's format and its theme-resolution rules, which is now recorded as
out of scope.

## Before / After

**Before** — a tuika app painted `Theme::default()` (or a bundled preset)
regardless of the terminal it was launched in. There was no way to ask a terminal
for its colors.

**After** — `cargo run --example inherit -- --probe`, driven under a pty by a
test that plays a terminal reporting `#d5d0c8` on `#1c1e26` with a bright-blue
`#5c9fec`:

```text
source: probed — derived from the colors this terminal reported
background: #1c1e26      <- reported, verbatim
surface:    #2f3036      <- derived (blend toward the foreground)
text:       #d5d0c8      <- reported, verbatim
muted:      #8b8987      <- derived, contrast-guarded
dim:        #57575a
accent:     #5c9fec      <- reported ANSI bright blue
accent_alt: #5ccfd8
border:     #626264
selection_bg: #324b6b
code.keyword: #e07cc8
code.string:  #88cc66
code.comment: #6b7280
```

The same binary against a terminal that answers **nothing** — no hang, no error,
it falls back:

```text
source: themes::TERMINAL — the terminal answered nothing, ANSI slots
background: terminal default
text:       terminal default
muted:      ansi 8
accent:     ansi 4
```

And the UI painted with the inherited theme (vt100-parsed from the same pty run):

```text
 ╭─ inherited theme ──────────────────────────────────────────────────────╮
 │ probed — derived from the colors this terminal reported                │
 ╰────────────────────────────────────────────────────────────────────────╯

 ╭─ slots ────────────────────────────────────────────────────────────────╮
 │ ████ background    #1c1e26                                             │
 │ ████ surface       #2f3036                                             │
 │ ████ text          #d5d0c8                                             │
 │ ████ muted         #8b8987                                             │
 │ ████ dim           #57575a                                             │
 │ ████ accent        #5c9fec                                             │
 │ ████ accent_alt    #5ccfd8                                             │
 │ ████ border        #626264                                             │
 │ ████ selection_bg  #324b6b                                             │
 │ ████ code.keyword  #e07cc8                                             │
 │ ████ code.string   #88cc66                                             │
 │ ████ code.comment  #6b7280                                             │
 ╰────────────────────────────────────────────────────────────────────────╯
```

## Risk

- **Low**
- Nothing runs unless a host opts in, and the default theme is untouched, so an
  existing application sees no change at all.
- The genuine risk is in the probe, and it is bounded three ways: the DA1 fence
  means an unsupported query costs a round-trip rather than a timeout, the read
  is capped at 1 KiB, and the parser skips malformed replies rather than failing.
  A terminal that answers nothing falls back to the ANSI-slot theme.
- Derived colors are a judgement call, not a correctness one — a user may dislike
  tuika's choice of blue as the accent. That is why reported colors are never
  adjusted: the parts that *can* be wrong are the parts the terminal never told
  us about.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

### API changes

All additive; nothing renamed, removed, or re-signed, so this is not a breaking
change. Recorded in `CHANGELOG.md` under Unreleased:

- new module `tuika::term::palette` — `TerminalPalette` (`parse`, `query`,
  `is_empty`), `QUERY_FOREGROUND`, `QUERY_BACKGROUND`, `query_sequence`. Not
  re-exported to the crate root, per the api-surface rules.
- `Theme::from_terminal`, `Theme::terminal`
- `themes::TERMINAL`, and a `terminal` entry in `themes::PRESETS` (a host
  iterating presets for a picker gains one row; `themes::by_name("terminal")`
  now resolves)
- `Capabilities::query_with_palette`
- `tests/public_api.rs` pins all of the above from outside the crate.

### Tests

Three layers, each covering something the others cannot:

- **Unit** (`src/term/palette.rs`) — the reply parser against every component
  width, both terminators, `#`/`rgba:` specs, packed OSC 4 replies, junk and
  malformed specs, and *every truncation* of a realistic stream; the derivation
  against a real palette, a light background, missing ANSI slots, and the
  degenerate case of a foreground equal to its background.
- **Integration** (`src/tests/integration.rs`) — painted **cells** pinned to
  their theme slots, for both routes: 24-bit values for the derived theme,
  `Reset` and `Indexed` for the ANSI one.
- **PTY** (`tests/pty_palette.rs`) — the test plays the terminal. It answers the
  queries and checks the theme end to end, sends a keystroke immediately behind
  the replies to prove the probe does not swallow it, and checks that a silent
  terminal falls back instead of hanging. This is the only layer that can
  observe the fence.

Smoke-tested through the new `inherit` example under a real pty (output above),
plus `cargo run --example demo -- check`,
`python3 scripts/validate_okf.py knowledge --check-links`, and the public-docs
boundary grep. `fmt`, `clippy --all-targets --all-features -D warnings`,
`test --all-features`, `doc` with `RUSTDOCFLAGS=-D warnings`, and
`cargo +1.88 check` (MSRV) are all clean.

Rebased onto `main` after #6 and #7 landed; `palette` was relocated from the
crate root into `term` as part of that, which is where the new API-surface policy
puts it.

## Knowledge

- **[Styling](knowledge/specs/styling.md)** — records the third source for a
  `Theme` beside the presets and a host literal, and the report/derive/invent
  boundary, which is the whole design and is not recoverable from the code. Adds
  the constraints that inheritance is opt-in and host-initiated and that reading
  a terminal's *config file* is out of scope. Restates the "no inheritance"
  non-goal, which was about the rule layer and now collides with a second
  meaning of the word.
- **[Out-of-band escapes](knowledge/specs/out-of-band.md)** — a third family, and
  `term::palette` in the module table. The other five capabilities *tell* the
  terminal something; a query is *asked*, and its answer arrives on stdin among
  the user's keystrokes. Records the two rules that follow: fence with DA1, and
  run once at startup stopping at the fence.
- **[Log](knowledge/log.md)** — an entry for both.

No change needed to `api-surface.md`: this change *follows* its placement rules
rather than altering them.

## Security

Reviewed against the repository's threat-model categories.

- **TM-ESC** — the new escapes (OSC 10/11/4 queries, DA1) are built entirely by
  tuika's own `query_sequence()` from constants and a `0..16` loop index. No
  caller-supplied string reaches the terminal; `probe_terminal` is `pub(crate)`
  and is only ever called with a tuika-constructed sequence. Classification: a
  terminal that does not implement a color query consumes the OSC and shows
  nothing — not garbage — so this needs no capability gate, only the fallback it
  has.
- **TM-PARSE** — `TerminalPalette::parse` runs over untrusted terminal output and
  was reviewed as such: bounded scan, no recursion, no `unwrap` on parsed input,
  ANSI indices written through `get_mut` so an out-of-range index is dropped
  rather than panicking, `scale_hex` rejecting anything over four digits or
  non-hex. Allocation is fixed-size regardless of input, and the read itself is
  capped at 1 KiB, so a hostile or broken terminal cannot make tuika buffer
  without bound. A test parses every prefix of a realistic stream to pin the
  no-panic property.
- **TM-STATE** — the probe sets no terminal mode and enters no screen, so it has
  nothing to restore. It *requires* raw mode, which the host owns; the `inherit`
  example pairs its own enable/disable so an early return cannot strand the
  terminal.
- **TM-CLIP** — no new painting code. A theme is data; the components that
  consume it are unchanged.
- **TM-DEP** — no new dependencies.

One pre-existing caveat is now documented on `probe_terminal` rather than left
implicit: if a terminal never answers *DA1 itself*, the timeout returns but the
reader thread is still blocked in `read` and will consume the next byte typed.
That behavior is unchanged from when this function only asked for Device
Attributes — the fence is precisely the sequence every terminal does answer — but
it is worth a host knowing.

## Follow-ups

- **Live re-theming on OS light/dark switch (DEC mode 2031).** Ghostty and a few
  others will push `CSI ? 997 ; 1|2 n` when the system appearance changes, which
  would turn this from a startup snapshot into live inheritance. Deferred
  deliberately: crossterm does not parse that sequence, so tuika's event pipeline
  cannot surface it today, and the enable/disable pair needs runner-owned
  teardown per TM-STATE. Shipping only the encoder constants would be API surface
  no host could actually use.
- **No demo recording for the `terminal` preset.** The theme gallery records one
  GIF per bundled palette; a recording of this one would only ever be a picture
  of the recorder's own colors. `docs/themes.md` says so and points at the
  `inherit` example instead. (VHS is also unavailable in this environment.)