### PR TITLE
chore(ci): cover the workspace on the macOS and Windows legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,10 @@ jobs:
   # The renderer talks to a terminal, and terminal behavior is the least
   # portable thing in the crate. Build and run the suite on macOS and Windows so
   # a Unix-only assumption fails here rather than in a downstream host.
+  #
+  # `--workspace` is load-bearing: Cargo defaults to the root package, which
+  # would leave `tuika-codeformatters` — the one member that compiles C, via
+  # tree-sitter's grammars through `cc`/MSVC — with no non-Unix coverage at all.
   cross-platform:
     name: Build + Tests (${{ matrix.os }})
     needs: changes
@@ -246,12 +250,12 @@ jobs:
           shared-key: "cross-${{ runner.os }}"
 
       - name: Build
-        run: cargo build --locked --all-targets
+        run: cargo build --locked --all-targets --workspace
 
       # The PTY smoke is `#![cfg(unix)]` and compiles to nothing on Windows;
       # everything else (buffer, property, snapshot tests) runs everywhere.
       - name: Tests
-        run: cargo test --locked --all-features
+        run: cargo test --locked --all-features --workspace
 
   benchmarks:
     name: Benchmarks (archive)

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,16 @@ change that makes them — an entry says why the knowledge moved, and that reaso
 is rarely recoverable later. Routine wording, formatting, and link fixes do not
 need entries.
 
+## 2026-07-25 — Non-Unix CI covered the workspace, not just the root package
+
+- CI's macOS and Windows legs ran Cargo's default package scope, which quietly
+  exempted `tuika-codeformatters` — the only member that compiles C — from every
+  non-Unix platform it is published for. Scoped both legs to `--workspace`.
+- [Testing](processes/testing.md) gained a *Platform coverage* section recording
+  why: this is the same blind spot as the MSRV, where local development cannot
+  reveal the break and the CI invocation is the entire guarantee. Worth stating
+  because the failure mode is silence — a too-narrow scope reports green.
+
 ## 2026-07-25 — TerminalSession makes modified keys real
 
 - `TextInputMode` already assigned different behavior to `Enter` and

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -82,6 +82,21 @@ text; the GUI legs (kitty under Xvfb, iTerm2, Windows Terminal) capture
 artifacts best-effort and do not fail the nightly. Promote a best-effort leg to
 asserting once its capture is proven stable on the runner.
 
+## Platform coverage
+
+Cross-terminal checks ask what an emulator paints; this asks what compiles and
+passes off Unix. CI's `cross-platform` job builds and runs the suite on macOS
+and Windows, so a Unix-only assumption fails there rather than in a downstream
+host. `tests/pty_smoke.rs` is `#![cfg(unix)]` and compiles to nothing on
+Windows; the cell-based layers run everywhere.
+
+Those legs must be scoped to the **workspace**, not the root package. Cargo
+defaults to the root, which silently exempts `tuika-codeformatters` — the one
+member that compiles C, through tree-sitter's grammars — from every non-Unix
+platform it is published for. This is the same class of blind spot as the MSRV
+below: local development never reveals it, so the CI invocation is the only
+thing holding the guarantee.
+
 ## Performance: one gate, one archive
 
 Two benchmark families with deliberately different standing:


### PR DESCRIPTION
## What changed

CI's `cross-platform` job (macOS + Windows) now builds and tests the whole
workspace instead of just the root package.

`tuika-codeformatters` had **no macOS or Windows coverage at all**. Cargo
defaults to the root package, and the two commands in that job never passed
`--workspace`, so every run silently skipped the one member that compiles C —
tree-sitter's 14 grammars, through `cc`/MSVC. It is published for those
platforms like any other crate; nothing was checking it built there.

The ubuntu `test` (`--workspace --tests`) and `docs` (`--no-deps --workspace`)
jobs already scope to the workspace, so this brings the non-Unix legs in line
rather than introducing a new convention.

## Why

Noticed while auditing what Windows CI actually covers. The failure mode is the
bad kind: a too-narrow scope reports green, so a break in the highlighter on
Windows would have surfaced in a downstream host, not here.

