### PR TITLE
chore(knowledge): conform bundle to OKF v0.2

### DIFF
--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -1,3 +1,7 @@
+---
+okf_version: "0.2"
+---
+
 # tuika Knowledge
 
 This directory is tuika's Open Knowledge Format (OKF) bundle: the durable

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,11 +1,12 @@
 # Knowledge Log
 
-Significant changes to tuika's durable knowledge are recorded here, in the same
-change that makes them — an entry says why the knowledge moved, and that reason
-is rarely recoverable later. Routine wording, formatting, and link fixes do not
-need entries.
+## 2026-07-25
 
-## 2026-07-25 — Demo format follows whether motion carries information
+- **OKF v0.2 compliance**: Declared the bundle version, normalized this log
+  into date groups, and extended the validator to enforce reserved-file
+  structure.
+
+- **Demo format follows whether motion carries information**
 
 - Component recordings treated GIF as a universal container even when a scene
   never moved. That needlessly quantized font antialiasing and themed colors to
@@ -20,7 +21,7 @@ need entries.
   generated SVGs, companion crates, the Codex example, and external showcases,
   rather than meaning only the component registry by accident.
 
-## 2026-07-25 — Borrowing stops at the scene root
+- **Borrowing stops at the scene root**
 
 - `Element = Box<dyn View>` deliberately remains owned and `'static`, but that
   forced a live application root either to clone large host models each frame or
@@ -34,7 +35,7 @@ need entries.
   borrowing policy even though the motivating state naturally belongs at the
   frame root.
 
-## 2026-07-25 — Positioned as the default Rust TUI application framework
+- **Positioned as the default Rust TUI application framework**
 
 - The project's goal is to become the default framework Rust developers build
   terminal *applications* on, but public material described a "small composable
@@ -45,7 +46,7 @@ need entries.
   keep the claim honest: additive to ratatui rather than competing with it, and
   backed by runnable examples and the showcases rather than asserted popularity.
 
-## 2026-07-25 — Screen modes: a split footer over live scrollback
+- **Screen modes: a split footer over live scrollback**
 
 - tuika could only own the whole terminal. That rules out the shape a
   long-running CLI wants: a live footer over output the user keeps — scrollable,
@@ -69,7 +70,7 @@ need entries.
   now runs the suite on the default feature set too, which it previously only
   compiled.
 
-## 2026-07-25 — docs.rs is a build CI has to rehearse, not assume
+- **docs.rs is a build CI has to rehearse, not assume**
 
 - 0.4.0 shipped with no documentation on docs.rs: `src/lib.rs` gated on
   `feature(doc_auto_cfg)`, removed in Rust 1.92, behind `cfg_attr(docsrs, …)`.
@@ -83,7 +84,7 @@ need entries.
   gate reports success.
 
 
-## 2026-07-25 — The tag history starts after the extraction
+- **The tag history starts after the extraction**
 
 - tuika 0.1.0–0.4.0 and `tuika-codeformatters` 0.1.0–0.2.0 were all published
   from the yolop workspace: every publish timestamp on crates.io precedes this
@@ -107,7 +108,7 @@ need entries.
   "every member excludes its GIFs", which would have been wrong for the very next
   member added.
 
-## 2026-07-25 — Non-Unix CI covered the workspace, not just the root package
+- **Non-Unix CI covered the workspace, not just the root package**
 
 - CI's macOS and Windows legs ran Cargo's default package scope, which quietly
   exempted `tuika-codeformatters` — the only member that compiles C — from every
@@ -117,7 +118,7 @@ need entries.
   reveal the break and the CI invocation is the entire guarantee. Worth stating
   because the failure mode is silence — a too-narrow scope reports green.
 
-## 2026-07-25 — TerminalSession makes modified keys real
+- **TerminalSession makes modified keys real**
 
 - `TextInputMode` already assigned different behavior to `Enter` and
   `Shift+Enter`, but the full terminal session never requested a protocol that
@@ -131,7 +132,7 @@ need entries.
 - Teardown pops exactly the level tuika pushed instead of globally resetting
   keyboard reporting, preserving a mode installed by an embedding host.
 
