### PR TITLE
chore(release): prepare v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,23 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
-## [Unreleased]
+## [0.6.0] - 2026-07-25
+
+Released alongside `tuika-codeformatters` 0.3.1 and `tuika-mermaid` 0.1.1,
+which update their tuika dependency requirement for 0.6 compatibility.
+
+### Highlights
+
+**Split-footer terminal mode.** Hosts can keep a live footer pinned to the bottom
+of the terminal while completed content moves into native scrollback, then return
+every reserved row cleanly on exit.
+
+![split-footer demo](https://raw.githubusercontent.com/everruns/tuika/v0.6.0/docs/demos/split-footer.svg)
+
+**Borrowed scene roots.** `ScopedScene` renders and dispatches events through a
+borrowed `View`, so hosts can keep application state outside the scene without
+requiring `'static` ownership.
+
 
 ### Added
 
@@ -42,8 +58,19 @@ described in the release process begins with the entry below.
 ### Changed
 
 - **Breaking**: `RunnerConfig` gains a `screen_mode` field. Struct literals need
-  `..RunnerConfig::default()`:
-  `RunnerConfig { tick_rate, .. }` → `RunnerConfig { tick_rate, ..RunnerConfig::default() }`.
+  a default update:
+
+  Before:
+
+  ```rust
+  RunnerConfig { tick_rate }
+  ```
+
+  After:
+
+  ```rust
+  RunnerConfig { tick_rate, ..RunnerConfig::default() }
+  ```
 - `ScreenMode` and `Scrollback` join the crate root and the prelude.
 
 ## [0.5.0] - 2026-07-25
@@ -267,3 +294,5 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 * docs: add the knowledge bundle and agent workflows
 * ci: add the build, documentation, release, and cross-terminal pipelines
 * test: add a PTY smoke test and guard the published crate contents
+
+[0.6.0]: https://github.com/everruns/tuika/releases/tag/v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "mmdflux",
  "ratatui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-codeformatters"
-version = "0.3.0"
+version = "0.3.1"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -26,7 +26,7 @@ exclude = ["docs/*.gif"]
 bench = false
 
 [dependencies]
-tuika = { version = "0.5.0", path = "../.." }
+tuika = { version = "0.6.0", path = "../.." }
 ratatui = "0.30.2"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"

--- a/crates/tuika-mermaid/Cargo.toml
+++ b/crates/tuika-mermaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-mermaid"
-version = "0.1.0"
+version = "0.1.1"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -19,6 +19,6 @@ keywords = ["tui", "mermaid", "markdown", "ratatui", "diagrams"]
 categories = ["command-line-interface", "text-processing"]
 
 [dependencies]
-tuika = { version = "0.5.0", path = "../.." }
+tuika = { version = "0.6.0", path = "../.." }
 ratatui-core = "0.1"
 mmdflux = { version = "2.6", default-features = false }


### PR DESCRIPTION
## [0.6.0] - 2026-07-25

Released alongside `tuika-codeformatters` 0.3.1 and `tuika-mermaid` 0.1.1,
which update their tuika dependency requirement for 0.6 compatibility.

### Highlights

**Split-footer terminal mode.** Hosts can keep a live footer pinned to the bottom
of the terminal while completed content moves into native scrollback, then return
every reserved row cleanly on exit.

![split-footer demo](https://raw.githubusercontent.com/everruns/tuika/v0.6.0/docs/demos/split-footer.svg)

**Borrowed scene roots.** `ScopedScene` renders and dispatches events through a
borrowed `View`, so hosts can keep application state outside the scene without
requiring `'static` ownership.

### Breaking Changes

- `TerminalSession::new` now requires a `ScreenMode` argument.
- `TerminalSession::enter` now requires `ScreenMode` before the optional title.
- `RunnerConfig` gains a `screen_mode` field; struct literals must include
  `..RunnerConfig::default()` or set the field explicitly.

### What's Changed

- Added split-footer terminal mode with native scrollback and clean teardown.
- Added `ScopedScene` for borrowed view roots.
- Added terminal background-color queries and OSC 9;4 progress reporting.
- Added markdown render caching and linear-time wrapped rendering.
- Strengthened terminal, PTY, property, snapshot, and integration coverage.
- Updated the companion crates for tuika 0.6 compatibility.

## Publish-readiness

- [x] `python3 scripts/validate_okf.py knowledge --check-links`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo run --example demo -- check`
- [x] `cargo doc --workspace --all-features --no-deps`
- [x] `cargo publish --dry-run --allow-dirty -p tuika`
- [x] `cargo test --test packaging`
- [x] `python3 scripts/publish_order.py`
- [x] crates.io serves tuika 0.5.0, tuika-codeformatters 0.3.0, and tuika-mermaid 0.1.0
- [x] manifests and `Cargo.lock` agree on 0.6.0 / 0.3.1 / 0.1.1
- [x] split-footer highlight is embedded and pinned to `v0.6.0`

## Post-merge verification

- [ ] `release.yml` created tag `v0.6.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] crates.io serves tuika 0.6.0, tuika-codeformatters 0.3.1, and tuika-mermaid 0.1.1
- [ ] docs.rs built tuika 0.6.0

Produced by [yolop](https://everruns.com/yolop)
