### PR TITLE
docs(markdown): consolidate detailed examples

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -131,73 +131,13 @@ view! {
 ### `Markdown` + `MarkdownState`
 
 Renders CommonMark (plus GFM tables and strikethrough) to styled lines —
-word-wrapping prose and re-laying-out code and tables to the render width.
-`MarkdownState` is the streaming form: fed deltas as a message arrives, it
-re-parses only the in-flight tail and caches everything before the last stable
-block boundary, so long transcripts don't re-tokenize. The cache holds
-width-independent parsed blocks, so layout (including table column fitting) is
-recomputed each frame — pass the current width and the output tracks the view
-as it resizes.
-[API](https://docs.rs/tuika/latest/tuika/components/markdown/struct.Markdown.html)
+word-wrapping prose and fitting code and tables to the render width.
+`MarkdownState` adds incremental rendering for streaming text. See the
+[markdown guide](markdown.md) for streaming, tables, fenced-block renderers,
+highlighting, links, and images.
+[API](https://docs.rs/tuika/latest/tuika/components/markdown/index.html)
 
 <img src="demos/markdown.gif" width="880" alt="Markdown streaming demo">
-
-```rust
-use tuika::prelude::*;
-let theme = Theme::default();
-let sheet = StyleSheet::from_theme(&theme);
-let mut md = MarkdownState::new();
-md.push_str(delta);                                  // forward each stream delta
-let lines = md.lines(width, &theme, &sheet, CodeHighlighter::Plain);
-view! { node(tuika::components::Text::new(lines)) }
-```
-
-#### Extensible fenced blocks
-
-`FencedBlockRenderer` can replace a language fence with terminal-native,
-width-aware lines. A renderer returns `None` for languages or inputs it does not
-handle, preserving the normal themed code block. `tuika-mermaid` supplies an
-mmdflux-backed implementation:
-
-```rust
-use tuika::prelude::*;
-use tuika_mermaid::MermaidRenderer;
-
-let mermaid = MermaidRenderer::new();
-let doc = Markdown::new(
-    "```mermaid\nflowchart LR\n  Source --> Parse --> Paint\n```",
-)
-.block_renderer(&mermaid);
-# let _ = doc;
-```
-
-The fence is painted directly as Unicode cells:
-
-<img src="https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-mermaid/examples/mermaid_markdown/mermaid.gif" width="880" alt="Mermaid diagram rendered as Unicode cells inside tuika Markdown">
-
-#### GFM tables
-
-Pipe tables render with box-drawing borders, a bold header, and per-column
-alignment from the `:---:` markers — cells keeping their inline styles, emoji,
-and links. Columns size to their content and are then fitted to the available
-width, so the same source reflows as the view resizes.
-
-<img src="demos/markdown_table.png" width="880" alt="A rendered GFM table with box-drawing borders: a bold header row; a left-aligned Component column of inline-code names; a centered Status column with ✅ and 🚧 emoji; and a right-aligned Docs column of underlined links.">
-
-```rust
-use tuika::prelude::*;
-let doc = Markdown::new("\
-| Component   |  Status   |                          Docs |
-| :---------- | :-------: | ----------------------------: |
-| `Markdown`  | ✅ stable | [docs.rs](https://docs.rs/tuika) |
-| **Image**   |  🚧 beta  | [features](features.md) |
-");
-# let _ = doc;
-```
-
-Markdown has more surface than one gallery entry holds — streaming, tables,
-highlighting, links, and images. The [markdown guide](markdown.md) covers all of
-it.
 
 ### `CodeBlock`
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -12,6 +12,7 @@ This page covers all of it in one place.
 - [Streaming](#streaming)
 - [GFM tables](#gfm-tables)
 - [Fenced code](#fenced-code)
+- [Extensible fenced blocks](#extensible-fenced-blocks)
 - [Links](#links)
 - [Images](#images)
 - [Styling](#styling)
@@ -140,6 +141,29 @@ view! { node(Markdown::new(source).highlighter(&highlighter)) }
 Without one, code is themed but uncolored. The `tuika-codeformatters` crate ships
 a tree-sitter implementation covering the common languages; a host with its own
 lexer implements the two-method trait instead.
+
+## Extensible fenced blocks
+
+`FencedBlockRenderer` can replace a language fence with terminal-native,
+width-aware lines. A renderer returns `None` for languages or inputs it does not
+handle, preserving the normal themed code block. `tuika-mermaid` supplies an
+mmdflux-backed implementation:
+
+```rust
+use tuika::prelude::*;
+use tuika_mermaid::MermaidRenderer;
+
+let mermaid = MermaidRenderer::new();
+let doc = Markdown::new(
+    "```mermaid\nflowchart LR\n  Source --> Parse --> Paint\n```",
+)
+.block_renderer(&mermaid);
+# let _ = doc;
+```
+
+The fence is painted directly as Unicode cells:
+
+<img src="https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-mermaid/examples/mermaid_markdown/mermaid.gif" width="880" alt="Mermaid diagram rendered as Unicode cells inside tuika Markdown">
 
 ## Links
 


### PR DESCRIPTION
## What changed

The component gallery now gives Markdown a concise overview, one representative recording, and direct links to the focused guide and module API. Detailed streaming, GFM table, and extensible fenced-block examples now live together in the Markdown guide.

## Why

The focused Markdown guide had outgrown its gallery entry, while the gallery duplicated most of the same material. This follows the documentation contract: keep the gallery presentational and let focused guides own detailed usage.

## Before / After

Before: `components.md` repeated the streaming example, GFM table walkthrough, and Mermaid integration alongside `markdown.md`.

After: `components.md` is a compact catalog entry; `markdown.md` owns the detailed examples. No runtime or API behavior changes.

## Risk

- Low
- Relative links or demo references could drift. The gallery integrity check and link-boundary review cover that risk.

## Validation

- `cargo run --example demo -- check` — 29 scenes, recordings, and references in sync
- `python3 scripts/validate_okf.py knowledge --check-links` — 14 concepts, 0 errors
- `git diff --check`
- Public docs contain no links into `knowledge/` or `.agents/`
- Automated behavior tests and terminal smoke are not applicable because this is documentation-only

## API

No API changes.

## Checklist

- [x] Tests added or updated — exempt: documentation-only, with no behavior change
- [x] Backward compatibility considered — no runtime or API changes
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this change aligns public docs with the existing documentation specification and does not alter durable behavior or policy.

## Security

No security-relevant code changes — only public Markdown documentation moved. Terminal escape emission, state restoration, untrusted-content parsing, clipping, and dependencies are unchanged.

## Follow-ups

No follow-ups.