### PR TITLE
fix(term): enable modified-key reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Releases](https://github.com/everruns/tuika/releases).
 
 ## [Unreleased]
 
+### Fixed
+
+- `TerminalSession` now enables and restores enhanced keyboard reporting, so
+  `Shift+Enter` reaches `TextInputState` as a distinct chord instead of being
+  decoded as plain `Enter`. The negotiation handles iTerm2 and tmux's xterm and
+  CSI-u formats.
+
 ### Highlights
 
 **The crate root is now a decision instead of an accumulation.** `tuika::` had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Releases](https://github.com/everruns/tuika/releases).
 - `TerminalSession` now enables and restores enhanced keyboard reporting, so
   `Shift+Enter` reaches `TextInputState` as a distinct chord instead of being
   decoded as plain `Enter`. The negotiation handles iTerm2 and tmux's xterm and
-  CSI-u formats.
+  CSI-u formats; Windows keeps using modifier-aware native console events.
 
 ### Highlights
 

--- a/README.md
+++ b/README.md
@@ -373,11 +373,14 @@ lifecycle.
 
 ## Terminal lifecycle and runner
 
-`TerminalSession` is the complete RAII guard: it owns raw mode, alternate
-screen, mouse capture, and cursor visibility, including rollback after partial
-initialization. It preserves raw mode when the caller had already enabled it.
-`AltScreen` remains available for hosts that intentionally own raw mode and
-cursor visibility themselves.
+`TerminalSession` is the complete RAII guard: it owns raw mode, enhanced
+keyboard reporting, alternate screen, mouse capture, and cursor visibility,
+including rollback after partial initialization. Enhanced reporting preserves
+non-character modifiers, so `Shift+Enter` reaches `TextInputState` as a
+different chord from `Enter`; iTerm2 and tmux get their required protocol
+variants. It preserves raw mode and any keyboard-reporting stack entries the
+caller had already enabled. `AltScreen` remains available for hosts that
+intentionally own raw mode, keyboard modes, and cursor visibility themselves.
 
 `Runner` is an optional synchronous event loop for dashboards and small tools.
 It owns `TerminalSession`, frame scheduling, Crossterm event translation, and

--- a/README.md
+++ b/README.md
@@ -378,8 +378,9 @@ keyboard reporting, alternate screen, mouse capture, and cursor visibility,
 including rollback after partial initialization. Enhanced reporting preserves
 non-character modifiers, so `Shift+Enter` reaches `TextInputState` as a
 different chord from `Enter`; iTerm2 and tmux get their required protocol
-variants. It preserves raw mode and any keyboard-reporting stack entries the
-caller had already enabled. `AltScreen` remains available for hosts that
+variants, while Windows uses the modifier state already carried by its native
+console events. It preserves raw mode and any keyboard-reporting stack entries
+the caller had already enabled. `AltScreen` remains available for hosts that
 intentionally own raw mode, keyboard modes, and cursor visibility themselves.
 
 `Runner` is an optional synchronous event loop for dashboards and small tools.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,20 @@ change that makes them — an entry says why the knowledge moved, and that reaso
 is rarely recoverable later. Routine wording, formatting, and link fixes do not
 need entries.
 
+## 2026-07-25 — TerminalSession makes modified keys real
+
+- `TextInputMode` already assigned different behavior to `Enter` and
+  `Shift+Enter`, but the full terminal session never requested a protocol that
+  could distinguish them. The advertised composer behavior therefore did not
+  work end to end.
+- `TerminalSession` now owns enhanced keyboard reporting as part of the same
+  lifecycle as raw mode, mouse capture, and the alternate screen. The transport
+  policy follows the compatibility constraints proven by Codex: suppress event
+  types for iTerm2 and tmux's xterm format, and enable `modifyOtherKeys` for
+  tmux CSI-u.
+- Teardown pops exactly the level tuika pushed instead of globally resetting
+  keyboard reporting, preserving a mode installed by an embedding host.
+
 ## 2026-07-25 — A theme can be inherited from the terminal
 
 - Added a third source for a `Theme`, beside the bundled presets and a host's own

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -103,9 +103,10 @@ before anything else sees them. `TerminalSession` first pushes enhanced keyboard
 reporting, because legacy terminal input cannot distinguish non-character
 chords such as `Shift+Enter` from `Enter`; it pops exactly its own stack entry on
 exit. iTerm2 and tmux's xterm format omit event-type reporting, while tmux CSI-u
-also enables `modifyOtherKeys` mode 2. Everything above that boundary — the
-keymap engine, focus routing, component handlers — consumes only tuika types,
-which is what lets all of it be unit-tested without a PTY.
+also enables `modifyOtherKeys` mode 2. Windows needs no negotiation because its
+native console events already include modifier state. Everything above that
+boundary — the keymap engine, focus routing, component handlers — consumes only
+tuika types, which is what lets all of it be unit-tested without a PTY.
 
 Focus is a registry of scopes rather than a flag per component: a `FocusScope`
 claims input ownership for its subtree, so a modal or overlay can take input

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -99,9 +99,13 @@ above it.
 ## Input and focus
 
 The host translates crossterm events into tuika's own `Key`/`Mouse` events
-before anything else sees them. Everything above that boundary — the keymap
-engine, focus routing, component handlers — consumes only tuika types, which is
-what lets all of it be unit-tested without a PTY.
+before anything else sees them. `TerminalSession` first pushes enhanced keyboard
+reporting, because legacy terminal input cannot distinguish non-character
+chords such as `Shift+Enter` from `Enter`; it pops exactly its own stack entry on
+exit. iTerm2 and tmux's xterm format omit event-type reporting, while tmux CSI-u
+also enables `modifyOtherKeys` mode 2. Everything above that boundary — the
+keymap engine, focus routing, component handlers — consumes only tuika types,
+which is what lets all of it be unit-tested without a PTY.
 
 Focus is a registry of scopes rather than a flag per component: a `FocusScope`
 claims input ownership for its subtree, so a modal or overlay can take input

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,25 +1,29 @@
 //! Terminal host: alternate-screen lifecycle, event translation, compositor.
 //!
 //! This is the seam between `tuika` and a real terminal. [`TerminalSession`]
-//! owns the complete full-screen lifecycle; [`AltScreen`] is the narrower
-//! guard for hosts that manage raw mode and cursor visibility themselves.
+//! owns the complete full-screen lifecycle, including enhanced keyboard
+//! reporting; [`AltScreen`] is the narrower guard for hosts that manage raw
+//! mode, keyboard modes, and cursor visibility themselves.
 //! [`translate_event`] maps crossterm input to `tuika` [`Event`]s. [`paint`]
 //! composites a root view plus any overlays into the frame buffer: background
 //! fill, root, then each overlay last (clearing its rect first), which is why
 //! overlays never leak surrounding chrome here.
 
+use std::fmt;
 use std::io::{self, Write};
+use std::process::{Command as ProcessCommand, Stdio};
 
 use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind,
-    KeyModifiers, MouseButton as CtMouseButton, MouseEventKind as CtMouseKind,
+    KeyModifiers, KeyboardEnhancementFlags, MouseButton as CtMouseButton,
+    MouseEventKind as CtMouseKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
-use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     is_raw_mode_enabled,
 };