-## 2026-07-25 — Markdown fences can replace source with rich blocks
+- **Markdown fences can replace source with rich blocks**
 
 - Split fenced-block extension into two contracts: `Highlighter` remains
   line-preserving token styling, while `FencedBlockRenderer` may replace a
@@ -146,7 +147,7 @@ need entries.
   layout are useful but heavyweight and independently versioned, so they follow
   the same companion-crate boundary as tree-sitter highlighting.
 
-## 2026-07-25 — A theme can be inherited from the terminal
+- **A theme can be inherited from the terminal**
 
 - Added a third source for a `Theme`, beside the bundled presets and a host's own
   literal: the terminal the application was launched in. [Styling](specs/styling.md)
@@ -169,7 +170,7 @@ need entries.
   non-goal "no cascade, inheritance, or selectors" was about the *rule* layer;
   terminal inheritance produces a plain `Theme` and involves no cascade.
 
-## 2026-07-25 — Markdown's two passes become its file layout
+- **Markdown's two passes become its file layout**
 
 - Splitting the 2293-line markdown module surfaced the invariant that made the
   split obvious: rendering is parse-then-flatten, separated by *what they know
@@ -182,7 +183,7 @@ need entries.
 - The files now follow the passes rather than the vocabulary. Submodules stay
   private per [Public API surface](specs/api-surface.md) — the split is an
   implementation detail, and `components::markdown` remains the one path in.
-## 2026-07-25 — Markdown gets a guide of its own
+- **Markdown gets a guide of its own**
 
 - The component gallery is one entry per component, but markdown's user-facing
   surface is much larger than one entry: streaming, GFM table fitting, the
@@ -195,7 +196,7 @@ need entries.
   and links out, and such a guide reuses `DEMOS` scenes rather than owning
   parallel assets — which puts it inside the `demo -- check` reference gate.
 
-## 2026-07-25 — The crate root becomes a decision, not an accumulation
+- **The crate root becomes a decision, not an accumulation**
 
 - The public tree had grown by accretion: 30 flat public modules plus 167 names
   re-exported to the crate root, so nearly every type had two equally valid
@@ -215,7 +216,7 @@ need entries.
   test scaffolding moved out of the crate root into `src/tests/`
   ([Testing](processes/testing.md)).
 
-## 2026-07-25 — The bundle now states and enforces its own upkeep
+- **The bundle now states and enforces its own upkeep**
 
 - The rule that concepts are updated by the change that invalidates them lived in
   `AGENTS.md`, three skills, and the pull-request template — everywhere except
@@ -236,7 +237,7 @@ need entries.
   `README.md` and `docs/` and nothing else — previously that scope was only
   discoverable by reading the CI grep.
 
-## 2026-07-25 — Process concepts split out of `specs/`
+- **Process concepts split out of `specs/`**
 
 - The bundle mixed two kinds of knowledge under one directory: what tuika *is*
   (goal, architecture, and the capability concepts) and how maintainers *work on
@@ -253,7 +254,7 @@ need entries.
   bundle recursively and does not care about directory names, so the split is a
   readability contract rather than a tooling one.
 
-## 2026-07-25 — Codegen shifts the instruction-count gate
+- **Codegen shifts the instruction-count gate**
 
 - Landing `ItemScroll` and the composer token seams turned the `iai` gate red on
   `main`: seven of nine benchmarks up 3.7–5.5%, including the markdown ones,
@@ -268,7 +269,9 @@ need entries.
   next red gate is diagnosed rather than blessed on a hunch — a shift that
   survives the isolation is a real regression.
 
-## 2026-07-24 — Element viewports and composer token seams
+## 2026-07-24
+
+- **Element viewports and composer token seams**
 
 - Building a coding-agent TUI as an example (`examples/codex/`) surfaced two
   places where the toolkit forced a host to hand-draw: a transcript could only
@@ -284,7 +287,7 @@ need entries.
   flag — otherwise a host's clamp and the paint would disagree about content
   height.
 
-## 2026-07-24 — Owned composition primitives
+- **Owned composition primitives**
 
 - Added owned scenes and dialogs, arbitrary-child two-axis viewports,
   responsive forms, and a closure-backed drawing view. Persistent input and
@@ -295,7 +298,7 @@ need entries.
   public `Theme` struct. The roles derive from each theme's existing syntax
   colors, preserving source compatibility for downstream struct literals.
 
