### PR TITLE
feat(scene): add borrowed root composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ described in the release process begins with the entry below.
 
 ### Added
 
+- **Borrowed scene roots.** `ScopedScene<'_, V>` borrows a concrete `View` for
+  one frame while owning the same ordered `SceneOverlay` / `Dialog` stack as
+  `Scene`. Hosts can paint large live models directly without cloning them into
+  a `'static` `Element`; rendering, backdrop, placement, and focus-owner
+  semantics are shared with owned scenes.
 - **Screen modes.** `ScreenMode` picks which part of the terminal a frame owns:
   `Alternate` (the previous, still-default behavior) or `split_footer(rows)`,
   which reserves rows at the bottom of the *main* screen and leaves everything

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ component. Linked names below jump straight to their demo.
 | [`Flex`](docs/components.md#flex) | Flexbox container (the composition primitive) |
 | `Responsive` / `Constrained` | Breakpoint selection and min/max measurement |
 | [`Boxed`](docs/components.md#boxed) | Border + padding + title, focus-aware |
-| `Scene` / `Dialog` | Owned root + anchored overlays; modal composition |
+| `Scene` / `ScopedScene` / `Dialog` | Owned or frame-borrowed root + anchored overlays |
 | `Spacer` | Flexible filler |
 | [`Scroll`](docs/components.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
 | [`ItemScroll`](docs/components.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
@@ -226,11 +226,11 @@ let root = view! {
 paint(f.buffer_mut(), f.area(), &theme, root.as_ref(), &[]);
 ```
 
-## Owned scenes, dialogs, and forms
+## Owned and scoped scenes, dialogs, and forms
 
 `Scene` owns a root `Element` and ordered `SceneOverlay`s. Each layer retains
 its `OverlaySpec`, so it resolves against the current terminal size inside
-rendering; callers do not retain borrowed views or pre-resolved `Rect`s.
+rendering; callers do not retain pre-resolved `Rect`s.
 `Dialog` composes `Boxed`, `Flex`, and optional `KeyHints` into a centered modal
 with size clamps, clear/dim behavior, and an optional focus-owner id:
 
@@ -248,6 +248,46 @@ let scene = Scene::new(element(base)).dialog(
 scene.sync_focus(&mut focus);
 paint_scene(buffer, area, &theme, &scene);
 ```
+
+`Element` is an owned, boxed view. When the base view reads a large host-owned
+model directly, `ScopedScene` borrows that concrete root for one paint while
+continuing to own ordinary `SceneOverlay`s and `Dialog`s:
+
+```rust
+use ratatui_core::layout::Rect;
+use tuika::prelude::*;
+
+struct Dashboard<'a> {
+    messages: &'a [String],
+}
+
+impl View for Dashboard<'_> {
+    fn measure(&self, available: Size) -> Size {
+        available
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        for (row, message) in self.messages.iter().take(area.height as usize).enumerate() {
+            surface.set_string(area.x, area.y + row as u16, message, ctx.theme.text_style());
+        }
+    }
+}
+
+let dashboard = Dashboard { messages: &app.messages };
+let scene = ScopedScene::new(&dashboard).dialog(
+    Dialog::new("Confirm", element(Text::raw("Delete this item?")))
+        .dim_backdrop(true)
+        .focus_owner("confirm"),
+);
+scene.sync_focus(&mut focus);
+paint(buffer, area, &theme, &scene, &[]);
+```
+
+The borrow lasts only as long as the scoped scene, matching Tuika's
+frame-by-frame view model. No transcript clone, leaked allocation, or
+application compositor is needed. Nested component children are still owned
+`Element`s; when a whole borrowed subtree is needed, represent that subtree as
+one concrete `View` and use it as the scoped root.
 
 `Form` lays out arbitrary control `Element`s beside responsive labels, stacking
 on narrow terminals. Help and validation rows are built in; `FormState` owns

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -20,6 +20,20 @@ need entries.
   generated SVGs, companion crates, the Codex example, and external showcases,
   rather than meaning only the component registry by accident.
 
+## 2026-07-25 — Borrowing stops at the scene root
+
+- `Element = Box<dyn View>` deliberately remains owned and `'static`, but that
+  forced a live application root either to clone large host models each frame or
+  to retain its own compositor beside Tuika's owned `Scene`.
+- Added `ScopedScene<'_, V>` as the narrow borrowing boundary: one concrete root
+  is borrowed for the frame, while overlays remain owned `SceneOverlay`s. Owned
+  and scoped scenes share rendering and focus-owner resolution so backdrop,
+  clipping, placement, ordering, and focus behavior cannot drift.
+- Recorded the choice in [Rendering architecture](specs/architecture.md).
+  Lifetime-generic elements would make every container and component carry the
+  borrowing policy even though the motivating state naturally belongs at the
+  frame root.
+
 ## 2026-07-25 — Positioned as the default Rust TUI application framework
 
 - The project's goal is to become the default framework Rust developers build

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`Element`/`RenderCtx`, owned `Scene` composition, layout, events, `Theme`/`StyleSheet`, `Surface`, host seam, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`Element`/`RenderCtx`, owned or scoped scene composition, layout, events, `Theme`/`StyleSheet`, `Surface`, host seam, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -35,6 +35,11 @@ rather than beside it.
   root and overlay elements for one frame and resolves each overlay's
   `OverlaySpec` while rendering. This removes borrowed compositor plumbing
   without adding identity, lifecycle, or hidden persistent state.
+- **Scoped scenes borrow only the frame root.** `ScopedScene` lets a concrete
+  root read large host-owned state directly while overlays remain owned
+  elements. It uses the same renderer and focus-owner resolution as `Scene`;
+  keeping the borrowing boundary at the root avoids making `Element` and every
+  component lifetime-generic.
 - **The host owns the terminal**: the screen mode (alternate screen or a split
   footer over live scrollback — see [screen-modes.md](./screen-modes.md)), raw
   mode, mouse capture, input translation, and frame compositing.
@@ -131,7 +136,9 @@ the child's logical extent is much larger.
 ## Rendering pipeline
 
 1. The host builds the view tree from application state (optionally through the
-   `view!` DSL, which expands to the same builder calls — no runtime cost).
+   `view!` DSL, which expands to the same builder calls — no runtime cost). A
+   root may borrow that state for the frame through `ScopedScene`; owned
+   component subtrees remain `Element`s.
 2. The solver resolves the tree to rects.
 3. Views paint into a clipped `Surface`; overlays composite over the base.
 4. The host calls out-of-band emitters (images, native progress) after the

--- a/src/host.rs
+++ b/src/host.rs
@@ -291,7 +291,8 @@ fn read_tmux_extended_keys_format() -> Option<String> {
 
 /// Composite `root` and `overlays` into `buffer` over `area`, using `theme`'s
 /// default [`StyleSheet`]. To centralize styling with a custom stylesheet, use
-/// [`paint_with_sheet`].
+/// [`paint_with_sheet`]. A [`ScopedScene`](crate::ScopedScene) can be passed as
+/// `root` to combine a borrowed application view with owned scene overlays.
 pub fn paint(
     buffer: &mut Buffer,
     area: Rect,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,17 @@
 //!   anchor over the base tree; the **host** ([`host`]) owns the screen
 //!   ([`screen::ScreenMode`] — the alternate screen, or a split footer over live
 //!   terminal scrollback), translates crossterm input, and composites the frame.
+//! - **Scene composition** is owned with [`Scene`], or borrows a host-state view
+//!   for one frame with [`ScopedScene`]; both use the same ordered overlay and
+//!   focus semantics.
 //!
 //! # Finding things
 //!
 //! The crate root re-exports the **framework**: the view model, layout,
 //! events, styling, and the host seam — the types you compose *with*. The
-//! widgets themselves live in [`components`], and everything that talks to the
+//! widgets themselves live in [`components`]. Owned [`Element`] trees use
+//! [`Scene`]; a concrete root that borrows large application state uses
+//! [`ScopedScene`] without cloning it. Everything that talks to the
 //! terminal outside the cell grid (clipboard, hyperlinks, images, native
 //! progress, capability detection) lives in [`term`].
 //!
@@ -113,7 +118,7 @@ pub use overlay::{Overlay, OverlaySpec};
 #[cfg(feature = "async")]
 pub use runner::{AsyncRunner, Signal};
 pub use runner::{Runner, RunnerConfig};
-pub use scene::{Backdrop, Scene, SceneOverlay};
+pub use scene::{Backdrop, Scene, SceneOverlay, ScopedScene};
 pub use screen::{ScreenMode, Scrollback};
 pub use style::{SemanticRole, StyleSheet, Theme};
 pub use surface::Surface;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,6 +21,10 @@
 //! `Text` and this crate's [`components::Text`](crate::components::Text) are the obvious
 //! pair. When that happens, import the two you need by path instead; the glob is
 //! a convenience, never a requirement.
+//!
+//! Both ownership forms of frame composition are included: [`Scene`] owns its
+//! root, while [`ScopedScene`] borrows a concrete root that reads host-owned
+//! data for the duration of one paint.
 
 pub use crate::anim::{Easing, Repeat, Timeline};
 pub use crate::components::*;
@@ -36,9 +40,9 @@ pub use crate::view;
 pub use crate::{
     Align, Backdrop, Dimension, Direction, Element, Event, EventFlow, Justify, Key, KeyCode,
     LayoutStyle, Mouse, MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx, Runner,
-    RunnerConfig, Scene, SceneOverlay, ScreenMode, Scrollback, SemanticRole, Size, StyleSheet,
-    Surface, TerminalSession, Theme, View, element, paint, paint_scene, paint_with_sheet,
-    translate_event,
+    RunnerConfig, Scene, SceneOverlay, ScopedScene, ScreenMode, Scrollback, SemanticRole, Size,
+    StyleSheet, Surface, TerminalSession, Theme, View, element, paint, paint_scene,
+    paint_with_sheet, translate_event,
 };
 
 #[cfg(feature = "async")]

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -1,4 +1,96 @@
-//! Owned base-tree and overlay composition.
+//! Owned and borrowed base-tree composition with owned overlays.
+//!
+//! [`Scene`] owns both its base [`Element`] and every [`SceneOverlay`]. Use it
+//! when the complete frame can be moved into Tuika's owned view tree.
+//! [`ScopedScene`] instead borrows a base [`View`] for one frame while retaining
+//! the same owned overlay stack. It is intended for application roots that read
+//! large host-owned state—such as transcripts, logs, or tables—directly during
+//! painting. The borrowed root does not need to clone that state or become a
+//! boxed `'static` [`Element`].
+//!
+//! Only the root is borrowed. Overlay views remain owned [`Element`]s, so all
+//! existing components, [`Dialog`](crate::components::Dialog) compositions, and
+//! scene focus behavior work unchanged. If a nested container itself needs
+//! borrowed children, implement a concrete [`View`] for that borrowed subtree
+//! and use it as the scoped root; `Element` and existing component APIs remain
+//! deliberately non-generic over lifetimes.
+//!
+//! # Borrowed application data with an owned dialog
+//!
+//! ```
+//! use ratatui_core::layout::Rect;
+//! use tuika::prelude::*;
+//!
+//! struct Dashboard<'data> {
+//!     messages: &'data [String],
+//! }
+//!
+//! impl View for Dashboard<'_> {
+//!     fn measure(&self, available: Size) -> Size {
+//!         Size::new(available.width, (self.messages.len() as u16).min(available.height))
+//!     }
+//!
+//!     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+//!         for (row, message) in self.messages.iter().take(area.height as usize).enumerate() {
+//!             surface.set_string(
+//!                 area.x,
+//!                 area.y + row as u16,
+//!                 message,
+//!                 ctx.theme.text_style(),
+//!             );
+//!         }
+//!     }
+//! }
+//!
+//! let messages = vec!["building".to_owned(), "ready".to_owned()];
+//! let dashboard = Dashboard { messages: &messages };
+//! let scene = ScopedScene::new(&dashboard).dialog(
+//!     Dialog::new("Confirm", element(Text::raw("Delete?"))).size(20, 5),
+//! );
+//!
+//! let rendered = tuika::testing::render(&scene, 30, 8, &Theme::default());
+//! assert!(tuika::testing::grid(&rendered).contains("Delete?"));
+//! ```
+//!
+//! # Rebuilding each frame without cloning
+//!
+//! The scene cannot outlive the root it borrows. End the frame's scope before
+//! mutating the host state, then build the next frame from a fresh borrow:
+//!
+//! ```
+//! use ratatui_core::layout::Rect;
+//! use tuika::prelude::*;
+//!
+//! struct Count<'data>(&'data [String]);
+//! impl View for Count<'_> {
+//!     fn measure(&self, available: Size) -> Size {
+//!         Size::new(available.width.min(8), available.height.min(1))
+//!     }
+//!     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+//!         surface.set_string(
+//!             area.x,
+//!             area.y,
+//!             &self.0.len().to_string(),
+//!             ctx.theme.text_style(),
+//!         );
+//!     }
+//! }
+//!
+//! let mut messages = vec!["first".to_owned()];
+//! {
+//!     let root = Count(&messages);
+//!     let scene = ScopedScene::new(&root);
+//!     let frame = tuika::testing::render(&scene, 8, 1, &Theme::default());
+//!     assert_eq!(&tuika::testing::grid(&frame)[..1], "1");
+//! }
+//! messages.push("second".to_owned());
+//! {
+//!     let root = Count(&messages);
+//!     let scene = ScopedScene::new(&root);
+//!     let frame = tuika::testing::render(&scene, 8, 1, &Theme::default());
+//!     assert_eq!(&tuika::testing::grid(&frame)[..1], "2");
+//! }
+//! ```
 
 use ratatui_core::layout::Rect;
 use ratatui_core::style::{Modifier, Style};
@@ -75,6 +167,9 @@ impl SceneOverlay {
 /// [`paint`](crate::paint). Overlays are rendered in insertion order and only
 /// the topmost one receives a focused render context.
 ///
+/// Use [`ScopedScene`] when the root view borrows host-owned data that should
+/// not be cloned into this scene's owned [`Element`].
+///
 /// ![owned primitives demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/primitives.gif)
 pub struct Scene {
     root: Element,
@@ -116,11 +211,7 @@ impl Scene {
     /// Call this after constructing the frame's scene. A scene without an
     /// owner-bearing overlay releases overlay ownership.
     pub fn sync_focus(&self, focus: &mut FocusRegistry) {
-        if let Some(owner) = self.overlays.last().and_then(SceneOverlay::owner) {
-            focus.set_owner(owner);
-        } else {
-            focus.clear_owner();
-        }
+        sync_focus(&self.overlays, focus);
     }
 }
 
@@ -130,29 +221,128 @@ impl View for Scene {
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
-        self.root
-            .render(area, &mut surface.child(area), &ctx.with_focus(false));
+        render_scene(self.root.as_ref(), &self.overlays, area, surface, ctx);
+    }
+}
 
-        let top = self.overlays.len().saturating_sub(1);
-        for (index, overlay) in self.overlays.iter().enumerate() {
-            if overlay.backdrop == Backdrop::Dim {
-                let dim_area = area.intersection(surface.area());
-                let buffer = surface.buffer_mut();
-                for y in dim_area.y..dim_area.bottom() {
-                    for x in dim_area.x..dim_area.right() {
-                        buffer[(x, y)].set_style(Style::default().add_modifier(Modifier::DIM));
-                    }
+/// A frame-scoped borrowed root view plus owned, ordered overlays.
+///
+/// `'view` is the lifetime of the reference to `root`; the root's own type may
+/// contain longer-lived references to host state. The scene must be painted
+/// before that root reference expires. `V` remains concrete, so constructing a
+/// scoped scene does not allocate or require a `dyn View` coercion.
+///
+/// Rendering and focus semantics are identical to [`Scene`]: the root renders
+/// first and unfocused when overlays exist, overlays render in insertion order,
+/// and only the topmost overlay receives a focused [`RenderCtx`].
+///
+/// See the [module-level examples](self) for borrowed data across successive
+/// frames.
+pub struct ScopedScene<'view, V: View + ?Sized> {
+    root: &'view V,
+    overlays: Vec<SceneOverlay>,
+}
+
+impl<'view, V: View + ?Sized> ScopedScene<'view, V> {
+    /// Borrow `root` for this scene's lifetime and start with no overlays.
+    pub fn new(root: &'view V) -> Self {
+        Self {
+            root,
+            overlays: Vec::new(),
+        }
+    }
+
+    /// Add an owned overlay.
+    pub fn overlay(mut self, overlay: SceneOverlay) -> Self {
+        self.overlays.push(overlay);
+        self
+    }
+
+    /// Add an owned view with a placement specification.
+    pub fn layer(self, view: Element, spec: OverlaySpec) -> Self {
+        self.overlay(SceneOverlay::new(view, spec))
+    }
+
+    /// Add an owned dialog composition over the borrowed root.
+    pub fn dialog(self, dialog: crate::components::Dialog) -> Self {
+        self.overlay(dialog.into_overlay())
+    }
+
+    /// The number of overlay layers.
+    pub fn overlay_count(&self) -> usize {
+        self.overlays.len()
+    }
+
+    /// Synchronize exclusive input ownership with the topmost overlay.
+    ///
+    /// Call this after constructing the frame's scene. An ownerless top layer
+    /// releases overlay ownership, even if a lower layer has an owner.
+    ///
+    /// ```
+    /// use tuika::prelude::*;
+    ///
+    /// let root = Text::raw("application");
+    /// let scene = ScopedScene::new(&root).dialog(
+    ///     Dialog::new("Confirm", element(Text::raw("Continue?")))
+    ///         .focus_owner("confirm-dialog"),
+    /// );
+    /// let mut focus = FocusRegistry::new();
+    /// focus.register("application");
+    /// scene.sync_focus(&mut focus);
+    ///
+    /// assert_eq!(focus.active(), Some("confirm-dialog"));
+    /// ```
+    pub fn sync_focus(&self, focus: &mut FocusRegistry) {
+        sync_focus(&self.overlays, focus);
+    }
+}
+
+impl<V: View + ?Sized> View for ScopedScene<'_, V> {
+    fn measure(&self, available: Size) -> Size {
+        self.root.measure(available)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        render_scene(self.root, &self.overlays, area, surface, ctx);
+    }
+}
+
+fn sync_focus(overlays: &[SceneOverlay], focus: &mut FocusRegistry) {
+    if let Some(owner) = overlays.last().and_then(SceneOverlay::owner) {
+        focus.set_owner(owner);
+    } else {
+        focus.clear_owner();
+    }
+}
+
+fn render_scene<V: View + ?Sized>(
+    root: &V,
+    overlays: &[SceneOverlay],
+    area: Rect,
+    surface: &mut Surface,
+    ctx: &RenderCtx,
+) {
+    root.render(area, &mut surface.child(area), &ctx.with_focus(false));
+
+    let top = overlays.len().saturating_sub(1);
+    for (index, overlay) in overlays.iter().enumerate() {
+        if overlay.backdrop == Backdrop::Dim {
+            let dim_area = area.intersection(surface.area());
+            let buffer = surface.buffer_mut();
+            for y in dim_area.y..dim_area.bottom() {
+                for x in dim_area.x..dim_area.right() {
+                    buffer[(x, y)].set_style(Style::default().add_modifier(Modifier::DIM));
                 }
             }
-            let overlay_area = overlay.resolve(area);
-            let mut layer = surface.child(overlay_area);
-            if overlay.clear {
-                layer.fill(Style::default().bg(ctx.theme.surface));
-            }
-            overlay
-                .view
-                .render(overlay_area, &mut layer, &ctx.with_focus(index == top));
         }
+        let overlay_area = overlay.resolve(area);
+        let mut layer = surface.child(overlay_area);
+        if overlay.clear {
+            layer.fill(Style::default().bg(ctx.theme.surface));
+        }
+        overlay
+            .view
+            .render(overlay_area, &mut layer, &ctx.with_focus(index == top));
     }
 }
 
@@ -195,11 +385,64 @@ mod tests {
     }
 
     #[test]
+    fn scoped_scene_matches_owned_composition() {
+        let owned = Scene::new(element(Text::raw("base")))
+            .overlay(
+                SceneOverlay::new(element(Text::raw("lower")), OverlaySpec::centered(100, 100))
+                    .clear(false)
+                    .backdrop(Backdrop::Dim),
+            )
+            .layer(element(Text::raw("top")), OverlaySpec::centered(50, 100));
+        let borrowed_root = Text::raw("base");
+        let scoped = ScopedScene::new(&borrowed_root)
+            .overlay(
+                SceneOverlay::new(element(Text::raw("lower")), OverlaySpec::centered(100, 100))
+                    .clear(false)
+                    .backdrop(Backdrop::Dim),
+            )
+            .layer(element(Text::raw("top")), OverlaySpec::centered(50, 100));
+
+        assert_eq!(
+            render(&owned, 8, 2, &Theme::default()),
+            render(&scoped, 8, 2, &Theme::default())
+        );
+        assert_eq!(scoped.overlay_count(), 2);
+    }
+
+    #[test]
+    fn scoped_scene_orders_overlays_and_focuses_only_the_topmost() {
+        let focus = Rc::new(RefCell::new(Vec::new()));
+        let root = FocusProbe(focus.clone());
+        let scene = ScopedScene::new(&root)
+            .overlay(SceneOverlay::new(
+                element(FocusProbe(focus.clone())),
+                OverlaySpec::centered(100, 100),
+            ))
+            .overlay(SceneOverlay::new(
+                element(FocusProbe(focus.clone())),
+                OverlaySpec::centered(50, 50),
+            ));
+
+        let _ = render(&scene, 8, 4, &Theme::default());
+        assert_eq!(&*focus.borrow(), &[false, false, true]);
+    }
+
+    #[test]
     fn scene_handles_zero_size_and_overlay_order() {
         let scene = Scene::new(element(Text::raw("base")))
             .layer(element(Text::raw("one")), OverlaySpec::centered(100, 100))
             .layer(element(Text::raw("two")), OverlaySpec::centered(100, 100));
         assert_eq!(grid(&render(&scene, 4, 1, &Theme::default())), "two ");
+        let _ = render(&scene, 0, 0, &Theme::default());
+    }
+
+    #[test]
+    fn scoped_scene_handles_zero_size() {
+        let root = Text::raw("borrowed");
+        let scene = ScopedScene::new(&root).layer(
+            element(Text::raw("overlay")),
+            OverlaySpec::centered(100, 100),
+        );
         let _ = render(&scene, 0, 0, &Theme::default());
     }
 
@@ -230,11 +473,51 @@ mod tests {
     }
 
     #[test]
+    fn scoped_scene_synchronizes_owner_and_releases_it_for_ownerless_top_layer() {
+        let root = Text::raw("borrowed");
+        let owned_top = ScopedScene::new(&root).overlay(
+            SceneOverlay::new(element(Text::raw("dialog")), OverlaySpec::centered(50, 50))
+                .focus_owner("dialog"),
+        );
+        let mut focus = FocusRegistry::new();
+        focus.register("base");
+        owned_top.sync_focus(&mut focus);
+        assert_eq!(focus.active(), Some("dialog"));
+
+        let ownerless_top =
+            owned_top.layer(element(Text::raw("tooltip")), OverlaySpec::centered(20, 20));
+        ownerless_top.sync_focus(&mut focus);
+        assert_eq!(focus.active(), Some("base"));
+    }
+
+    #[test]
     fn dim_backdrop_respects_the_parent_surface_clip() {
         use ratatui_core::buffer::{Buffer, Cell};
 
         let mut buffer = Buffer::filled(Rect::new(0, 0, 6, 1), Cell::new("#"));
         let scene = Scene::new(element(Text::raw("base"))).overlay(
+            SceneOverlay::new(element(Text::raw("modal")), OverlaySpec::centered(100, 100))
+                .clear(false)
+                .backdrop(Backdrop::Dim),
+        );
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let mut surface = Surface::new(&mut buffer, Rect::new(2, 0, 2, 1));
+        scene.render(Rect::new(0, 0, 6, 1), &mut surface, &ctx);
+
+        assert!(!buffer[(1, 0)].modifier.contains(Modifier::DIM));
+        assert!(buffer[(2, 0)].modifier.contains(Modifier::DIM));
+        assert!(buffer[(3, 0)].modifier.contains(Modifier::DIM));
+        assert!(!buffer[(4, 0)].modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn scoped_dim_backdrop_respects_the_parent_surface_clip() {
+        use ratatui_core::buffer::{Buffer, Cell};
+
+        let mut buffer = Buffer::filled(Rect::new(0, 0, 6, 1), Cell::new("#"));
+        let root = Text::raw("base");
+        let scene = ScopedScene::new(&root).overlay(
             SceneOverlay::new(element(Text::raw("modal")), OverlaySpec::centered(100, 100))
                 .clear(false)
                 .backdrop(Backdrop::Dim),

--- a/src/view.rs
+++ b/src/view.rs
@@ -62,7 +62,8 @@ impl<'a> RenderCtx<'a> {
 /// `measure` reports the intrinsic content size the view would like given
 /// `available`; the flex solver uses it for `Dimension::Auto` sizing.
 /// `render` paints into the `area` the layout assigned, through the clipped
-/// `surface`.
+/// `surface`. A view may borrow application state; use it as the root of a
+/// [`ScopedScene`](crate::ScopedScene) when it needs Tuika-owned overlays.
 pub trait View {
     /// Report the intrinsic content size wanted given `available`.
     fn measure(&self, available: Size) -> Size;
@@ -70,7 +71,11 @@ pub trait View {
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx);
 }
 
-/// Boxed view, the element type stored by containers.
+/// Boxed `'static` view, the element type stored by owned containers.
+///
+/// For a frame root that borrows host state, keep the concrete view on the
+/// stack and compose it with [`ScopedScene`](crate::ScopedScene) instead of
+/// cloning the state into an `Element`.
 pub type Element = Box<dyn View>;
 
 impl View for Element {

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -76,8 +76,8 @@ fn components_are_reachable_flat() {
     let _ = Dialog::new("title", element(Text::raw("content")));
 }
 
-/// Owned composition belongs to the framework spine; custom canvases remain an
-/// explicit view-module escape hatch rather than growing the prelude.
+/// Owned and scoped composition belong to the framework spine; custom canvases
+/// remain an explicit view-module escape hatch rather than growing the prelude.
 #[test]
 fn scene_and_custom_drawing_follow_the_surface_policy() {
     use ratatui_core::layout::Rect;
@@ -94,6 +94,12 @@ fn scene_and_custom_drawing_follow_the_surface_policy() {
     let rendered = grid(&render(&scene, 30, 8, &Theme::default()));
     assert!(rendered.contains("title"));
     assert!(rendered.contains("content"));
+
+    let borrowed = Text::raw("borrowed");
+    let scoped =
+        ScopedScene::new(&borrowed).dialog(Dialog::new("scoped", element(Text::raw("overlay"))));
+    assert!(grid(&render(&scoped, 30, 8, &Theme::default())).contains("overlay"));
+
     assert_eq!(
         Theme::default().semantic_style(SemanticRole::Info),
         Theme::default().info_style()

--- a/tests/scoped_scene.rs
+++ b/tests/scoped_scene.rs
@@ -1,0 +1,53 @@
+//! Consumer-style coverage for painting a borrowed host root and owned dialog
+//! as one view.
+
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use tuika::prelude::*;
+use tuika::testing::grid;
+
+struct Transcript<'data> {
+    messages: &'data [String],
+}
+
+impl View for Transcript<'_> {
+    fn measure(&self, available: Size) -> Size {
+        Size::new(
+            available.width,
+            (self.messages.len() as u16).min(available.height),
+        )
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        for (row, message) in self.messages.iter().take(area.height as usize).enumerate() {
+            surface.set_string(area.x, area.y + row as u16, message, ctx.theme.text_style());
+        }
+    }
+}
+
+#[test]
+fn borrowed_transcript_and_owned_dialog_paint_as_one_root() {
+    let messages = vec!["first message".to_owned(), "second message".to_owned()];
+    let transcript = Transcript {
+        messages: &messages,
+    };
+    let scene = ScopedScene::new(&transcript).dialog(
+        Dialog::new("Confirm", element(Text::raw("Delete?")))
+            .size(20, 5)
+            .dim_backdrop(true)
+            .focus_owner("confirm"),
+    );
+    let area = Rect::new(0, 0, 30, 8);
+    let mut buffer = Buffer::empty(area);
+    let mut focus = FocusRegistry::new();
+    focus.register("transcript");
+
+    scene.sync_focus(&mut focus);
+    paint(&mut buffer, area, &Theme::default(), &scene, &[]);
+
+    let painted = grid(&buffer);
+    assert!(painted.contains("Confirm"));
+    assert!(painted.contains("Delete?"));
+    assert_eq!(focus.active(), Some("confirm"));
+    assert_eq!(messages[1], "second message");
+}


### PR DESCRIPTION
## What changed

Adds `ScopedScene<'_, V>`, a frame-scoped composition that borrows a concrete root `View` while owning the existing ordered `SceneOverlay` and `Dialog` stack. Owned `Scene` remains source-compatible, and both forms share one renderer and focus-owner synchronization path.

The new root/prelude API includes docs.rs-visible ownership and lifetime guidance, compiling borrowed-data and frame-rebuild examples, a focus example, README discovery, changelog coverage, and a consumer-style integration test.

## Why

Applications with large live models can render those models directly instead of cloning them into a `'static` `Element` each dirty frame or maintaining a second application compositor beside Tuika overlays.

## Before / After

Before: a borrowed dashboard root could not be placed inside `Scene`, so hosts cloned the model or painted a borrowed root and an owned modal scene separately.

After:

```rust
let dashboard = Dashboard { messages: &app.messages };
let scene = ScopedScene::new(&dashboard)
    .dialog(Dialog::new("Confirm", element(Text::raw("Delete?"))));
scene.sync_focus(&mut focus);
paint(buffer, area, &theme, &scene, &[]);
```

`cargo run --example primitives` still renders the owned scene composition correctly. The scoped consumer integration paints a borrowed transcript and owned dialog through one `paint` call.

## Risk

- Low to medium: additive public API plus an internal renderer extraction.
- Existing owned `Scene`, `Element`, component, and host call sites are unchanged.
- Cell-level parity tests cover backdrop dimming and clearing, resolved placement, overlay order, base/top focus, focus-owner synchronization, ownerless top layers, clipping, and zero-sized areas.
- No dependency or crate-version change. This additive API is recorded under `Unreleased`; version changes remain release-time work.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

## Knowledge

Updated rendering architecture and API-surface concepts, plus the knowledge log, to record why borrowing stops at the frame root rather than making `Element` and every component lifetime-generic.

## Security

Reviewed TM-ESC, TM-STATE, TM-PARSE, TM-CLIP, and TM-DEP.

- No terminal escape emission, terminal lifecycle, parsing, unsafe code, or dependency changes.
- TM-CLIP is the relevant surface. Owned and scoped scenes use the same renderer; tests exercise clipped backdrop dimming and zero-sized rendering.
- Overlay storage remains a host-sized `Vec`; no input-driven recursion or new unbounded allocation path.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo +1.88 check -p tuika --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo +1.94.0 doc --locked --all-features --no-deps --workspace`
- `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --locked --all-features --no-deps --workspace`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `python3 scripts/test_validate_okf.py`
- `cargo run --example demo -- check`
- `cargo run --example primitives`
- Inspected generated crate, scene module, `ScopedScene`, and prelude pages for examples and cross-links.

## Follow-ups

No follow-ups.