+use crossterm::{Command, execute};
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 use ratatui_core::style::Style;
@@ -68,14 +72,17 @@ impl Drop for AltScreen {
 
 /// Complete RAII ownership of a full-screen terminal session.
 ///
-/// Construction enables raw mode, enters the alternate screen, enables mouse
-/// capture, and hides the cursor. Drop restores the terminal, including when
-/// unwinding from a panic. Pre-existing raw mode is preserved rather than
-/// disabled. If construction fails partway through, it performs the same
+/// Construction enables raw mode and enhanced keyboard reporting, enters the
+/// alternate screen, enables mouse capture, and hides the cursor. Enhanced
+/// reporting is what lets crossterm distinguish chords such as Shift+Enter from
+/// plain Enter. Drop restores the terminal, including when unwinding from a
+/// panic. Pre-existing raw mode and keyboard-reporting stack entries are
+/// preserved. If construction fails partway through, it performs the same
 /// best-effort rollback before returning.
 pub struct TerminalSession {
     active: bool,
     raw_mode_owned: bool,
+    keyboard_enhancement: Option<KeyboardEnhancement>,
 }
 
 impl TerminalSession {
@@ -86,10 +93,18 @@ impl TerminalSession {
             enable_raw_mode()?;
         }
         let mut out = io::stdout();
+        let keyboard = KeyboardEnhancement::detect();
+        if let Err(error) = keyboard.enable(&mut out) {
+            if raw_mode_owned {
+                let _ = disable_raw_mode();
+            }
+            return Err(error);
+        }
         if let Err(error) =
             execute!(out, EnterAlternateScreen, EnableMouseCapture, Hide).and_then(|()| out.flush())
         {
             let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
+            keyboard.disable(&mut out);
             if raw_mode_owned {
                 let _ = disable_raw_mode();
             }
@@ -98,6 +113,7 @@ impl TerminalSession {
         Ok(Self {
             active: true,
             raw_mode_owned,
+            keyboard_enhancement: Some(keyboard),
         })
     }
 
@@ -111,6 +127,9 @@ impl TerminalSession {
             crate::term::pointer::encode(crate::term::pointer::PointerShape::Default).as_bytes(),
         );
         let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
+        if let Some(keyboard) = self.keyboard_enhancement.take() {
+            keyboard.disable(&mut out);
+        }
         let _ = out.flush();
         if self.raw_mode_owned {
             let _ = disable_raw_mode();
@@ -122,6 +141,118 @@ impl TerminalSession {
 impl Drop for TerminalSession {
     fn drop(&mut self) {
         self.leave();
+    }
+}
+
+/// Keyboard-reporting policy for one terminal session.
+///
+/// Kitty's protocol is a stack: push exactly one level on entry and pop exactly
+/// one on exit, preserving any mode the caller had already installed. iTerm2
+/// and tmux's xterm key format must not report event types: both can lose or
+/// leak modified key events in that mode. tmux's CSI-u format instead needs
+/// xterm modifyOtherKeys mode 2 so modified Enter reaches the application.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct KeyboardEnhancement {
+    flags: KeyboardEnhancementFlags,
+    modify_other_keys: bool,
+}
+
+impl KeyboardEnhancement {
+    fn detect() -> Self {
+        let iterm2 = std::env::var("TERM_PROGRAM")
+            .is_ok_and(|value| value.eq_ignore_ascii_case("iTerm.app"))
+            || std::env::var("LC_TERMINAL").is_ok_and(|value| value.eq_ignore_ascii_case("iTerm2"));
+        let in_tmux = std::env::var_os("TMUX").is_some() || std::env::var_os("TMUX_PANE").is_some();
+        let tmux_format = in_tmux.then(read_tmux_extended_keys_format).flatten();
+        Self::for_terminal(iterm2, in_tmux, tmux_format.as_deref())
+    }
+
+    fn for_terminal(iterm2: bool, in_tmux: bool, tmux_format: Option<&str>) -> Self {
+        let mut flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS;
+        if !iterm2 && tmux_format != Some("xterm") {
+            flags |= KeyboardEnhancementFlags::REPORT_EVENT_TYPES;
+        }
+        Self {
+            flags,
+            modify_other_keys: in_tmux && tmux_format == Some("csi-u"),
+        }
+    }
+
+    fn enable(self, out: &mut impl Write) -> io::Result<()> {
+        execute!(
+            out,
+            DisableModifyOtherKeys,
+            PushKeyboardEnhancementFlags(self.flags)
+        )?;
+        if self.modify_other_keys
+            && let Err(error) = execute!(out, EnableModifyOtherKeys)
+        {
+            self.disable(out);
+            return Err(error);
+        }
+        out.flush()
+    }
+
+    fn disable(self, out: &mut impl Write) {
+        let _ = execute!(out, PopKeyboardEnhancementFlags, DisableModifyOtherKeys);
+    }
+}
+
+fn read_tmux_extended_keys_format() -> Option<String> {
+    for args in [
+        ["display-message", "-p", "#{extended-keys-format}"],
+        ["show-options", "-gqv", "extended-keys-format"],
+    ] {
+        let output = ProcessCommand::new("tmux")
+            .args(args)
+            .stdin(Stdio::null())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if output.status.success()
+            && let Ok(value) = String::from_utf8(output.stdout)
+        {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct EnableModifyOtherKeys;
+
+impl Command for EnableModifyOtherKeys {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str("\x1b[>4;2m")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "modifyOtherKeys is unavailable through the legacy Windows API",
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DisableModifyOtherKeys;
+
+impl Command for DisableModifyOtherKeys {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        f.write_str("\x1b[>4;0m")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "modifyOtherKeys is unavailable through the legacy Windows API",
+        ))
     }
 }
 
@@ -297,6 +428,48 @@ mod tests {
         assert_eq!((m.column, m.row), (7, 3));
         assert!(m.shift && m.ctrl && !m.alt && m.super_key);
         assert!(!m.plain());
+    }
+
+    #[test]
+    fn translate_preserves_shift_enter() {
+        let ct = CtEvent::Key(crossterm::event::KeyEvent::new(
+            CtKeyCode::Enter,
+            KeyModifiers::SHIFT,
+        ));
+        let Some(Event::Key(key)) = translate_event(ct) else {
+            panic!("expected a key event");
+        };
+        assert_eq!(key.code, KeyCode::Enter);
+        assert!(key.shift && !key.ctrl && !key.alt);
+    }
+
+    #[test]
+    fn keyboard_enhancement_uses_event_reporting_by_default() {
+        let keyboard = KeyboardEnhancement::for_terminal(false, false, None);
+        let mut output = Vec::new();
+        keyboard.enable(&mut output).unwrap();
+        keyboard.disable(&mut output);
+        assert_eq!(output, b"\x1b[>4;0m\x1b[>7u\x1b[<1u\x1b[>4;0m");
+    }
+
+    #[test]
+    fn keyboard_enhancement_avoids_event_types_in_iterm_and_xterm_tmux() {
+        for keyboard in [
+            KeyboardEnhancement::for_terminal(true, false, None),
+            KeyboardEnhancement::for_terminal(false, true, Some("xterm")),
+        ] {
+            let mut output = Vec::new();
+            keyboard.enable(&mut output).unwrap();
+            assert_eq!(output, b"\x1b[>4;0m\x1b[>5u");
+        }
+    }
+
+    #[test]
+    fn keyboard_enhancement_enables_modify_other_keys_for_csi_u_tmux() {
+        let keyboard = KeyboardEnhancement::for_terminal(false, true, Some("csi-u"));
+        let mut output = Vec::new();
+        keyboard.enable(&mut output).unwrap();
+        assert_eq!(output, b"\x1b[>4;0m\x1b[>7u\x1b[>4;2m");
     }
 
     #[test]

--- a/src/host.rs
+++ b/src/host.rs
@@ -9,7 +9,6 @@
 //! fill, root, then each overlay last (clearing its rect first), which is why
 //! overlays never leak surrounding chrome here.
 
-use std::fmt;
 use std::io::{self, Write};
 use std::process::{Command as ProcessCommand, Stdio};
 
@@ -17,13 +16,13 @@ use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind,
     KeyModifiers, KeyboardEnhancementFlags, MouseButton as CtMouseButton,
-    MouseEventKind as CtMouseKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    MouseEventKind as CtMouseKind,
 };
+use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     is_raw_mode_enabled,
 };
-use crossterm::{Command, execute};
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 use ratatui_core::style::Style;
@@ -75,10 +74,11 @@ impl Drop for AltScreen {
 /// Construction enables raw mode and enhanced keyboard reporting, enters the
 /// alternate screen, enables mouse capture, and hides the cursor. Enhanced
 /// reporting is what lets crossterm distinguish chords such as Shift+Enter from
-/// plain Enter. Drop restores the terminal, including when unwinding from a
-/// panic. Pre-existing raw mode and keyboard-reporting stack entries are
-/// preserved. If construction fails partway through, it performs the same
-/// best-effort rollback before returning.
+/// plain Enter on ANSI terminals; Windows console events already carry modifier
+/// state through the native input API. Drop restores the terminal, including
+/// when unwinding from a panic. Pre-existing raw mode and keyboard-reporting
+/// stack entries are preserved. If construction fails partway through, it
+/// performs the same best-effort rollback before returning.
 pub struct TerminalSession {
     active: bool,
     raw_mode_owned: bool,
@@ -94,17 +94,22 @@ impl TerminalSession {
         }
         let mut out = io::stdout();
         let keyboard = KeyboardEnhancement::detect();
-        if let Err(error) = keyboard.enable(&mut out) {
-            if raw_mode_owned {
-                let _ = disable_raw_mode();
+        let keyboard_active = match keyboard.enable(&mut out) {
+            Ok(active) => active,
+            Err(error) => {
+                if raw_mode_owned {
+                    let _ = disable_raw_mode();
+                }
+                return Err(error);
             }
-            return Err(error);
-        }
+        };
         if let Err(error) =
             execute!(out, EnterAlternateScreen, EnableMouseCapture, Hide).and_then(|()| out.flush())
         {
             let _ = execute!(out, Show, DisableMouseCapture, LeaveAlternateScreen);
-            keyboard.disable(&mut out);
+            if keyboard_active {
+                keyboard.disable(&mut out);
+            }
             if raw_mode_owned {
                 let _ = disable_raw_mode();
             }
@@ -113,7 +118,7 @@ impl TerminalSession {
         Ok(Self {
             active: true,
             raw_mode_owned,
-            keyboard_enhancement: Some(keyboard),
+            keyboard_enhancement: keyboard_active.then_some(keyboard),
         })
     }
 
@@ -179,23 +184,41 @@ impl KeyboardEnhancement {
         }
     }
 
-    fn enable(self, out: &mut impl Write) -> io::Result<()> {
-        execute!(
-            out,
-            DisableModifyOtherKeys,
-            PushKeyboardEnhancementFlags(self.flags)
-        )?;
-        if self.modify_other_keys
-            && let Err(error) = execute!(out, EnableModifyOtherKeys)
-        {
-            self.disable(out);
-            return Err(error);
-        }
-        out.flush()
+    #[cfg(not(windows))]
+    fn enable(self, out: &mut impl Write) -> io::Result<bool> {
+        self.write_enable_ansi(out)?;
+        out.flush()?;
+        Ok(true)
     }
 
+    // The Windows console input API already reports modifier state, while
+    // crossterm deliberately does not implement Kitty keyboard negotiation for
+    // the legacy WinAPI backend.
+    #[cfg(windows)]
+    fn enable(self, _out: &mut impl Write) -> io::Result<bool> {
+        Ok(false)
+    }
+
+    #[cfg(not(windows))]
     fn disable(self, out: &mut impl Write) {
-        let _ = execute!(out, PopKeyboardEnhancementFlags, DisableModifyOtherKeys);
+        let _ = self.write_disable_ansi(out);
+    }
+
+    #[cfg(windows)]
+    fn disable(self, _out: &mut impl Write) {}
+
+    #[cfg(any(not(windows), test))]
+    fn write_enable_ansi(self, out: &mut impl Write) -> io::Result<()> {
+        write!(out, "\x1b[>4;0m\x1b[>{}u", self.flags.bits())?;
+        if self.modify_other_keys {
+            out.write_all(b"\x1b[>4;2m")?;
+        }
+        Ok(())
+    }
+
+    #[cfg(any(not(windows), test))]
+    fn write_disable_ansi(self, out: &mut impl Write) -> io::Result<()> {
+        out.write_all(b"\x1b[<1u\x1b[>4;0m")
     }
 }
 
@@ -220,40 +243,6 @@ fn read_tmux_extended_keys_format() -> Option<String> {
         }
     }
     None
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct EnableModifyOtherKeys;
-
-impl Command for EnableModifyOtherKeys {
-    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        f.write_str("\x1b[>4;2m")
-    }
-
-    #[cfg(windows)]
-    fn execute_winapi(&self) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "modifyOtherKeys is unavailable through the legacy Windows API",
-        ))
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct DisableModifyOtherKeys;
-
-impl Command for DisableModifyOtherKeys {
-    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        f.write_str("\x1b[>4;0m")
-    }
-
-    #[cfg(windows)]
-    fn execute_winapi(&self) -> io::Result<()> {
-        Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "modifyOtherKeys is unavailable through the legacy Windows API",
-        ))
-    }
 }
 
 /// Composite `root` and `overlays` into `buffer` over `area`, using `theme`'s