-## 2026-07-24 — Demo recordings can no longer be silently clipped
+- **Demo recordings can no longer be silently clipped**
 
 - Six gallery GIFs (`qr`, `ascii_font`, `diff`, `slider`, `timeline`,
   `hyperlink`) shipped with content cut off: each scene's recorded height is a
@@ -310,7 +313,7 @@ need entries.
   scene's recorded geometry, so the pre-record preview shows the real framing
   instead of a roomier one. See [Documentation](specs/documentation.md).
 
-## 2026-07-24 — Showcases
+- **Showcases**
 
 - Added `docs/showcases.md`: applications built on tuika (yolop, LLMSim), each
   with a recording of its real UI. It answers a question the component gallery
@@ -323,7 +326,7 @@ need entries.
   scenes are driven by a local LLMSim, so no provider key or live model is
   involved.
 
-## 2026-07-24 — Changelog format: demos in, commit links out
+- **Changelog format: demos in, commit links out**
 
 - Release notes now **show** the release: `### Highlights` embeds a VHS
   recording of the one or two most TUI-centric features. The recordings are
@@ -343,7 +346,7 @@ need entries.
   @handle` appears only for authors other than @chaliy, since the maintainer is
   the default and repeating it is noise.
 
-## 2026-07-24 — Signed history, signing identities, PR policy
+- **Signed history, signing identities, PR policy**
 
 - Rewrote the repository's history so every commit is signed and verifies.
   Signing is now a hard requirement rather than a convention; a rewrite that
@@ -357,7 +360,7 @@ need entries.
   way, so the shipping outcomes were reworded around "landing" rather than
   "merging" a PR.
 
-## 2026-07-24 — First green CI after extraction
+- **First green CI after extraction**
 
 - The `iai-baseline.json` files carried over from yolop measured yolop's copy of
   the code, not this repository's: the scroll benches sat 15–80% above them at
@@ -369,7 +372,7 @@ need entries.
   (see [Testing](processes/testing.md)), and the PTY smoke needs the `gallery`
   example built inside the coverage run's instrumented target directory.
 
-## 2026-07-24 — Extraction from yolop
+- **Extraction from yolop**
 
 - tuika and `tuika-codeformatters` moved out of the `everruns/yolop` workspace
   into this repository. tuika is now the root package of its own workspace; yolop

--- a/scripts/test_validate_okf.py
+++ b/scripts/test_validate_okf.py
@@ -39,6 +39,92 @@ class ValidateOkfTests(unittest.TestCase):
             self.assertEqual(concepts, 0)
             self.assertEqual(messages, ["index.md: broken link -> specs/missing.md"])
 
+    def test_accepts_root_index_version_and_date_grouped_log(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "index.md").write_text(
+                '---\nokf_version: "0.2"\n---\n\n# Index\n'
+            )
+            (root / "log.md").write_text(
+                "# Knowledge Log\n\n## 2026-07-25\n\n- **Update**: Current.\n"
+                "\n## 2026-07-24\n\n- **Creation**: Initial.\n"
+            )
+            messages, concepts = validate(root)
+            self.assertEqual(messages, [])
+            self.assertEqual(concepts, 0)
+
+    def test_rejects_decorated_log_date_heading(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "log.md").write_text(
+                "# Knowledge Log\n\n"
+                "## 2026-07-25 — Update\n\n- First.\n\n"
+                "## 2026-07-25\n\n- Second.\n"
+            )
+            messages, _ = validate(root)
+            self.assertIn(
+                "log.md: log date heading is not ISO 8601 `YYYY-MM-DD`: "
+                "2026-07-25 — Update",
+                messages,
+            )
+
+    def test_rejects_repeated_log_date_groups(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "log.md").write_text(
+                "# Knowledge Log\n\n"
+                "## 2026-07-25\n\n- First.\n\n"
+                "## 2026-07-25\n\n- Second.\n"
+            )
+            messages, _ = validate(root)
+            self.assertEqual(
+                messages,
+                ["log.md: log entries for the same date must share one date group"],
+            )
+
+    def test_rejects_impossible_log_date(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "log.md").write_text(
+                "# Knowledge Log\n\n## 2026-02-30\n\n- Impossible.\n"
+            )
+            messages, _ = validate(root)
+            self.assertEqual(
+                messages,
+                [
+                    "log.md: log date heading is not ISO 8601 `YYYY-MM-DD`: "
+                    "2026-02-30"
+                ],
+            )
+
+    def test_rejects_nested_index_frontmatter(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "group").mkdir()
+            (root / "group" / "index.md").write_text(
+                '---\nokf_version: "0.2"\n---\n\n# Group\n'
+            )
+            messages, _ = validate(root)
+            self.assertEqual(
+                messages,
+                [
+                    "group/index.md: frontmatter is only permitted in the "
+                    "bundle-root index.md"
+                ],
+            )
+
+    def test_rejects_log_groups_that_are_not_newest_first(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "log.md").write_text(
+                "# Knowledge Log\n\n## 2026-07-24\n\n- Old.\n"
+                "\n## 2026-07-25\n\n- New.\n"
+            )
+            messages, _ = validate(root)
+            self.assertEqual(
+                messages, ["log.md: log date groups are not newest first"]
+            )
+
     def test_rejects_concept_the_index_does_not_list(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -73,7 +159,9 @@ class ValidateOkfTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             (root / "index.md").write_text("# Index\n")
-            (root / "log.md").write_text("# Log\n\n[Concept](specs/concept.md)\n")
+            (root / "log.md").write_text(
+                "# Log\n\n## 2026-07-25\n\n- [Concept](specs/concept.md)\n"
+            )
             (root / "specs").mkdir()
             (root / "specs" / "concept.md").write_text("---\ntype: Policy\n---\n")
             messages, _ = validate(root)

--- a/scripts/validate_okf.py
+++ b/scripts/validate_okf.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Validate an Open Knowledge Format bundle using only the standard library.
+"""Validate an Open Knowledge Format v0.2 bundle using only the standard library.
 
 Usage: python3 scripts/validate_okf.py <bundle-dir> [--strict] [--check-links]
 
---strict requires title, description, and timestamp in addition to OKF's
-required type field. --check-links validates local Markdown link targets.
+--strict requires the recommended title and description fields in addition to
+OKF's required type field. --check-links validates local Markdown link targets.
 
 Every concept must also be reachable from the bundle index, so adding, moving,
 or renaming one without updating `index.md` fails rather than leaving a concept
@@ -16,13 +16,18 @@ from __future__ import annotations
 
 import re
 import sys
+from datetime import date
 from pathlib import Path
 
 INDEX = "index.md"
-RESERVED = {INDEX, "log.md"}
+LOG = "log.md"
+RESERVED = {INDEX, LOG}
 FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 LINK_RE = re.compile(r"\]\(([^)\s]+)(?:\s+['\"][^)]*['\"])?\)")
 SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:")
+HEADING_RE = re.compile(r"^#\s+\S", re.MULTILINE)
+LOG_DATE_RE = re.compile(r"^##\s+(\S.*)$", re.MULTILINE)
+ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 def parse_frontmatter(text: str) -> tuple[dict[str, str], str | None]:
@@ -75,6 +80,65 @@ def indexed_concepts(root: Path) -> set[str] | None:
     return linked
 
 
+def validate_index(path: Path, root: Path, text: str) -> list[str]:
+    messages: list[str] = []
+    body = text
+    if text.startswith("---"):
+        if path != root / INDEX:
+            messages.append("frontmatter is only permitted in the bundle-root index.md")
+            return messages
+        frontmatter, error = parse_frontmatter(text)
+        if error:
+            messages.append(error)
+            return messages
+        unknown = set(frontmatter) - {"okf_version"}
+        if unknown:
+            messages.append(
+                "frontmatter contains fields other than `okf_version`: "
+                + ", ".join(sorted(unknown))
+            )
+        if not frontmatter.get("okf_version"):
+            messages.append("frontmatter has no non-empty `okf_version` field")
+        elif frontmatter["okf_version"] != "0.2":
+            messages.append(
+                f"validator supports `okf_version: \"0.2\"`, got "
+                f"{frontmatter['okf_version']!r}"
+            )
+        match = FRONTMATTER_RE.match(text)
+        assert match
+        body = text[match.end() :]
+    if not HEADING_RE.search(body):
+        messages.append("index body has no section heading")
+    return messages
+
+
+def validate_log(text: str) -> list[str]:
+    if text.startswith("---"):
+        return ["log.md must not contain frontmatter"]
+    headings = LOG_DATE_RE.findall(text)
+    if not headings:
+        return ["log.md has no date-group headings"]
+    messages: list[str] = []
+    valid_dates: list[str] = []
+    for heading in headings:
+        if ISO_DATE_RE.fullmatch(heading):
+            try:
+                date.fromisoformat(heading)
+            except ValueError:
+                pass
+            else:
+                valid_dates.append(heading)
+                continue
+        messages.append(
+            f"log date heading is not ISO 8601 `YYYY-MM-DD`: {heading}"
+        )
+    if len(valid_dates) != len(set(valid_dates)):
+        messages.append("log entries for the same date must share one date group")
+    if valid_dates != sorted(valid_dates, reverse=True):
+        messages.append("log date groups are not newest first")
+    return messages
+
+
 def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> tuple[list[str], int]:
     messages: list[str] = []
     concepts = 0
