### PR TITLE
chore(release): prepare v0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.94.0
 
+      - name: Install nightly for the docs.rs rehearsal
+        uses: dtolnay/rust-toolchain@nightly
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
@@ -157,7 +160,20 @@ jobs:
       - name: Build documentation
         env:
           RUSTDOCFLAGS: -D warnings
-        run: cargo doc --locked --all-features --no-deps --workspace
+        run: cargo +1.94.0 doc --locked --all-features --no-deps --workspace
+
+      # The step above is what a *consumer* sees. docs.rs builds something else:
+      # nightly, with `--cfg docsrs` set, which is the only configuration that
+      # compiles the `cfg_attr(docsrs, feature(…))` line in `src/lib.rs`. A
+      # removed nightly feature is invisible to every other job and cost 0.4.0
+      # its documentation, so rehearse docs.rs's own invocation. Lints are not
+      # capped here the way docs.rs caps them, hence no `-D warnings`: this leg
+      # is guarding against compilation failing, not against nightly's lint
+      # churn.
+      - name: Build documentation the way docs.rs does
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
+        run: cargo +nightly doc --locked --all-features --no-deps --workspace
 
   test:
     name: Build + Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-Notable changes to `tuika`. This file starts with the entry below, which will be
-the first release cut from this repository.
+Notable changes to `tuika`. This file starts at 0.5.0, the first release cut
+from this repository.
 
 Versions 0.1.0 through 0.4.0 were published to crates.io from the
 [`everruns/yolop`](https://github.com/everruns/yolop) workspace, before tuika was
@@ -11,14 +11,10 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
-## [Unreleased]
+## [0.5.0] - 2026-07-25
 
-### Fixed
-
-- `TerminalSession` now enables and restores enhanced keyboard reporting, so
-  `Shift+Enter` reaches `TextInputState` as a distinct chord instead of being
-  decoded as plain `Enter`. The negotiation handles iTerm2 and tmux's xterm and
-  CSI-u formats; Windows keeps using modifier-aware native console events.
+The first release cut from this repository. Companion crates released alongside
+it: `tuika-codeformatters` 0.3.0 and `tuika-mermaid` 0.1.0 (its first release).
 
 ### Highlights
 
@@ -63,7 +59,56 @@ host-initiated, so nothing changes for an app that does not ask.
 - **New example**: `cargo run --example inherit` (and `-- --probe` to print what
   your terminal answers without taking over the screen).
 
-Additive only — nothing moved or was renamed by this change.
+The palette work is additive only — nothing moved or was renamed by it.
+
+**A dialog, a form, and a scrollable viewport are no longer every host's
+homework.** Three patterns every application rebuilt by hand are components now,
+and a `Scene` owns the base tree plus its overlays so focus and compositing stop
+being hand-wired at the call site.
+
+![primitives demo](https://raw.githubusercontent.com/everruns/tuika/v0.5.0/docs/demos/primitives.gif)
+
+- **New**: `components::Dialog` — a titled, bordered, optionally backdrop-dimmed
+  panel with key hints and an action row, placed by an `OverlaySpec`.
+- **New**: `components::{Form, FormField, FormState, FormOutcome}` — labelled
+  fields with help and error rows, `Tab`/`Shift+Tab` focus, and a responsive
+  `stack_below(width)` breakpoint.
+- **New**: `components::Viewport` — a clipping, panning window over an
+  oversized child, with optional scrollbars on both axes.
+- **New**: `Scene`, `SceneOverlay`, `Backdrop`, and `paint_scene` — one value
+  carrying the root and its overlay stack, with `sync_focus` for the registry.
+- **New**: `DrawView` (alias `CanvasView`) — a `View` from a closure, for
+  one-off custom painting without declaring a type.
+- **New**: `SemanticRole` and `Theme::{semantic_color, semantic_style,
+  success_style, warning_style, danger_style, info_style}` — success / warning /
+  danger / info resolved from the theme instead of hardcoded per host.
+
+**Markdown fenced blocks are extensible.** A fence with an unknown language used
+to render as code and nothing else. A host can now claim any info string and
+paint the block itself — which is how Mermaid diagrams became terminal-native,
+without tuika taking on a diagram engine.
+
+![mermaid demo](https://raw.githubusercontent.com/everruns/tuika/v0.5.0/crates/tuika-mermaid/examples/mermaid_markdown/mermaid.gif)
+
+- **New**: `components::markdown::FencedBlockRenderer` — the seam, plus
+  `Markdown::block_renderer`, `MarkdownState::with_block_renderer`, and
+  `markdown::{to_lines_with_renderer, to_linked_lines_with_renderer}`.
+- **New crate**: [`tuika-mermaid`](https://crates.io/crates/tuika-mermaid) —
+  `MermaidRenderer`, an mmdflux-backed implementation for ```` ```mermaid ````
+  fences. Diagram layout stays out of tuika core.
+
+**Long transcripts scroll by item, not by line.** `ItemScroll` scrolls a list of
+laid-out elements — the shape a chat log or an agent transcript actually has —
+and the text input grew the seams a composer needs.
+
+- **New**: `components::ItemScroll` — item-granular scrolling with `windowed`
+  construction, `gap`, `scrollbar`, and `measure_height`.
+- **New**: `components::textinput::{Trigger, TriggerAnchor, Token, TextSpan}`,
+  plus `TextInputState::{tokens, active_token, replace_token}` and
+  `TextInput::{highlights, placeholder}` — `@`/`/` mention and slash-command
+  tokens, and styled spans over the edited text.
+- **New example**: `cargo run --example codex` — a replica of the Codex CLI's UI
+  built entirely from tuika components.
 
 ### Breaking Changes
 
@@ -121,6 +166,18 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 
 ### Fixed
 
+- **docs.rs builds the crate again.** 0.4.0 documented nothing on docs.rs:
+  `src/lib.rs` gated on `feature(doc_auto_cfg)`, which was merged into
+  `doc_cfg` and removed as a name in Rust 1.92, so rustdoc failed outright on
+  docs.rs's nightly. Nothing else saw it — the attribute compiles only under
+  `--cfg docsrs`, which no local or CI build set. CI now rehearses docs.rs's
+  own invocation (nightly, `--cfg docsrs`) alongside the consumer-facing one.
+- **`Shift+Enter` reaches the text input as its own chord.** `TerminalSession`
+  now enables and restores enhanced keyboard reporting, so the chord arrives at
+  `TextInputState` distinctly instead of being decoded as plain `Enter` — the
+  difference between "insert a newline" and "submit". The negotiation handles
+  iTerm2 and tmux's xterm and CSI-u formats; Windows keeps using modifier-aware
+  native console events.
 - **Markdown: a block inside a tight list item no longer swallows the item's
   text.** A tight list item carries no `Paragraph` of its own, so a nested list,
   block quote, or code fence opened while the parent item's text was still
@@ -144,17 +201,34 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 
 ### What's Changed
 
+* fix(packaging): trim the companion crates and correct the release history (#12)
 * feat(markdown): render GFM task-list checkboxes as themed markers
 * fix(markdown): flush the pending item line before a nested block opens
 * fix(markdown): never settle the streaming prefix on an unterminated blank line
-* docs: add `docs/markdown.md` and a `markdown_table` demo scene
-* refactor: give the crate root, components, and term one job each
+* docs(markdown): add `docs/markdown.md` and a `markdown_table` demo scene
+* chore(ci): cover the workspace on the macOS and Windows legs (#15)
+* feat(markdown): render extensible fenced blocks through `FencedBlockRenderer`, and add the `tuika-mermaid` companion crate
+* fix(term): enable modified-key reporting so `Shift+Enter` arrives as its own chord (#13)
+* docs(example): follow the stream in the markdown example until the reader scrolls back (#11)
+* refactor(markdown): split the module along its parse/flatten passes (#9)
+* fix(docs): preserve demo colors during recording (#10)
+* feat(themes): inherit the terminal's palette (#8)
+* feat(components): add `Dialog`, `Form`, `Viewport`, `Scene`, and `DrawView` (#7)
+* refactor: give the crate root, components, and term one job each (#6)
 * refactor(term): group the out-of-band escapes under one module
 * refactor(components): move markdown and the image view in with the components
 * refactor: fold `async_runner` into `runner` and rename `ratatui_view` to `interop`
 * refactor(tests): move the crate's test scaffolding under `src/tests`
-* refactor(markdown): split the module along its parse/flatten passes
-* docs(example): follow the stream in the markdown example until the reader scrolls back
 * test: pin the public module layout from outside the crate (`tests/public_api.rs`)
 * docs: add `knowledge/specs/api-surface.md` and a crate-layout section to the README
-* feat(themes): inherit the terminal's palette
+* chore(knowledge): split out process concepts and enforce upkeep (#5)
+* feat(components): add `ItemScroll` and the composer token seams, plus the `codex` example
+* docs: record the showcases at gallery pixel density and point yolop at its product page
+* fix(docs): stop the demo recordings clipping their own scenes
+* docs: add a showcases page with yolop and LLMSim demos (#3)
+* chore(release): show demos in the changelog highlights and drop commit links
+* chore: require signed commits, Doppler-managed secrets, and PRs for external contributions
+* fix(ci): green the pipeline after the yolop extraction
+* docs: add the knowledge bundle and agent workflows
+* ci: add the build, documentation, release, and cross-terminal pipelines
+* test: add a PTY smoke test and guard the published crate contents

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-codeformatters"
-version = "0.2.0"
+version = "0.3.0"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -26,7 +26,7 @@ exclude = ["docs/*.gif"]
 bench = false
 
 [dependencies]
-tuika = { version = "0.4.0", path = "../.." }
+tuika = { version = "0.5.0", path = "../.." }
 ratatui = "0.30.2"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"

--- a/crates/tuika-mermaid/Cargo.toml
+++ b/crates/tuika-mermaid/Cargo.toml
@@ -19,6 +19,6 @@ keywords = ["tui", "mermaid", "markdown", "ratatui", "diagrams"]
 categories = ["command-line-interface", "text-processing"]
 
 [dependencies]
-tuika = { version = "0.4.0", path = "../.." }
+tuika = { version = "0.5.0", path = "../.." }
 ratatui-core = "0.1"
 mmdflux = { version = "2.6", default-features = false }

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,19 @@ change that makes them — an entry says why the knowledge moved, and that reaso
 is rarely recoverable later. Routine wording, formatting, and link fixes do not
 need entries.
 
+## 2026-07-25 — docs.rs is a build CI has to rehearse, not assume
+
+- 0.4.0 shipped with no documentation on docs.rs: `src/lib.rs` gated on
+  `feature(doc_auto_cfg)`, removed in Rust 1.92, behind `cfg_attr(docsrs, …)`.
+  That attribute exists only under `--cfg docsrs`, which nothing outside docs.rs
+  sets — so `cargo doc` was green everywhere while the one build that matters
+  failed in twelve seconds.
+- [Documentation](specs/documentation.md) now records docs.rs as a *different*
+  build rather than a stricter one, and CI builds the docs twice: once the way a
+  consumer does, once the way docs.rs does. Recorded because the failure mode is
+  silence — a library's documentation surface can be entirely absent while every
+  gate reports success.
+
 ## 2026-07-25 — The tag history starts after the extraction
 
 - tuika 0.1.0–0.4.0 and `tuika-codeformatters` 0.1.0–0.2.0 were all published

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -37,6 +37,13 @@ terminal UI with tuika without requiring knowledge of repository internals.
   is what docs.rs renders as the front page; component demos are embedded inline
   on the relevant type via `raw.githubusercontent.com` URLs so they resolve
   there.
+- docs.rs is a *different build*, not a stricter one: nightly, `--cfg docsrs`,
+  and therefore the only configuration in which the crate's
+  `cfg_attr(docsrs, feature(…))` line exists at all. An ordinary `cargo doc`
+  cannot prove that build works — 0.4.0 published with a since-removed nightly
+  feature gated behind exactly that cfg and rendered no documentation at all,
+  while every local and CI doc build stayed green. CI therefore builds the docs
+  twice: once as a consumer does, once as docs.rs does.
 - `knowledge/` is internal durable memory: intent, constraints, tradeoffs, and
   architectural decisions for maintainers, split into `specs/` (the product) and
   `processes/` (working on it).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,11 @@
 
 #![warn(missing_docs)]
 // On docs.rs (nightly, `--cfg docsrs`) annotate feature-gated items with the
-// feature that enables them. A no-op on stable builds.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// feature that enables them. A no-op on stable builds. `doc_auto_cfg` was
+// merged into `doc_cfg` in 1.92 and removed as a name, so gating on the old
+// one is a hard rustdoc error on current nightly — which is what silently
+// left 0.4.0 undocumented on docs.rs.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod anim;
 pub mod components;


### PR DESCRIPTION
## What changed

Cuts **tuika 0.5.0** — the first release tagged from this repository — together
with **tuika-codeformatters 0.3.0** and the first release of **tuika-mermaid
0.1.0**. Versions and the lockfile are bumped, both companions' `tuika`
requirement moves to `0.5.0`, and `CHANGELOG.md` gains the full 0.5.0 section.

It also carries one code fix that the release cannot ship without: **0.4.0
rendered no documentation on docs.rs at all.** `src/lib.rs` gated on
`feature(doc_auto_cfg)`, which Rust 1.92 merged into `doc_cfg` and removed as a
name, so rustdoc failed outright on docs.rs's nightly — twelve seconds, no
docs, no signal anywhere else. The attribute exists only under `--cfg docsrs`,
which no local or CI build sets, so every gate stayed green. The gate is now
`feature(doc_cfg)`, and CI builds the docs twice: once the way a consumer does,
once the way docs.rs does.

## Why

The tree carries ~25 unreleased commits since 0.4.0 was published from the yolop
workspace: a breaking crate-root reorganization plus `prelude`, terminal-palette
themes, extensible markdown fenced blocks (and the companion crate that proves
the seam), `Dialog`/`Form`/`Viewport`/`Scene`, `ItemScroll` and the composer
token seams, and three markdown rendering fixes. Pre-1.0 with `pub` removals and
renames, that is a minor bump.

Both companions must move with it: they depend on `tuika` by version, so leaving
their requirement at `0.4.0` would publish them resolving against the old crate.

## Before / After

**Before** — docs.rs, tuika 0.4.0 ([build log](https://docs.rs/crate/tuika/0.4.0/builds/3940645)):

```
error[E0557]: feature has been removed
  --> src/lib.rs:43:29
   |
43 | #[cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in 1.92.0; merged into `doc_cfg`
error: could not document `tuika`
```

`https://docs.rs/tuika/0.4.0/tuika/` redirects to the crate page — there is no
documentation to serve.

**After** — the same invocation on nightly 1.99, locally:

```
$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --locked --all-features --no-deps --workspace
 Documenting tuika v0.5.0
 Documenting tuika-codeformatters v0.3.0
 Documenting tuika-mermaid v0.1.0
    Finished `dev` profile in 18.16s
```

Feature badges still render (3 pages carry "Available on crate feature `async`
only"), so the `doc_cfg` swap preserves what the old gate was there for.

No other behavior changes: the rest of the diff is versions, the lockfile, the
changelog, CI, and knowledge.

## Risk

- Low
- The CI docs job now has a nightly leg. It is deliberately not `-D warnings`,
  so nightly lint churn cannot redden `main`; only a compilation failure can —
  which is exactly the failure being guarded. If nightly itself breaks, that leg
  fails loudly rather than silently shipping undocumented crates.
- `feature(doc_cfg)` is unstable and compiles only under `--cfg docsrs`, so
  stable consumer builds are untouched.

## Checklist

- [x] Tests added or updated — CI's docs.rs rehearsal is the regression test for
      the fix; nothing else in the diff is behavioral
- [x] Backward compatibility considered — the breaking API changes are 0.5.0's
      content and documented with before/after under `### Breaking Changes`
- [x] Knowledge concepts updated

## Publish-readiness

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (463 tests, 0 failures)
- [x] `cargo run --example demo -- check` (29 scenes in sync)
- [x] `cargo doc` both ways: stable `-D warnings`, and nightly `--cfg docsrs`
- [x] `cargo publish --dry-run -p tuika` (companions are validated in CI after
      tuika publishes)
- [x] `cargo test --test packaging`
- [x] `python3 scripts/publish_order.py` → tuika, tuika-codeformatters, tuika-mermaid
- [x] `python3 scripts/validate_okf.py knowledge --check-links` — 13 concepts, 0 errors
- [x] crates.io currently serves `0.4.0` → publishing `0.5.0`
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.5.0`
- [x] highlight demos embedded and pinned to `v0.5.0`; both were recorded by the
      commits that introduced their features and no source has changed since, so
      neither shows superseded behavior

## Post-merge verification

- [ ] `release.yml` created tag `v0.5.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] crates.io serves tuika `0.5.0`, tuika-codeformatters `0.3.0`, tuika-mermaid `0.1.0`
- [ ] docs.rs built `0.5.0` — the one check 0.4.0 would have failed

## Knowledge

- `knowledge/specs/documentation.md` — docs.rs is a *different* build (nightly,
  `--cfg docsrs`), not a stricter one, so CI must rehearse it rather than assume
  an ordinary `cargo doc` covers it.
- `knowledge/log.md` — why that entry exists: the failure mode is silence.

## Security

No security-relevant code changed. The diff is version metadata, a changelog, a
rustdoc feature gate, a CI job, and knowledge prose. No new dependencies, no
network or filesystem surface, no unsafe.

## Follow-ups

- `tuika-mermaid` publishes for the first time here, so its `cargo publish`
  dry-run can only be validated in CI after tuika 0.5.0 is live. `publish.yml`
  derives the order and skips already-live versions.

---

## [0.5.0] - 2026-07-25

The first release cut from this repository. Companion crates released alongside
it: `tuika-codeformatters` 0.3.0 and `tuika-mermaid` 0.1.0 (its first release).

### Highlights

**The crate root is now a decision instead of an accumulation.** `tuika::` had
grown to 30 flat public modules plus 167 names re-exported to the root, so
almost every type had two equally valid paths and neither was canonical. Four
levels now each have one job, and where a new item goes is a rule rather than a
preference:

| Path | Holds |
| --- | --- |
| `tuika::` | the framework spine — `View`, `Element`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
| `tuika::components` | every widget |
| `tuika::term` | everything out-of-band: `clipboard`, `hyperlink`, `progress`, `pointer`, `image`, `capabilities`, `palette` |
| `tuika::prelude` | the spine and the components in one glob import |

- **New**: `tuika::prelude` — `use tuika::prelude::*;` replaces most import
  blocks outright, which is the intended migration for application code.
- No behavior change: this release moves and renames public items only. Every
  test, snapshot, and benchmark passes unchanged apart from its imports, and
  `tests/public_api.rs` now pins the layout from outside the crate, the way a
  host sees it.

**A theme can be inherited from the terminal.** An application can adopt the
palette the user already configured instead of imposing its own — opt-in and
host-initiated, so nothing changes for an app that does not ask.

- **New**: `themes::TERMINAL` (also `Theme::terminal()`, and a `terminal` entry
  in `themes::PRESETS`) — a `const Theme` whose every slot is `Color::Reset` or a
  `Color::Indexed` ANSI slot, so the terminal resolves the palette. No query, no
  timeout, no failure mode.
- **New**: `tuika::term::palette` — `TerminalPalette` with `parse`/`query`, plus
  `QUERY_FOREGROUND`, `QUERY_BACKGROUND`, and `query_sequence()`. Asks the
  terminal for its colors with the xterm queries (OSC 10 / 11 / 4), fenced by the
  Device Attributes request so an unsupported query costs a round-trip rather
  than a timeout.
- **New**: `Theme::from_terminal(&TerminalPalette)` derives a full theme from the
  reply — reported foreground and background verbatim, in-between tones blended
  and contrast-guarded, hues from the ANSI palette.
- **New**: `Capabilities::query_with_palette(timeout)` answers "what can this
  terminal do" and "what colors is it using" in one round-trip.
- **New example**: `cargo run --example inherit` (and `-- --probe` to print what
  your terminal answers without taking over the screen).

The palette work is additive only — nothing moved or was renamed by it.

**A dialog, a form, and a scrollable viewport are no longer every host's
homework.** Three patterns every application rebuilt by hand are components now,
and a `Scene` owns the base tree plus its overlays so focus and compositing stop
being hand-wired at the call site.

![primitives demo](https://raw.githubusercontent.com/everruns/tuika/v0.5.0/docs/demos/primitives.gif)

- **New**: `components::Dialog` — a titled, bordered, optionally backdrop-dimmed
  panel with key hints and an action row, placed by an `OverlaySpec`.
- **New**: `components::{Form, FormField, FormState, FormOutcome}` — labelled
  fields with help and error rows, `Tab`/`Shift+Tab` focus, and a responsive
  `stack_below(width)` breakpoint.
- **New**: `components::Viewport` — a clipping, panning window over an
  oversized child, with optional scrollbars on both axes.
- **New**: `Scene`, `SceneOverlay`, `Backdrop`, and `paint_scene` — one value
  carrying the root and its overlay stack, with `sync_focus` for the registry.
- **New**: `DrawView` (alias `CanvasView`) — a `View` from a closure, for
  one-off custom painting without declaring a type.
- **New**: `SemanticRole` and `Theme::{semantic_color, semantic_style,
  success_style, warning_style, danger_style, info_style}` — success / warning /
  danger / info resolved from the theme instead of hardcoded per host.

**Markdown fenced blocks are extensible.** A fence with an unknown language used
to render as code and nothing else. A host can now claim any info string and
paint the block itself — which is how Mermaid diagrams became terminal-native,
without tuika taking on a diagram engine.

![mermaid demo](https://raw.githubusercontent.com/everruns/tuika/v0.5.0/crates/tuika-mermaid/examples/mermaid_markdown/mermaid.gif)

- **New**: `components::markdown::FencedBlockRenderer` — the seam, plus
  `Markdown::block_renderer`, `MarkdownState::with_block_renderer`, and
  `markdown::{to_lines_with_renderer, to_linked_lines_with_renderer}`.
- **New crate**: [`tuika-mermaid`](https://crates.io/crates/tuika-mermaid) —
  `MermaidRenderer`, an mmdflux-backed implementation for ```` ```mermaid ````
  fences. Diagram layout stays out of tuika core.

**Long transcripts scroll by item, not by line.** `ItemScroll` scrolls a list of
laid-out elements — the shape a chat log or an agent transcript actually has —
and the text input grew the seams a composer needs.

- **New**: `components::ItemScroll` — item-granular scrolling with `windowed`
  construction, `gap`, `scrollbar`, and `measure_height`.
- **New**: `components::textinput::{Trigger, TriggerAnchor, Token, TextSpan}`,
  plus `TextInputState::{tokens, active_token, replace_token}` and
  `TextInput::{highlights, placeholder}` — `@`/`/` mention and slash-command
  tokens, and styled spans over the edited text.
- **New example**: `cargo run --example codex` — a replica of the Codex CLI's UI
  built entirely from tuika components.

### Breaking Changes

Most application code migrates by replacing its `use tuika::{…};` block with
`use tuika::prelude::*;`. The tables below cover what the prelude does not
carry.

**Modules moved**

- **Out-of-band escapes are one family**: they shared a shape but had three
  unrelated names, so a reader had to learn each separately.
  - Before: `tuika::clipboard`, `tuika::hyperlink`, `tuika::native`, `tuika::capabilities`
  - After: `tuika::term::{clipboard, hyperlink, progress, pointer, capabilities}`
- **Images split along the cell boundary**: the protocol half talks to the
  terminal, the view half is a component like any other.
  - Before: `tuika::image::{Image, ImageData, ImageLayer, ImageSupport}`
  - After: `tuika::components::Image` and `tuika::term::image::{ImageData, ImageLayer, ImageSupport}`
- **Markdown is a component**, and lives where the other components live.
  - Before: `tuika::markdown`
  - After: `tuika::components::markdown`
- **One runner module**: a `cfg` is an implementation detail, not a second entry
  in the module list.
  - Before: `tuika::async_runner::{AsyncRunner, Signal}`
  - After: `tuika::runner::{Runner, RunnerConfig, AsyncRunner, Signal}`
- **Ratatui interop is named for the seam, not for its only type.**
  - Before: `tuika::ratatui_view::RatatuiView`
  - After: `tuika::interop::RatatuiView`

**Items renamed**

- **The OSC encoders share one shape** — a pure `encode`, a thin writer.
  - Before: `osc52`, `write_clipboard`, `osc8`, `osc8_with`, `encode_pointer_shape`, `write_pointer_shape`
  - After: `term::clipboard::{encode, write}`, `term::hyperlink::{encode, encode_with}`, `term::pointer::{encode, write}`
- **`tuika::highlight` was a module and a function at once.** The module is the
  `Highlighter` seam; the function paints a selection.
  - Before: `tuika::highlight(buffer, area, range, style)`
  - After: `tuika::mouse::paint_selection(buffer, area, range, style)`
- **Hand-prefixed names get their module back.** The prefixes existed only to
  disambiguate a flat root.
  - Before: `markdown_to_lines`, `markdown_to_linked_lines`, `diff_rows`, `qr_encode`, `wrap_lines`
  - After: `components::markdown::{to_lines, to_linked_lines}`, `components::diff::rows`, `components::qr::encode`, `components::text::wrap_lines`
  - Before: `ASCII_FONT_HEIGHT`, `CONSOLE_DEFAULT_CAPACITY`, `TOAST_DEFAULT_TTL`
  - After: `components::ascii_font::FONT_HEIGHT`, `components::console::DEFAULT_CAPACITY`, `components::toast::DEFAULT_TTL`
- **`Overlay` sits beside `OverlaySpec`**, since resolving a spec to a rect and
  pairing that rect with a view are two halves of one pipeline.
  - Before: `tuika::host::Overlay`
  - After: `tuika::overlay::Overlay` (still re-exported as `tuika::Overlay`)

**Root re-exports removed**

Components and the per-module surface (`anim`, `focus`, `framebuffer`,
`highlight`, `keymap`, `live`, `mouse`, `probe`, `themes`, `width`, and the
styling extras) are no longer flattened to `tuika::`. Reach them through
`tuika::prelude::*` or their module path.

### Fixed

- **docs.rs builds the crate again.** 0.4.0 documented nothing on docs.rs:
  `src/lib.rs` gated on `feature(doc_auto_cfg)`, which was merged into
  `doc_cfg` and removed as a name in Rust 1.92, so rustdoc failed outright on
  docs.rs's nightly. Nothing else saw it — the attribute compiles only under
  `--cfg docsrs`, which no local or CI build set. CI now rehearses docs.rs's
  own invocation (nightly, `--cfg docsrs`) alongside the consumer-facing one.
- **`Shift+Enter` reaches the text input as its own chord.** `TerminalSession`
  now enables and restores enhanced keyboard reporting, so the chord arrives at
  `TextInputState` distinctly instead of being decoded as plain `Enter` — the
  difference between "insert a newline" and "submit". The negotiation handles
  iTerm2 and tmux's xterm and CSI-u formats; Windows keeps using modifier-aware
  native console events.
- **Markdown: a block inside a tight list item no longer swallows the item's
  text.** A tight list item carries no `Paragraph` of its own, so a nested list,
  block quote, or code fence opened while the parent item's text was still
  buffered — rendering `- outer` / `  - inner` as a single `• outerinner` line,
  and placing a fence *ahead* of the item it follows.
- **Markdown: streaming no longer splits a block on a half-arrived indent.**
  `MarkdownState` settles its prefix at the last blank line, and mid-stream a
  nested item's indent arrives as a whitespace-only *unterminated* line — which
  looked blank. The prefix was committed there, permanently cutting a list in
  two so the halves re-parsed as unrelated top-level lists. Only a
  newline-terminated blank line settles the prefix now, so a streamed render
  matches the one-shot render character-for-character.
- **Markdown: `- [ ]` / `- [x]` task lists render as checkboxes.** The renderer
  had the checkbox handler and a `task_marker` stylesheet slot, but the parser
  option that emits the event was never enabled, so both were unreachable and
  the markers rendered as literal text.

  Together these cost ~3% instructions on the markdown render benches — the old
  counts were cheap because a nested item's line was being dropped rather than
  laid out — which the committed `benches/iai-baseline.json` absorbs unchanged.

### What's Changed

* fix(packaging): trim the companion crates and correct the release history (#12)
* feat(markdown): render GFM task-list checkboxes as themed markers
* fix(markdown): flush the pending item line before a nested block opens
* fix(markdown): never settle the streaming prefix on an unterminated blank line
* docs(markdown): add `docs/markdown.md` and a `markdown_table` demo scene
* chore(ci): cover the workspace on the macOS and Windows legs (#15)
* feat(markdown): render extensible fenced blocks through `FencedBlockRenderer`, and add the `tuika-mermaid` companion crate
* fix(term): enable modified-key reporting so `Shift+Enter` arrives as its own chord (#13)
* docs(example): follow the stream in the markdown example until the reader scrolls back (#11)
* refactor(markdown): split the module along its parse/flatten passes (#9)
* fix(docs): preserve demo colors during recording (#10)
* feat(themes): inherit the terminal's palette (#8)
* feat(components): add `Dialog`, `Form`, `Viewport`, `Scene`, and `DrawView` (#7)
* refactor: give the crate root, components, and term one job each (#6)
* refactor(term): group the out-of-band escapes under one module
* refactor(components): move markdown and the image view in with the components
* refactor: fold `async_runner` into `runner` and rename `ratatui_view` to `interop`
* refactor(tests): move the crate's test scaffolding under `src/tests`
* test: pin the public module layout from outside the crate (`tests/public_api.rs`)
* docs: add `knowledge/specs/api-surface.md` and a crate-layout section to the README
* chore(knowledge): split out process concepts and enforce upkeep (#5)
* feat(components): add `ItemScroll` and the composer token seams, plus the `codex` example
* docs: record the showcases at gallery pixel density and point yolop at its product page
* fix(docs): stop the demo recordings clipping their own scenes
* docs: add a showcases page with yolop and LLMSim demos (#3)
* chore(release): show demos in the changelog highlights and drop commit links
* chore: require signed commits, Doppler-managed secrets, and PRs for external contributions
* fix(ci): green the pipeline after the yolop extraction
* docs: add the knowledge bundle and agent workflows
* ci: add the build, documentation, release, and cross-terminal pipelines
* test: add a PTY smoke test and guard the published crate contents

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3KEmHZJcQMsLcPLYBy4Kf)_