@@ -447,8 +436,8 @@ mod tests {
     fn keyboard_enhancement_uses_event_reporting_by_default() {
         let keyboard = KeyboardEnhancement::for_terminal(false, false, None);
         let mut output = Vec::new();
-        keyboard.enable(&mut output).unwrap();
-        keyboard.disable(&mut output);
+        keyboard.write_enable_ansi(&mut output).unwrap();
+        keyboard.write_disable_ansi(&mut output).unwrap();
         assert_eq!(output, b"\x1b[>4;0m\x1b[>7u\x1b[<1u\x1b[>4;0m");
     }
 
@@ -459,7 +448,7 @@ mod tests {
             KeyboardEnhancement::for_terminal(false, true, Some("xterm")),
         ] {
             let mut output = Vec::new();
-            keyboard.enable(&mut output).unwrap();
+            keyboard.write_enable_ansi(&mut output).unwrap();
             assert_eq!(output, b"\x1b[>4;0m\x1b[>5u");
         }
     }
@@ -468,7 +457,7 @@ mod tests {
     fn keyboard_enhancement_enables_modify_other_keys_for_csi_u_tmux() {
         let keyboard = KeyboardEnhancement::for_terminal(false, true, Some("csi-u"));
         let mut output = Vec::new();
-        keyboard.enable(&mut output).unwrap();
+        keyboard.write_enable_ansi(&mut output).unwrap();
         assert_eq!(output, b"\x1b[>4;0m\x1b[>7u\x1b[>4;2m");
     }
 

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -3,10 +3,10 @@
 //! Unit, property, and snapshot tests render into an in-memory ratatui `Buffer`
 //! and never touch a real terminal. This drives the `gallery` example under a
 //! pseudo-terminal (`portable-pty`) and asserts the terminal-facing behavior a
-//! buffer test cannot see: entering and restoring the alternate screen, cursor
-//! and mouse-capture lifecycle, the native OSC 9;4 progress indicator, OSC 8
-//! hyperlinks, truecolor and Braille cells surviving a reference terminal
-//! parser, resize survival, and a clean exit.
+//! buffer test cannot see: entering and restoring the alternate screen, enhanced
+//! keyboard reporting, cursor and mouse-capture lifecycle, the native OSC 9;4
+//! progress indicator, OSC 8 hyperlinks, truecolor and Braille cells surviving a
+//! reference terminal parser, resize survival, and a clean exit.
 //!
 //! This covers the *protocol* a terminal receives. Whether a specific emulator
 //! paints those bytes correctly is the cross-terminal nightly plus the manual
@@ -87,6 +87,16 @@ fn run_gallery(rows: u16, cols: u16, resize_to: Option<(u16, u16)>) -> GalleryRu
 
     let mut cmd = CommandBuilder::new(gallery_bin());
     cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    for inherited in [
+        "NO_COLOR",
+        "TERM_PROGRAM",
+        "LC_TERMINAL",
+        "TMUX",
+        "TMUX_PANE",
+    ] {
+        cmd.env_remove(inherited);
+    }
 
     let mut child = pair.slave.spawn_command(cmd).expect("spawn gallery");
     drop(pair.slave);
@@ -253,6 +263,14 @@ fn gallery_drives_altscreen_and_native_progress() {
     assert!(
         contains(out, b"\x1b[?1000l"),
         "should disable mouse capture on exit"
+    );
+    assert!(
+        contains(out, b"\x1b[>7u"),
+        "should request modified-key and key-event reporting"
+    );
+    assert!(
+        contains(out, b"\x1b[<1u"),
+        "should pop enhanced keyboard reporting on exit"
     );
     // OSC 9;4: indeterminate on start, cleared on exit.
     assert!(


### PR DESCRIPTION
## What changed

`TerminalSession` now negotiates enhanced keyboard reporting, so non-character modifiers survive terminal decoding and `Shift+Enter` reaches `TextInputState` separately from plain `Enter`.

The policy includes Codex-proven compatibility handling: iTerm2 and tmux xterm format omit event-type reporting, while tmux CSI-u enables `modifyOtherKeys` mode 2. Teardown pops exactly the keyboard stack level tuika pushed.

No public API or dependency change.

## Why

`TextInputMode::SubmitOnEnter` advertised `Shift+Enter` as newline, but `TerminalSession` never enabled a protocol capable of distinguishing it from `Enter`. In normal terminal sessions the advertised behavior was therefore broken end to end.

## Before / After

Before: the Codex replica received `Shift+Enter` as plain `Enter` on terminals requiring enhanced keyboard negotiation and submitted the draft.

After: a real-terminal smoke sent CSI-u `Shift+Enter` between `first line` and `second line`; the composer rendered them on separate rows without submitting, then emitted the keyboard-mode pop during clean exit.

Automated protocol evidence pins the default push (`CSI > 7 u`), matching pop, iTerm2/tmux-xterm flags, tmux CSI-u `modifyOtherKeys`, and Shift+Enter modifier translation.

## Risk

- Medium: this changes process-wide terminal input mode for every `TerminalSession`.
- Compatibility risk is contained by transport-specific flags and stack-scoped teardown. Unsupported terminals ignore the CSI sequences and `Ctrl+J` remains the newline fallback.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo +1.88 check -p tuika --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Real-terminal `cargo run --example codex` smoke with CSI-u Shift+Enter

## Knowledge

Updated `knowledge/specs/architecture.md` with the terminal input negotiation contract and `knowledge/log.md` with the reason and lifecycle decision. README, rustdoc, and changelog are aligned.

## Security

- **TM-ESC:** all new terminal sequences are fixed encoders; no caller or tmux output reaches the terminal as interpreted content.
- **TM-STATE:** every successful keyboard push is paired with a stack pop; alternate-screen initialization failure and `Drop` both restore the mode. Existing caller stack entries are preserved.
- **TM-DEP:** no new dependency. The tmux probe executes only the fixed `tmux` binary with fixed read-only arguments, null stdin/stderr, and accepts only exact `xterm`/`csi-u` values.
- **TM-PARSE / TM-CLIP:** not affected.

## Follow-ups

No follow-ups.