@@ -82,7 +146,11 @@ def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> 
     for path in sorted(root.rglob("*.md")):
         rel = path.relative_to(root).as_posix()
         text = path.read_text(encoding="utf-8", errors="replace")
-        if path.name not in RESERVED:
+        if path.name == INDEX:
+            messages.extend(f"{rel}: {message}" for message in validate_index(path, root, text))
+        elif path.name == LOG:
+            messages.extend(f"{rel}: {message}" for message in validate_log(text))
+        else:
             if linked is not None and rel not in linked:
                 messages.append(f"{rel}: concept is not listed in {INDEX}")
             frontmatter, error = parse_frontmatter(text)
@@ -93,7 +161,7 @@ def validate(root: Path, *, strict: bool = False, check_links: bool = False) -> 
             if not frontmatter.get("type"):
                 messages.append(f"{rel}: frontmatter has no non-empty `type` field")
             if strict:
-                for required in ("title", "description", "timestamp"):
+                for required in ("title", "description"):
                     if not frontmatter.get(required):
                         messages.append(f"{rel}: --strict requires `{required}`")
         if check_links:


### PR DESCRIPTION
## What changed

The internal knowledge bundle now conforms to Open Knowledge Format v0.2:

- the root index declares `okf_version: "0.2"`
- the knowledge log uses one exact ISO 8601 heading per date, newest first
- the validator enforces reserved `index.md` and `log.md` structure
- strict validation no longer requires the superseded v0.1 `timestamp` field

