### PR TITLE
docs(example): follow the stream until the reader scrolls back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 * refactor: fold `async_runner` into `runner` and rename `ratatui_view` to `interop`
 * refactor(tests): move the crate's test scaffolding under `src/tests`
 * refactor(markdown): split the module along its parse/flatten passes
+* docs(example): follow the stream in the markdown example until the reader scrolls back
 * test: pin the public module layout from outside the crate (`tests/public_api.rs`)
 * docs: add `knowledge/specs/api-surface.md` and a crate-layout section to the README
 * feat(themes): inherit the terminal's palette

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Each enters the alternate screen; press `q` (or `esc`) to quit.
 | Example    | Command                                   | Shows                                              |
 | ---------- | ----------------------------------------- | -------------------------------------------------- |
 | [`gallery`](examples/gallery.rs)  | `cargo run --example gallery`    | motion components + native OSC 9;4 progress        |
-| [`markdown`](examples/markdown.rs) | `cargo run --example markdown`   | streaming `MarkdownState` + highlighted `CodeBlock` |
+| [`markdown`](examples/markdown.rs) | `cargo run --example markdown`   | streaming `MarkdownState` + highlighted `CodeBlock`, following the stream until you scroll back |
 | [`select`](examples/select.rs)   | `cargo run --example select`     | `SelectState` + `SelectList` (stateful-widget idiom) |
 | [`overlay`](examples/overlay.rs)  | `cargo run --example overlay`    | `OverlaySpec` centered dialog + input routing      |
 | [`primitives`](examples/primitives.rs) | `cargo run --example primitives` | owned dialog scene + form + arbitrary-child viewport |

