### PR TITLE
docs: lead with tuika's goal of becoming Rust's default TUI framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,11 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "A composable terminal UI toolkit — flexbox layout, overlays, focus, and safe ratatui interoperability."
+description = "The application framework for Rust terminal UIs — flexbox layout, overlays, focus, keymap, components, and safe ratatui interoperability."
 homepage.workspace = true
 repository.workspace = true
 readme = "README.md"
-keywords = ["tui", "terminal", "ratatui", "widgets", "layout"]
+keywords = ["tui", "terminal", "ratatui", "framework", "widgets"]
 categories = ["command-line-interface"]
 # Two kinds of file are kept out of the published `.crate`:
 #

--- a/README.md
+++ b/README.md
@@ -1,30 +1,107 @@
 # tuika
 
+<div align="center">
+
 [![crates.io](https://img.shields.io/crates/v/tuika.svg)](https://crates.io/crates/tuika)
 [![docs.rs](https://img.shields.io/docsrs/tuika)](https://docs.rs/tuika)
 [![downloads](https://img.shields.io/crates/d/tuika.svg)](https://crates.io/crates/tuika)
 [![license](https://img.shields.io/crates/l/tuika.svg)](https://github.com/everruns/tuika/blob/main/LICENSE)
-![msrv](https://img.shields.io/badge/rust-1.88%2B-blue.svg)
+![msrv](https://img.shields.io/badge/rust-1.88%2B-blue.svg) \
+[Docs](https://docs.rs/tuika) · [Components](docs/components.md) ·
+[Markdown](docs/markdown.md) · [Terminal features](docs/features.md) ·
+[Keymap](docs/keymap.md) · [Styling](docs/styling.md) ·
+[Themes](docs/themes.md) \
+[Showcases](docs/showcases.md) · [Examples](#runnable-examples) ·
+[Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) ·
+[Report a bug](https://github.com/everruns/tuika/issues)
+
+</div>
 
 <p align="center">
   <img src="docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
 </p>
 
-A small composable terminal UI toolkit. `tuika` provides the layout,
-overlay, focus, and component primitives that `ratatui` leaves to you, while
-letting `ratatui` keep ownership of the cell buffer and its diff against the
-terminal.
+<div align="center">
 
-It is a published, self-contained crate that depends only on `ratatui-core`
-(plus `ratatui-crossterm` for the terminal backend), `crossterm`, `textwrap`,
-`unicode-segmentation`, and `unicode-width`, and is host-agnostic — it knows
-nothing about the application embedding it. tuika renders none of ratatui's own
-widgets, so it builds against `ratatui-core` directly rather than the `ratatui`
-umbrella — keeping `ratatui-widgets`, `ratatui-macros`, and their transitive
-weight out of its dependency tree. Your application still uses any ratatui
-widget it likes (see [Compatibility](#compatibility)). (The optional `async`
-feature adds Tokio for [`AsyncRunner`](#screen-modes-lifecycle-and-runner); it is
-off by default.)
+### tuika's goal is to become the default TUI [application](./docs/showcases.md) framework for Rust
+
+**Build the app, not the render loop.**
+
+</div>
+
+<details>
+<summary>Table of contents</summary>
+
+- [Install](#install)
+- [Model](#model)
+- [Crate layout](#crate-layout)
+- [Components](#components)
+- [Example](#example)
+- [Owned scenes, dialogs, and forms](#owned-scenes-dialogs-and-forms)
+- [Markdown and syntax highlighting](#markdown-and-syntax-highlighting)
+- [Theming](#theming)
+- [Runnable examples](#runnable-examples)
+- [Declarative DSL (`view!`)](#declarative-dsl-view)
+- [Ratatui interoperability](#ratatui-interoperability)
+- [Screen modes, lifecycle, and runner](#screen-modes-lifecycle-and-runner)
+- [Images](#images)
+- [Mouse, selection, and clipboard](#mouse-selection-and-clipboard)
+- [Testing your UI](#testing-your-ui)
+- [Used in](#used-in)
+- [Compatibility](#compatibility)
+- [Extending](#extending)
+- [License](#license)
+
+</details>
+
+`ratatui` gives you a cell buffer and widgets to draw into it; everything above
+that — layout, overlays, focus, input, the terminal lifecycle — has been left to
+each application to build for itself. tuika is that missing layer, and wants to
+be the standing answer to "what do I build a Rust TUI *application* on?": start
+with `cargo add tuika`, describe your screen, and get a real app instead of a
+render loop.
+
+You write views; tuika owns the rest:
+
+- **A whole app, not a widget set** — [flexbox layout](#model), anchored
+  [overlays](#owned-scenes-dialogs-and-forms), focus, a declarative
+  [keymap](docs/keymap.md), [themes and stylesheets](#theming), and a
+  [runner](#screen-modes-lifecycle-and-runner) that owns raw mode, the alternate
+  screen (or a [split footer](#screen-modes-lifecycle-and-runner) over live
+  scrollback), and event translation.
+- **Batteries the terminal era expects** — [30+ components](#components)
+  including streaming [Markdown](docs/markdown.md) with pluggable syntax
+  highlighting, [images](#images) over Kitty/iTerm2/Sixel, mermaid diagrams,
+  [mouse selection and clipboard](#mouse-selection-and-clipboard), and
+  [native OSC 9;4 progress](#native-terminal-progress).
+- **No lock-in** — it is additive to ratatui, not a replacement: wrap any
+  ratatui widget in [`RatatuiView`](#ratatui-interoperability) and it composes
+  like a built-in, and your own types implement the same `View` trait the
+  built-ins do (see [Extending](#extending)).
+- **Boring where it counts** — no reconciler, no retained tree, no runtime, no
+  macro DSL you are forced into. Views are rebuilt each frame and `ratatui`
+  diffs the buffer. Rendering is deterministic, so
+  [UI is unit-tested](#testing-your-ui) against an in-memory buffer with no
+  terminal at all.
+- **Small enough to adopt without a second thought** — a self-contained crate
+  depending only on `ratatui-core` (plus `ratatui-crossterm` for the backend),
+  `crossterm`, `textwrap`, `unicode-segmentation`, `unicode-width`, and
+  `pulldown-cmark`. Anything heavy — grammars, diagram layout, image decoding —
+  lives behind a trait in a companion crate or your host.
+
+It is host-agnostic: it knows nothing about the application embedding it, and no
+type, feature, or default exists to serve one host. tuika renders none of
+ratatui's own widgets, so it builds against `ratatui-core` directly rather than
+the `ratatui` umbrella — keeping `ratatui-widgets`, `ratatui-macros`, and their
+transitive weight out of its dependency tree. Your application still uses any
+ratatui widget it likes (see [Compatibility](#compatibility)). (The optional
+`async` feature adds Tokio for [`AsyncRunner`](#screen-modes-lifecycle-and-runner);
+it is off by default.)
+
+See what that buys in practice: the [showcases](docs/showcases.md) are
+recordings of real applications running on tuika (also listed under
+[Used in](#used-in)), and the [`codex` example](examples/codex) is a whole
+coding-agent UI built with nothing else.
 
 ## Install
 
@@ -284,7 +361,7 @@ onto the style it draws with. Override a role in one place and every element wit
 that role restyles at once; markdown parts and bare URLs are role-driven too. See
 the [styling guide](docs/styling.md).
 
-### Runnable examples
+## Runnable examples
 
 Each takes over the terminal — the alternate screen, or a pinned footer for
 [`split_footer`](examples/split_footer.rs); press `q` (or `esc`) to quit.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,6 +5,17 @@ change that makes them — an entry says why the knowledge moved, and that reaso
 is rarely recoverable later. Routine wording, formatting, and link fixes do not
 need entries.
 
+## 2026-07-25 — Positioned as the default Rust TUI application framework
+
+- The project's goal is to become the default framework Rust developers build
+  terminal *applications* on, but public material described a "small composable
+  toolkit" — accurate about the code, silent about the ambition, and easy to
+  read as one more widget crate.
+- Recorded the positioning in [Product goal](specs/goal.md) and led with it in
+  the README and the crates.io description/keywords, with the guard rails that
+  keep the claim honest: additive to ratatui rather than competing with it, and
+  backed by runnable examples and the showcases rather than asserted popularity.
+
 ## 2026-07-25 — Screen modes: a split footer over live scrollback
 
 - tuika could only own the whole terminal. That rules out the shape a

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -1,7 +1,7 @@
 ---
 type: Product Specification
 title: Product Goal
-description: Defines what tuika is for and the boundary it defends against host-specific and heavyweight concerns.
+description: Defines what tuika is for, the default-framework ambition it is positioned around, and the boundary it defends against host-specific and heavyweight concerns.
 ---
 
 # Product Goal
@@ -14,6 +14,29 @@ declarative keymap, an alternate-screen host, and a component set — while
 leaving `ratatui` in charge of the cell buffer and its diff against the
 terminal. A host should be able to describe a screen declaratively and get
 correct layout, focus, and terminal lifecycle without writing a reconciler.
+
+## Positioning
+
+The ambition is to be **the default framework for building terminal
+applications in Rust** — the answer a developer reaches for after deciding to
+build a TUI, the way a web developer reaches for a framework rather than a
+drawing API. Public material leads with that claim: the README states it as a
+banner above the fold, and the crates.io description and keywords say
+*application framework*, not *widget collection*.
+
+The claim is earned by scope and by adoption evidence, never by overstatement:
+
+- **Scope.** What a TUI application needs beyond drawing — layout, overlays,
+  focus, keymap, theming, terminal lifecycle, screen modes, and a component set
+  covering the modern expectations (streaming markdown, images, mouse and
+  clipboard, native progress) — is in the box.
+- **Additive, never a replacement.** Positioning above ratatui must not read as
+  competing with it. tuika depends on ratatui's buffer and composes its widgets;
+  "default framework" means the layer applications sit on, with ratatui still
+  underneath.
+- **Evidence over adjectives.** Public claims point at runnable examples and the
+  [showcases](../../docs/showcases.md) — real applications on tuika — rather
+  than asserting popularity the project does not yet have.
 
 ## Design goals
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,9 @@
-//! `tuika` — a small composable terminal UI toolkit over
+//! `tuika` — the application framework for Rust terminal UIs, built over
 //! [`ratatui`](https://docs.rs/ratatui).
+//!
+//! Where ratatui owns the cell buffer and the widgets drawn into it, `tuika`
+//! owns the layer an *application* needs above that, so a TUI starts as a
+//! described screen rather than a render loop.
 //!
 //! `tuika` adds the pieces ratatui leaves to you — a flexbox-style layout
 //! solver, anchored overlays, focus/input-ownership, a host for either screen


### PR DESCRIPTION
## What changed

tuika's public entry points now lead with the project's goal instead of describing it as one more widget crate.

- **README header, ratatui-style.** A centered badge + navigation block (Docs · Components · Markdown · Terminal features · Keymap · Styling · Themes / Showcases · Examples · Changelog · Contributing · Report a bug), the hero recording, then a banner above the fold:

  > ### tuika's goal is to become the default TUI [application](./docs/showcases.md) framework for Rust
  > **Build the app, not the render loop.**

  Followed by a collapsible table of contents and a rewritten lead: what ratatui leaves to each application, and the five things tuika brings (whole app not a widget set; batteries — streaming markdown, images, mouse/clipboard, native progress; no lock-in with ratatui; no reconciler/runtime and hermetically testable; a small dependency set).
- **crates.io metadata** says the same thing: description now "The application framework for Rust terminal UIs — …", and keyword `layout` → `framework`.
- **Crate-level rustdoc** opener matches, so docs.rs's front page and the README agree.
- **`Runnable examples` promoted** from `###` (nested under Theming) to a top-level section, so it is reachable from the new TOC and nav row. Anchor is unchanged.
- The existing dependency-boundary and host-agnostic prose is kept, moved below the highlight.

## Why

The goal is for tuika to be the default framework Rust developers build terminal *applications* on. The README opened with "a small composable terminal UI toolkit" — accurate about the code, silent about the ambition, and easy to skim as another widget collection. The claim is stated where a reader lands, and pointed at the showcases as evidence rather than asserted.

## Before / After

Documentation only; no observable runtime behavior changes.

**Before** (README, above the fold): title, badges, hero, then "A small composable terminal UI toolkit. `tuika` provides the layout, overlay, focus, and component primitives that `ratatui` leaves to you…".

**After**: title, centered badges + navigation, hero, the goal banner quoted above, a collapsible TOC, then the lead paragraph and the "You write views; tuika owns the rest" bullets.

Rendered rustdoc front page and the packaged README were both regenerated and inspected (`cargo doc --all-features --no-deps`, `cargo publish --dry-run -p tuika`).

## Risk

- Low
- Prose, manifest metadata, and one rustdoc paragraph. The one mechanical risk is link rot in the new nav/TOC block: every target was checked to exist (`docs/*.md`, `CHANGELOG.md`, `CONTRIBUTING.md`) and every in-page anchor matches a heading, including `#runnable-examples`, whose heading level changed but whose slug did not.

## Checklist

- [x] Tests added or updated — n/a, see below
- [x] Backward compatibility considered — no API change
- [x] Knowledge concepts updated, or no update required with a reason

No automated test was added: the change is docs and manifest metadata with no behavior change, which the shipping spec exempts. The existing `tests/packaging.rs` already guards the packaged file set the README depends on, and it passes.

Validation: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features` (511 tests green), `cargo doc --all-features --no-deps`, `cargo run --example demo -- check` ("29 scenes, recordings, and references in sync"), `cargo publish --dry-run -p tuika`, and `python3 scripts/validate_okf.py knowledge --check-links`. No terminal smoke test: nothing that draws changed.

## API changes

None. No `pub` item was added, renamed, removed, or re-signed. `Cargo.toml`'s `description` and `keywords` changed, which affects the crates.io listing only.

## Knowledge

Updated [`knowledge/specs/goal.md`](knowledge/specs/goal.md) with a **Positioning** section recording the default-framework ambition and the guard rails that keep it honest — additive to ratatui rather than competing with it, and backed by runnable examples and the showcases rather than asserted popularity — plus an entry in [`knowledge/log.md`](knowledge/log.md).

## Security

No security-relevant code changes: the diff is Markdown, manifest metadata, and a doc comment. No escape emission (TM-ESC), terminal state (TM-STATE), parsing (TM-PARSE), clipping (TM-CLIP), or dependency (TM-DEP) surface is touched — the dependency set is unchanged.

## Follow-ups

No follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jh9hcogA3A5QU7KEovZ7Jn)_