The validator has direct regression coverage for valid v0.2 reserved files, decorated, repeated, impossible, and out-of-order log dates, and forbidden nested-index frontmatter.

No public Rust API or packaged crate behavior changes.

## Why

The concept documents met OKF's core requirements, but decorated log headings violated v0.2's reserved-file structure. The existing validator skipped reserved-file structure entirely and therefore reported a false clean result.

## Before / After

Before: `log.md` used headings such as `## 2026-07-25 — Demo format...`, while `validate_okf.py` reported zero errors.

After: entries are grouped beneath exact `## YYYY-MM-DD` headings, the bundle declares v0.2, and strict validation reports:

```text
14 concept(s) checked in knowledge — 0 error(s)
```

Automated evidence:

```text
python3 scripts/test_validate_okf.py
Ran 13 tests ... OK

python3 scripts/validate_okf.py knowledge --strict --check-links
14 concept(s) checked in knowledge — 0 error(s)

cargo fmt --all -- --check
git diff --check
```

A terminal UI smoke test is not applicable: this changes repository knowledge and its validator only. The validator CLI was exercised through its real entry point.

## Risk

- Low
- CI will now reject malformed reserved OKF files that it previously accepted. This is intentional and covered by regression tests.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/index.md` to declare OKF v0.2 and `knowledge/log.md` to record and follow the conformant date-group structure.

## Security

No terminal escape, terminal state, parser/layout, clipping, dependency, credential, process, or network surface changes. The Python validator reads repository-local Markdown as before; this change only tightens structural validation and adds no dependency. TM-ESC, TM-STATE, TM-PARSE, TM-CLIP, and TM-DEP are unaffected.

## Follow-ups

No follow-ups.