--- a/docs/components.md
+++ b/docs/components.md
@@ -334,6 +334,29 @@ state.clamp_x(widest_line_w, viewport_w);    // keep the pan within the content
 view! { node(Scroll::new(lines, &state)) }
 ```
 
+#### Following a stream
+
+Content that grows while it is being read — a transcript, a log tail, a
+streaming answer — wants to show the newest rows *until the reader scrolls away
+from them*. That is not a mode to implement; it falls out of two calls:
+
+```rust
+use tuika::prelude::*;
+let mut state = ScrollState::new();
+
+// Once per frame, after appending: pins the offset to the newest content while
+// the state is stuck to the bottom, and leaves a scrolled-back reader alone.
+state.clamp(content_h, viewport_h);
+
+// Scrolling up releases the stick; reaching the bottom again re-arms it.
+state.handle(&event, content_h, viewport_h);
+
+// Read it back to tell the reader which they are.
+let live = state.is_stuck_to_bottom();
+```
+
+`examples/markdown.rs` runs exactly this over a streaming `MarkdownState`.
+
 ### `ItemScroll`
 
 The same viewport over **items** instead of lines: `Vec<Element>`, each measured

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -1,12 +1,32 @@
 //! Streaming Markdown renderer. Run with `cargo run --example markdown`
-//! (space pause/resume · r restart · q or esc quit).
+//! (space pause/resume · r restart · PgUp/PgDn/Home/End or wheel scroll ·
+//! q or esc quit).
 //!
 //! Demonstrates [`MarkdownState`]: a rich CommonMark document is fed in a few
 //! glyphs per frame — exactly how a host feeds an assistant message as it
 //! streams — while only the in-flight tail re-parses each frame. Fenced code is
-//! syntax-highlighted through a tiny self-contained [`Highlighter`](tuika::Highlighter)
+//! syntax-highlighted through a tiny self-contained [`Highlighter`](tuika::highlight::Highlighter)
 //! (see `DemoHighlighter` below); for production highlighting across many
 //! languages, use the `tuika-codeformatters` crate.
+//!
+//! # Following a stream
+//!
+//! A streamed document outgrows the viewport, so this also shows the pattern
+//! every streaming host needs: the view **follows the newest content, until the
+//! reader scrolls away from it**. Scrolling back must not be yanked to the
+//! bottom by the next delta, and returning to the bottom must resume following.
+//!
+//! That is two calls, not a mechanism:
+//!
+//! - [`ScrollState::clamp`] once per frame reconciles the offset with the
+//!   current content and viewport heights, pinning it to the bottom *while the
+//!   state is stuck there*. Appending content therefore scrolls it into view on
+//!   its own.
+//! - [`ScrollState::handle`] releases that stick when the reader scrolls up, and
+//!   re-arms it when they reach the bottom again.
+//!
+//! [`ScrollState::is_stuck_to_bottom`] reads the flag back, which is how the
+//! status bar below can say whether it is live or held.
 
 use std::io;
 use std::time::Duration;
@@ -149,6 +169,7 @@ fn main() -> io::Result<()> {
     let doc: Vec<char> = SOURCE.chars().collect();
 
     let mut state = MarkdownState::new();
+    let mut scroll = ScrollState::new();
     let mut cursor = 0usize;
     let mut paused = false;
 
@@ -166,36 +187,59 @@ fn main() -> io::Result<()> {
         // Advance the stream: a few glyphs per frame until the document is fully
         // in, then hold. `push_str` is the delta a host would forward verbatim.
         if !paused && cursor < doc.len() {
-            let end = (cursor + 3).min(doc.len());
+            // Fast enough that the document outgrows a normal viewport within a
+            // few seconds, which is when the follow behavior becomes visible.
+            let end = (cursor + 6).min(doc.len());
             let chunk: String = doc[cursor..end].iter().collect();
             state.push_str(&chunk);
             cursor = end;
         }
 
+        // Lay the document out *before* drawing: the scroll state has to
+        // reconcile against the content and viewport heights, and neither is
+        // known until the lines exist.
+        let size = terminal.size()?;
+        let width = size.width.saturating_sub(4);
+        let lines = state
+            .lines(width, &theme, &sheet, CodeHighlighter::With(&highlighter))
+            .to_vec();
+        let content_h = lines.len();
+        // The column's own chrome: one row of padding top and bottom, the gap,
+        // and the status bar.
+        let viewport_h = usize::from(size.height.saturating_sub(4));
+
+        // The whole follow-while-streaming behavior. `clamp` pins the offset to
+        // the newest content while the state is stuck to the bottom, and leaves
+        // a reader who scrolled back exactly where they were.
+        scroll.clamp(content_h, viewport_h);
+
         terminal.draw(|f| {
             let area = f.area();
-            let width = area.width.saturating_sub(4);
-            let lines = state
-                .lines(width, &theme, &sheet, CodeHighlighter::With(&highlighter))
-                .to_vec();
             let status = if cursor < doc.len() {
                 format!("streaming… {}/{} glyphs", cursor, doc.len())
             } else {
                 "done".to_string()
             };
+            // Reading the stick back is what lets a host tell the reader whether
+            // they are live or holding a position.
+            let follow = if scroll.is_stuck_to_bottom() {
+                Span::styled(" following ", theme.selection_style())
+            } else {
+                Span::styled(" scrolled back — End to follow ", theme.warning_style())
+            };
             let bar = StatusBar::new()
-                .left(vec![Span::styled(
-                    format!(" {status} "),
-                    theme.selection_style(),
-                )])
+                .left(vec![
+                    Span::styled(format!(" {status} "), theme.selection_style()),
+                    follow,
+                ])
                 .right(vec![Span::styled(
-                    "space pause · r restart · q quit ",
+                    "space pause · r restart · pgup/pgdn scroll · q quit ",
                     theme.muted_style(),
                 )])
                 .background(Style::default().bg(theme.surface));
             let root = view! {
                 col(padding = Padding::all(1), gap = 1) {
-                    grow(1) { node(Text::new(lines)) }
+                    grow(1) { node(Scroll::new(lines, &scroll)) }
                     fixed(1) { node(bar) }
                 }
             };
@@ -205,22 +249,27 @@ fn main() -> io::Result<()> {
         if !event::poll(Duration::from_millis(70))? {
             continue;
         }
-        let Some(Event::Key(k)) = translate_event(event::read()?) else {
+        let Some(event) = translate_event(event::read()?) else {
             continue;
         };
-        if !k.plain() {
-            continue;
-        }
-        match k.code {
-            KeyCode::Char('q') | KeyCode::Esc => break,
-            KeyCode::Char(' ') => paused = !paused,
-            KeyCode::Char('r') => {
-                state = MarkdownState::new();
-                cursor = 0;
-                paused = false;
+        if let Event::Key(k) = &event
+            && k.plain()
+        {
+            match k.code {
+                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Char(' ') => paused = !paused,
+                KeyCode::Char('r') => {
+                    state = MarkdownState::new();
+                    scroll = ScrollState::new();
+                    cursor = 0;
+                    paused = false;
+                }
+                _ => {}
             }
-            _ => {}
         }
+        // PgUp/PgDn/Home/End and the wheel; scrolling up releases the stick,
+        // reaching the bottom re-arms it.
+        scroll.handle(&event, content_h, viewport_h);
     }
 
     let _ = terminal.clear();

--- a/src/components/scroll.rs
+++ b/src/components/scroll.rs
@@ -497,6 +497,48 @@ mod tests {
         );
     }
 
+    /// The streaming host's loop: follow the newest content, hold position when
+    /// the reader scrolls back, and resume following when they page down to the
+    /// end again. `End` is the shortcut for the last step
+    /// ([`scroll_end_key_rearms_bottom_stick`]); this covers arriving there by
+    /// scrolling, which is how a reader normally does it.
+    #[test]
+    fn scrolling_back_to_the_bottom_resumes_following() {
+        let mut s = ScrollState::new();
+        s.clamp(100, 10);
+        assert_eq!(s.offset(), 90);
+
+        // Read back a couple of screens.
+        let up = Event::Mouse(Mouse::at(MouseKind::ScrollUp, 0, 0));
+        s.handle(&up, 100, 10);
+        s.handle(&up, 100, 10);
+        assert_eq!(s.offset(), 84);
+        assert!(!s.is_stuck_to_bottom());
+
+        // Deltas keep arriving while the reader is back there: the view must not
+        // move under them.
+        s.clamp(130, 10);
+        assert_eq!(s.offset(), 84, "content growth must not yank a reader back");
+
+        // Page down until the end is reached; arriving there re-arms the stick.
+        let down = Event::Key(Key::new(KeyCode::PageDown));
+        for _ in 0..8 {
+            if s.is_stuck_to_bottom() {
+                break;
+            }
+            s.handle(&down, 130, 10);
+        }
+        assert!(
+            s.is_stuck_to_bottom(),
+            "reaching the bottom resumes following"
+        );
+        assert_eq!(s.offset(), 120);
+
+        // ...so the next delta scrolls itself into view again.
+        s.clamp(160, 10);
+        assert_eq!(s.offset(), 150);
+    }
+
     #[test]
     fn scroll_end_key_rearms_bottom_stick() {
         let mut s = ScrollState::new();


### PR DESCRIPTION
## What changed

`examples/markdown.rs` streamed into a plain `Text`, so a document longer than the terminal ran off the bottom and stayed there. It now scrolls, and **follows the newest content until the reader scrolls away from it**:

- `ScrollState::clamp` once per frame pins the offset to the bottom *while the state is stuck there*, so appending scrolls itself into view.
- `ScrollState::handle` releases that stick on scroll-up and re-arms it on reaching the end.
- The status bar reads `is_stuck_to_bottom` back and says `following` or `scrolled back — End to follow`, so the screen shows which state it is in.

Two calls, no mode flag. `docs/components.md` gains a *Following a stream* section under `Scroll` stating the same pattern, since it applies to any growing content — transcripts, log tails, streaming answers — not just markdown.

Also **doubles the stream rate** (3 → 6 glyphs/frame). See Before/After for why that turned out to be load-bearing rather than cosmetic.

## Why

This is the gap identified when we discussed whether tuika should ship a `MarkdownViewer`. It shouldn't: the composition is three lines, and a component could not own the other half of markdown viewing anyway — image emission has to happen *after* `terminal.draw` returns, outside any view's `render`. But the pattern being demonstrated nowhere except buried inside `examples/codex/` was a real hole, and that is what this fills.

## Before / After

**Before** — a plain `Text`, so once the document exceeded the viewport the newest content was simply off-screen with no way to reach it.

**After** — driven under a PTY at 100×24, asserting what the status bar reports at each step:

```
$ python3 drive_md.py target/debug/examples/markdown
PASS  streaming: expected 'following'
PASS  paged_up: expected 'scrolled back'
PASS  end: expected 'following'
scrollbar thumb present: True | track: True
```

That harness is throwaway (it lives in my scratchpad, not the repo) — `tests/pty_smoke.rs` remains the committed PTY coverage, and it drives `gallery`.

**The stream-rate change came out of that run.** At the original 3 glyphs/frame the document did not outgrow a 24-row viewport for ~15 seconds — longer on a normally-sized terminal — so the follow behaviour this example now exists to demonstrate was invisible for most of its runtime, and my first PTY run found no scrollbar at all because nothing had overflowed yet. At 6 glyphs/frame the overflow, the scrollbar, and the follow/release behaviour are all visible within a few seconds, and the whole document still takes ~14s to stream in.

Other evidence:

| Check | Result |
| --- | --- |
| `cargo test --workspace --all-features` | 385 + 3 + 4 + 4 + 8 + 5 + 33 + 1 pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo doc --no-deps --all-features` | 0 warnings |
| `cargo run --example demo -- check` | `ok: 28 scenes, recordings, and references in sync` |
| `python3 scripts/validate_okf.py knowledge --check-links` | 13 concepts, 0 errors |