## Before / After

No runtime behavior changes — this is CI scope only. The observable effect is
which test binaries execute on the non-Unix runners.

Running the job's exact new commands locally:

**Before** (`cargo test --locked --all-features`) — root package only:

```
Running unittests src/lib.rs (deps/tuika-fe2ddfc467d804a5)   389 passed
Running tests/packaging.rs                                     3 passed
Running tests/pty_palette.rs                                   4 passed
Running tests/pty_smoke.rs                                     4 passed
Running tests/public_api.rs                                    8 passed
```

**After** (`cargo test --locked --all-features --workspace`) — adds:

```
Running unittests src/lib.rs (deps/tuika_codeformatters-…)     5 passed
Doc-tests tuika_codeformatters                                 1 passed
```

`cargo build --locked --all-targets --workspace` also succeeds; the added
`highlight_iai` bench target compiles the same `iai-callgrind` dev-dependency
the root package's `markdown_iai`/`scroll_iai` targets already build on these
runners today, so it introduces no new toolchain requirement.

Confirmed on the runners themselves: the Windows leg passed first time, and the
macOS leg builds all 14 grammars and runs the added tests.

## Risk

- **Low**
- Longer first run on the macOS/Windows legs while the 14 tree-sitter grammars
  compile. `Swatinem/rust-cache` is keyed per-OS (`cross-${{ runner.os }}`) and
  absorbs it on subsequent runs; the job's 25-minute timeout has room.
- If a grammar genuinely does not build under MSVC, this job now goes red. That
  is the intended outcome — it is a real defect that was previously invisible —
  but it is the one way this change can turn CI red on unrelated work.

## Checklist
- [x] Tests added or updated — n/a, see below
- [x] Backward compatibility considered — no API or runtime surface touched
- [x] Knowledge concepts updated

## Knowledge

`knowledge/processes/testing.md` gains a **Platform coverage** section: what the
`cross-platform` job guarantees, and why those legs must be workspace-scoped.
Grouped with the MSRV section deliberately — both are blind spots local
development cannot reveal, where the CI invocation *is* the entire guarantee.
Logged in `knowledge/log.md`.

## Security

No security-relevant code changed. This is a CI configuration change that widens
test scope; no library code, no dependency added or changed. Against the
threat-model categories: TM-ESC, TM-STATE, TM-PARSE, and TM-CLIP are untouched
(no code in the diff). TM-DEP is unaffected — the tree-sitter grammars are
existing workspace dependencies, now compiled on more runners rather than newly
introduced.

Config-only with no behavior change, so the automated-test and real-terminal
smoke outcomes are exempt; the validation above is the running of the changed
commands themselves, which is the only thing this diff can be proven by.

## Follow-ups

- **`tests/pty_palette.rs::a_terminals_answer_becomes_the_theme` is flaky on
  macOS.** It failed once on this PR's first run with `send replies: Os { code:
  5, … "Input/output error" }` at `tests/pty_palette.rs:138`, then passed on a
  re-run of the same commit. The race is pre-existing and independent of this
  diff, which adds no code: `examples/inherit.rs` sets `PROBE_TIMEOUT` to 100 ms,
  while the test polls for the Device Attributes fence every 20 ms before writing
  its replies. If that poll lands more than 100 ms after the child emitted DA1,
  the probe has already given up and exited, the pty slave is closed, and the
  write gets EIO on macOS. Its sibling test — same `run_inherit` setup — passed
  in the same run, which is the signature of timing rather than breakage.
  Deferred because the fix belongs to the probe test, not to CI job scope, and
  wants its own before/after; it does not reproduce on Linux even under 15×
  CPU oversubscription, so it needs to be reasoned about on macOS pty semantics
  rather than fixed blind.
- The ubuntu `test` job's standalone `cargo build --locked --all-targets` step
  (`ci.yml:187`) is also root-only. Harmless today, since the coverage step below
  it rebuilds with `--workspace`, so nothing is actually unchecked on Linux —
  left alone to keep this diff to the gap it is fixing.