### PR TITLE
docs: move the benchmark procedure into benches/README.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,42 +78,9 @@ cargo run --example codex -- --split-footer   # the agent UI in that mode
 
 ### Benchmarks
 
-Component render benchmarks live in `benches/` (Criterion). When checking a
-change for a regression, save a baseline first and compare against it:
-
-```bash
-cargo bench --bench markdown -- --save-baseline before
-# ...make the change...
-cargo bench --bench markdown -- --baseline before
-```
-
-Wall-clock numbers are too noisy on shared CI runners to gate on, so CI runs the
-Criterion benches only on `main` (and via manual dispatch) and uploads the output
-as an artifact; regression-checking is a local, baseline-to-baseline comparison.
-New component benches go in the owning crate's `benches/` as another `[[bench]]`
-with `harness = false`.
-
-Alongside those, the `*_iai` benches count CPU instructions under
-Valgrind/callgrind ([iai-callgrind](https://github.com/iai-callgrind/iai-callgrind)).
-Instruction counts are deterministic and machine-independent for a fixed
-toolchain + libc, so the numbers are committed to `*/benches/iai-baseline.json`
-and the CI `iai` job **fails** on a regression past the baseline's tolerance —
-this is a real gate, not an archive. Running them locally needs Valgrind and a
-version-matched runner (`cargo install iai-callgrind-runner`):
-
-```bash
-rm -rf target/iai
-cargo bench -p tuika --bench markdown_iai --bench scroll_iai \
-  -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
-python3 benches/check_iai.py            # compare to the committed baseline
-python3 benches/check_iai.py --update   # bless new counts (commit alongside the change)
-```
-
-When a change legitimately shifts counts (renderer change, dependency bump,
-toolchain upgrade), regenerate the baseline with `--update` and commit it with
-the code — like a snapshot test. To refresh it from CI's exact environment,
-run the workflow manually (`workflow_dispatch`) and commit the uploaded
-`iai-baseline` artifact.
+Criterion targets measure wall clock and are advisory; the `*_iai` targets count
+instructions against a committed baseline and are a CI gate. Procedure lives in
+[`benches/README.md`](benches/README.md).
 
 ### Testing
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,52 @@
+# tuika benchmarks
+
+Two suites with different jobs. Criterion measures wall clock and is advisory;
+iai-callgrind counts instructions and is a CI gate.
+
+## Criterion (wall clock)
+
+`markdown.rs` and `scroll.rs` here, and `highlight.rs` in
+`crates/tuika-codeformatters/benches/`, are Criterion targets. Wall-clock
+numbers are too noisy on shared runners to gate on, so CI runs these only on
+`main` (and via manual dispatch) and uploads the Criterion output as an
+artifact. Regression checking is local and baseline-to-baseline:
+
+```bash
+cargo bench --bench markdown -- --save-baseline before
+# ...make the change...
+cargo bench --bench markdown -- --baseline before
+```
+
+A new component bench goes in the owning crate's `benches/` as another
+`[[bench]]` with `harness = false`.
+
+## iai-callgrind (instruction counts)
+
+The `*_iai` targets count CPU instructions under Valgrind/callgrind
+([iai-callgrind](https://github.com/iai-callgrind/iai-callgrind)). Counts are
+deterministic and machine-independent for a fixed toolchain + libc, so they are
+committed to each crate's `benches/iai-baseline.json` and the CI `iai` job
+**fails** on a regression past the baseline's tolerance. This is a real gate,
+not an archive.
+
+Running locally needs Valgrind and a version-matched runner
+(`cargo install iai-callgrind-runner`, matching the `iai-callgrind` version in
+`Cargo.toml`):
+
+```bash
+rm -rf target/iai
+cargo bench -p tuika --bench markdown_iai --bench scroll_iai \
+  -p tuika-codeformatters --bench highlight_iai -- --save-summary=json
+python3 benches/check_iai.py            # compare to the committed baseline
+python3 benches/check_iai.py --update   # bless new counts
+```
+
+Name the targets explicitly. A bare `cargo bench` would sweep the Criterion
+targets in too, and they reject iai's flags just as the iai targets reject
+Criterion's.
+
+Treat the baseline like a snapshot test: when a change legitimately shifts
+counts (renderer change, dependency bump, toolchain upgrade), regenerate with
+`--update` and commit it alongside the code. To refresh from CI's exact
+environment, run the workflow manually (`workflow_dispatch`) and commit the
+uploaded `iai-baseline` artifact.


### PR DESCRIPTION
## What changed

`AGENTS.md` loses 36 lines of benchmark runbook and keeps the two facts that
change a decision: Criterion is advisory, iai is a gate. The procedure moves to
`benches/README.md`, next to the targets it describes.

The README is the file yolop grew for these crates just after the extraction,
brought across with its commands corrected for the split:

- `scroll_iai` was missing from the iai invocation, so following it verbatim
  would have measured two of the three targets and left the third's baseline
  unchecked.
- the baseline is per-crate (`benches/iai-baseline.json` in each), not a single
  file.
- why the targets must be named explicitly is now stated rather than left as a
  trap: a bare `cargo bench` sweeps both harnesses in together, and each rejects
  the other's flags.

## Why

`AGENTS.md` is read on every turn. Procedure that only matters once you are
already running a benchmark is cost paid on every unrelated task, and it is the
same layering the repository applies elsewhere — the fact up front, the runbook
behind a link.

The content also has a home now. `benches/` had no README, so the only copy of
this procedure was in the file that should not be carrying it.

## Before / After

No observable behavior — documentation only. No source, manifest, or workflow
file is touched, so nothing about how the benches run changes.

## Risk

- Low
- Worst case is a stale link if `benches/` is ever restructured. The packaging
  guard already covers whether the file ships: `benches/README.md` lands inside
  the published `.crate` alongside the bench sources, which is where a consumer
  reading the tarball would expect it.

## Checklist

- [x] Tests added or updated — none needed; see below
- [x] Backward compatibility considered — documentation only, no API surface
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — the benchmark *contract* (Criterion advisory, iai
gated, baseline treated as a snapshot test) is already recorded in
`knowledge/processes/testing.md`. This change moves operator procedure between
two contributor-facing files and does not alter that contract.

## Security

No security-relevant code changed. Documentation only: no source, dependency,
workflow, or credential surface is touched.

## Follow-ups

No follow-ups.

## Validation

- `python3 scripts/validate_okf.py knowledge --check-links` — 14 concepts, 0 errors
- public docs boundary grep — clean
- `cargo test --test packaging` — 5 passed

Rust jobs are unaffected (no `.rs`, manifest, or workflow change), so CI should
resolve to the docs legs.

## Note for the merger

The commit on this branch is **unsigned**, which `AGENTS.md` treats as a defect.
This environment has no usable signing identity — the configured
`user.signingkey` (`~/.ssh/commit_signing_key.pub`) is a zero-byte placeholder
with no private key, and the Doppler CLI that holds the backup OpenPGP identity
is not installed. Rather than reach for an unmanaged credential, I stopped at
that boundary. Please re-sign before merging.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ff4au8y9SaHyBGbBYyok4w)_