## Risk

- **Low** — an example, a doc section, and one added test. No library behaviour changes.
- What can break: nothing for hosts. The `Scroll`/`ScrollState` API is untouched; this only exercises and documents it.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Tests

The example itself is not unit-testable, but the *pattern* it demonstrates is library behaviour, and it was almost fully covered already — `scroll_sticks_to_bottom_until_scrolled_up` proves clamp pins to the bottom and that growth doesn't drag a scrolled-back reader; `scroll_end_key_rearms_bottom_stick` proves `End` re-arms.

The gap was the case a reader actually hits: scrolling *back down* to the end re-arms the stick, so the next delta follows again. `scrolling_back_to_the_bottom_resumes_following` now covers that full loop — follow, read back, content grows without yanking, page down to the end, follow again.

## Knowledge

**No knowledge update required** — this demonstrates and documents an existing seam rather than changing one. The stick-to-bottom design is already stated in `scroll.rs`'s module docs, and `specs/architecture.md` already covers the viewport primitives; nothing durable changed.

## Security

No security-relevant code changes: an example, a markdown doc, and one test. No escapes, parsing, clipping, state handling, or dependencies were touched.

## Follow-ups

- **No demo recording.** `docs/demos/markdown.gif` is generated from the `DEMOS` scene in `examples/demo.rs`, not from this example, so the gallery is unaffected and `demo -- check` passes. A recording of the follow/scroll-back interaction would be a nice addition to the gallery, but it needs its own scene and a VHS run — worth doing separately if you want it.
- The `0.5.0` version bump still sits under `## [Unreleased]`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lucc2UeqHEUpoZZSXvcy9c)_