### PR TITLE
docs(html): put HTML where the docs structure says it belongs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,11 @@ tuika's own suite covers more:
 ## Docs layout
 
 - `docs/components.md` — the public component gallery (name, description, demo
-  per component). Keep it **presentational only**: no build or regeneration
-  instructions belong here (they live in this file).
+  per component), covering **every** component, including those published in a
+  companion crate. Keep it **presentational only**: no build or regeneration
+  instructions belong here (they live in this file). The README links to entries
+  here rather than explaining a component itself; see
+  `knowledge/specs/documentation.md`.
 - `docs/markdown.md` — the markdown guide: streaming, GFM tables, the
   highlighter seam, link policy, and images in one page. It reuses the gallery's
   `DEMOS` recordings, so it is inside the `demo -- check` reference invariant.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ component. Linked names below jump straight to their demo.
 | `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
 | [`Markdown`](docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](docs/markdown.md) |
 | [`CodeBlock`](docs/components.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
+| [`Html`](docs/components.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
 | `Diff` | Line diff (LCS), unified or side-by-side, with `+`/`-` gutters and line numbers |
 | `AsciiFont` | Large "figlet-style" block-letter banner text |
 | `QrCode` (+ `QrEcc`) | QR code (byte-mode v1–4 encoder) rendered with half-blocks |
@@ -368,42 +369,17 @@ Run the complete integration demo with
 Images use the same host-extension pattern: supply an `ImageResolver` and
 `![alt](url)` renders as real pixels (see [Images](#images)).
 
-Block-level HTML is a seam of its own. Attach an `HtmlBlockRenderer` and raw
-`<details>`, `<table>`, and `<div>` blocks lay out instead of being dropped;
-[`tuika-html`](crates/tuika-html/) is the ready-made implementation.
-
-```rust
-use tuika::prelude::*;
-use tuika_html::HtmlRenderer;
-
-let html = HtmlRenderer::new();
-let document = Markdown::new("<details><summary>Notes</summary>Body</details>")
-    .html_renderer(&html);
-# let _ = document;
-```
-
-<img src="https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_markdown/html.png" width="880" alt="HTML blocks rendered inside tuika Markdown: a details summary with a bullet list, a box-drawn table, and a quoted line with Unicode subscript and superscript">
-
-The same crate carries [`Html`](crates/tuika-html/#standalone), a `View` for
-markup that is not inside markdown at all — the HTML counterpart to `Markdown`,
-placed in a layout the same way. Run it with
-`cargo run -p tuika-html --example html_view`.
-
-```rust
-use tuika_html::Html;
-
-let page = Html::new("<h1>Release notes</h1><ul><li>Faster</li></ul>");
-# let _ = page;
-```
-
-<img src="https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_view/html_view.png" width="880" alt="The Html view filling a bordered pane: a heading, wrapped prose with bold and italic runs, a definition list, a box-drawn table, a block quote, a pre block on a code background, a rule, and a footer line with a link, keyboard keys and a highlighted run">
-
-Markdown in the wild carries HTML, so the presentational inline tags render too
-— `<b>`, `<em>`, `<code>`, `<kbd>`, `<mark>`, `<a href>`, `<img>`, `<br>`, and
-`<sub>`/`<sup>` — each through the same `StyleSheet` role as the markdown it
-mirrors. It is a fixed whitelist, not an HTML parser: block-level HTML and
-anything unrecognized is dropped rather than printed. See
-[the markdown guide](docs/markdown.md#inline-html).
+Markdown in the wild carries HTML. The presentational inline tags — `<b>`,
+`<em>`, `<code>`, `<kbd>`, `<mark>`, `<a>`, `<br>`, `<sub>`/`<sup>` — render in
+tuika itself, each through the same `StyleSheet` role as the markdown it
+mirrors. Block-level HTML is a seam, for the same reason highlighting is: an
+HTML parser is a dependency tuika will not carry. Attach an `HtmlBlockRenderer`
+and `<details>`, `<table>`, and `<div>` lay out too.
+[`tuika-html`](crates/tuika-html/) is the ready-made one, and it also supplies
+the [`Html`](docs/components.md#html) component for markup that is not inside
+markdown at all. See the markdown guide for
+[inline HTML](docs/markdown.md#inline-html) and
+[block HTML](docs/markdown.md#block-html).
 
 ## Theming
 
@@ -807,7 +783,7 @@ The separately published companion crates live in this repository:
   terminal diagrams through mmdflux.
 - [`tuika-html`](crates/tuika-html/) lays out block-level HTML with html5ever —
   inside Markdown through the `HtmlBlockRenderer` seam, or standalone through
-  its own [`Html` view](crates/tuika-html/#standalone).
+  its own [`Html`](docs/components.md#html) component.
 
 All three keep their heavier parsers and grammars out of tuika core.
 

--- a/crates/tuika-html/README.md
+++ b/crates/tuika-html/README.md
@@ -7,8 +7,6 @@ blocks inside Markdown, and a standalone `Html` view. Built on
 them — which is exactly the dependency tuika core will not carry, and why this
 crate exists separately.
 
-<img src="examples/html_markdown/html.png" width="880" alt="HTML blocks rendered inside tuika Markdown: a details summary with a bullet list, a box-drawn table, and a quoted line with Unicode subscript and superscript">
-
 ## In Markdown
 
 `HtmlRenderer` implements both of tuika's markdown seams: `HtmlBlockRenderer`
@@ -25,6 +23,12 @@ let document = Markdown::new("<details><summary>Notes</summary>Body</details>")
     .block_renderer(&html);
 # let _ = document;
 ```
+
+Below, the `<details>`, the `<ul>` inside it, and the `<table>` are all raw HTML
+in a markdown document — laid out by the seam, beside markdown the renderer
+never sees:
+
+<img src="examples/html_markdown/html.png" width="880" alt="HTML blocks rendered inside tuika Markdown: a details summary with a bullet list, a box-drawn table, and a quoted line with Unicode subscript and superscript">
 
 Without a renderer attached, tuika drops block HTML — so adding this crate is
 purely additive. The presentational *inline* tags (`<b>`, `<a>`, `<br>`,

--- a/crates/tuika-html/src/lib.rs
+++ b/crates/tuika-html/src/lib.rs
@@ -120,6 +120,10 @@ impl Default for Limits {
 ///     .block_renderer(&renderer);
 /// # let _ = doc;
 /// ```
+///
+/// ![HTML blocks in markdown](https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_markdown/html.png)
+///
+/// `cargo run -p tuika-html --example html_markdown` is the scene above.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HtmlRenderer {
     limits: Limits,
@@ -191,6 +195,10 @@ impl FencedBlockRenderer for HtmlRenderer {
 /// let sheet = StyleSheet::from_theme(&theme);
 /// let lines = tuika_html::to_lines("<p>Hello <b>world</b></p>", 40, &theme, &sheet);
 /// assert_eq!(lines.len(), 1);
+///
+/// // Block elements are separated, and each is fitted to the width.
+/// let page = tuika_html::to_lines("<h1>Title</h1><p>Prose.</p>", 40, &theme, &sheet);
+/// assert_eq!(page.len(), 3); // heading, blank, prose
 /// ```
 pub fn to_lines(html: &str, width: u16, theme: &Theme, sheet: &StyleSheet) -> Vec<Line<'static>> {
     to_lines_with_limits(html, width, theme, sheet, Limits::default()).unwrap_or_default()

--- a/docs/components.md
+++ b/docs/components.md
@@ -147,6 +147,20 @@ The presentational inline HTML tags render too — `<b>`, `<em>`, `<code>`,
 
 <img src="demos/markdown_html.png" width="880" alt="Inline HTML in markdown: strong, emphasis, struck and underlined text, a highlighted run, keyboard keys, a link, Unicode subscript and superscript, and a line broken by a br tag">
 
+### `Html`
+
+Renders an HTML fragment to styled lines: headings, paragraphs, lists,
+definition lists, block quotes, `<pre>`, `<hr>`, `<table>`,
+`<details>`/`<summary>`, and the presentational inline elements. Every element
+resolves a `StyleSheet` role, so HTML inherits the app's theme like everything
+else. No CSS — this renders content, not pages. Ships in the companion crate
+[`tuika-html`](../crates/tuika-html/), which also supplies the
+`HtmlBlockRenderer` that lays out HTML blocks inside
+[Markdown](markdown.md#block-html).
+[API](https://docs.rs/tuika-html/latest/tuika_html/struct.Html.html)
+
+<img src="../crates/tuika-html/examples/html_view/html_view.png" width="880" alt="The Html view filling a bordered pane: a heading, wrapped prose with bold and italic runs, a definition list, a box-drawn table, a block quote, a pre block on a code background, a rule, and a footer line with a link, keyboard keys and a highlighted run">
+
 ### `CodeBlock`
 
 A themed, syntax-highlighted fenced block: a language label, a left rail, and a
@@ -663,8 +677,5 @@ view! { node(FrameBufferView::new(&fb, 64, 16)) }
   `Constrained`, `Wrap`, `KeyHints`).
 - [Markdown guide](markdown.md) — streaming, GFM tables, highlighting, links,
   images, and inline HTML, in one place.
-- [`tuika-html`](../crates/tuika-html/) — a companion crate whose `Html` view
-  renders a whole HTML fragment, and whose `HtmlBlockRenderer` lays out HTML
-  blocks inside Markdown.
 - [Runnable examples](../examples/) — enter the alternate screen; quit with `q`/`esc`.
 - [README](../README.md) — the model behind the toolkit.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -10,6 +10,7 @@ This page covers all of it in one place.
 - [The two entry points](#the-two-entry-points)
 - [What renders](#what-renders)
 - [Inline HTML](#inline-html)
+- [Block HTML](#block-html)
 - [Streaming](#streaming)
 - [GFM tables](#gfm-tables)
 - [Fenced code](#fenced-code)
@@ -98,12 +99,22 @@ does not parse HTML: this is a fixed tag whitelist, so untrusted markdown cannot
 reach anything but these styles. Unbalanced tags (`<b>` with no `</b>`, a stray
 `</i>`) degrade quietly, and no tag styles past the block it opened in.
 
-Block-level HTML is a *seam* rather than a feature, for the same reason syntax
-highlighting is: an HTML parser is a dependency tuika will not carry. Attach an
-`HtmlBlockRenderer` and `<details>`, `<table>`, and the rest lay out too —
-[`tuika-html`](https://crates.io/crates/tuika-html) is the ready-made one, and
-it also ships an [`Html` view](../crates/tuika-html/#standalone) for markup that
-is not inside markdown at all.
+`<sub>`/`<sup>` transliterate only when *every* character has a Unicode form —
+digits and `+ - = ( )`. `4<sup>th</sup>` renders `4th` rather than half-shifted.
+
+## Block HTML
+
+`<div>`, `<details>`, `<table>` — block-level HTML is a *seam* rather than a
+feature, for the same reason syntax highlighting is: an HTML parser is a
+dependency tuika will not carry. Without a renderer attached the block is
+dropped, exactly as before the seam existed, so adding one is purely additive.
+
+<img src="../crates/tuika-html/examples/html_markdown/html.png" width="880" alt="HTML blocks rendered inside tuika Markdown: a details summary with a bullet list, a box-drawn table, and a quoted line with Unicode subscript and superscript">
+
+The `<details>` above, the `<ul>` nested in it, and the `<table>` are all raw
+HTML in an otherwise ordinary markdown document.
+[`tuika-html`](https://crates.io/crates/tuika-html) is the ready-made renderer;
+one value serves both block HTML and ` ```html ` fences:
 
 ```rust
 use tuika::prelude::*;
@@ -111,12 +122,27 @@ use tuika_html::HtmlRenderer;
 
 let html = HtmlRenderer::new();
 let doc = Markdown::new("<details><summary>Notes</summary>Body</details>")
-    .html_renderer(&html);
+    .html_renderer(&html)
+    .block_renderer(&html);
 # let _ = doc;
 ```
 
-`<sub>`/`<sup>` transliterate only when *every* character has a Unicode form —
-digits and `+ - = ( )`. `4<sup>th</sup>` renders `4th` rather than half-shifted.
+A streaming host attaches it once, with
+`MarkdownState::with_html_renderer(Box::new(HtmlRenderer::new()))`; a settled
+block is then laid out once per width, like a fenced block.
+
+Implementing the seam yourself means `HtmlBlockRenderer`: it receives the raw
+run, the available width, the theme, and the active `StyleSheet` — so headings,
+links, and code resolve the same roles the surrounding markdown does. Returning
+`None` drops the block.
+
+One framing detail is worth knowing, because it looks like a bug: pulldown-cmark
+ends an HTML block at a blank line, so an element whose content is separated by
+blank lines reaches the renderer as several independent blocks. Keep an
+element's markup contiguous and it lays out as one.
+
+For HTML that is not inside markdown at all, the same crate ships the
+[`Html`](components.md#html) component.
 
 ## Streaming
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -48,6 +48,17 @@
 - Its example runs as a real app rather than printing a rendered grid: styling
   is half of what the crate does, and a plain-text dump discards all of it. The
   recording is a screenshot, since the scene is settled.
+- **Documentation placement is a rule, not a habit.** HTML landed correctly and
+  was documented by accretion: the block-seam recording sat as an unlabeled hero
+  above the crate README's first section, the `Html` component was missing from
+  the gallery entirely, and the root README grew code samples and screenshots
+  that belong in a guide. Every individual edit looked reasonable; the shape was
+  wrong. [Documentation](specs/documentation.md) now states the four rules that
+  were only ever implicit — every component appears in the gallery including
+  companion-crate ones, the README indexes while guides explain, a demo sits with
+  what it demonstrates, and rustdoc carries both a compiling example and the
+  demo. Written down because the gallery's own integrity check enforces asset
+  *existence*, never placement, so nothing failed while the docs drifted.
 - Two renderers for one vocabulary need one *observable* result: the crate's
   own `<sub>`/`<sup>` were left untransliterated, so the same document rendered
   `H₂O` through markdown and `H2O` through tuika-html. Separate implementations

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -53,6 +53,55 @@ terminal UI with tuika without requiring knowledge of repository internals.
   a reader arrives at without being sent, and it may name internal machinery
   where a contributor would otherwise be asked for something unexplained.
 
+### Every public component is in the gallery
+
+`docs/components.md` carries **every** component: a name, a description, an API
+link, and its demo — including a component that ships in a companion crate,
+whose entry names the crate. A reader asking "does tuika have an X view?" must be
+able to answer it from one page, without knowing how the workspace is split
+across published crates. A component whose only documentation is its rustdoc is
+undiscoverable to someone who does not already know it exists.
+
+The gallery stays presentational: an entry describes and shows, and links to a
+guide when the surface is larger than one entry.
+
+### The README indexes; the guides explain
+
+`README.md` is the entry point, and its job is to say what exists and where to
+read about it. Detail belongs in `docs/`. A feature earns at most a short
+paragraph and a link there, plus a row in the component table — not a code
+sample, and not a screenshot per entry point. Two symptoms mean the boundary has
+slipped: an example that appears in both the README and a guide, and a README
+section that grows every time the feature does.
+
+The guides take the opposite posture: `docs/markdown.md` and its siblings are
+where examples, options, caveats, and recordings accumulate.
+
+### A demo sits with what it demonstrates
+
+A recording is evidence for a claim, so it goes immediately after the prose or
+API it depicts, with a line saying what to look at when the frame is not
+self-evident. A recording placed above the first section, or on a page whose
+subject it only partly covers, reads as chrome and is skipped — a demo nobody
+connects to a feature is as good as absent.
+
+The same rule decides which page: the seam's demo goes where the seam is
+documented, the component's where the component is.
+
+### rustdoc carries an example and a demo
+
+Every public component and every host-facing seam documents itself twice over:
+
+- **An example that compiles** — a doctest, so it cannot rot silently. For a
+  seam, the example shows an *implementation*, not only how to attach one; the
+  reader's question is what their `impl` has to do.
+- **The demo**, embedded by absolute `raw.githubusercontent.com` URL so it
+  resolves on docs.rs, plus the command that runs the example it came from.
+
+docs.rs is where most readers meet the API, and it cannot follow a repository
+relative link. Rustdoc that only names a guide leaves them with nothing to look
+at.
+
 ## Direction of links
 
 The public documentation boundary is one-way:
@@ -101,8 +150,11 @@ staged by hand. The rule is that the *scene registry is the source of truth*:
   example source instead of embedding the full recording; the recording belongs
   on the relevant guide or showcase page. These sit outside the `demo -- check`
   invariant, which is about single-component scenes and their gallery references.
-  The `tuika-mermaid` recording follows this rule and ships with that companion
-  crate so its crates.io README can show the integration it documents.
+  The `tuika-mermaid` and `tuika-html` recordings follow this rule and ship with
+  their companion crates so each crates.io README can show what it documents.
+  A crate with more than one entry point records more than one scene —
+  `tuika-html` has a demo for the markdown seam and another for its standalone
+  component, because one recording cannot answer both questions.
 - `tuika-codeformatters` follows the same example-driven rule for its language
   gallery; `scripts/gen-language-demo.sh` records the real `languages` example.
 - `scripts/gen-all-demos.sh` is the repository-wide inventory and regeneration
@@ -233,7 +285,7 @@ determines whether the packaged copy is ever read:
 
 So a member needs an `exclude` only when it has an absolute-URL asset; what every
 published member does need is a case in `tests/packaging.rs`, which drives the
-real `cargo package --list` for all three and asserts both directions.
+real `cargo package --list` for all four and asserts both directions.
 
 ### Capture toolchain
 

--- a/src/components/markdown/mod.rs
+++ b/src/components/markdown/mod.rs
@@ -107,6 +107,49 @@ pub trait FencedBlockRenderer {
 ///
 /// Note that pulldown-cmark ends an HTML block at a blank line, so one element
 /// with blank lines inside arrives as several calls.
+///
+/// With [`tuika-html`](https://crates.io/crates/tuika-html) attached, the
+/// `<details>`, its nested `<ul>`, and the `<table>` below are raw HTML inside
+/// an otherwise ordinary markdown document:
+///
+/// ![HTML blocks in markdown](https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_markdown/html.png)
+///
+/// ```
+/// use ratatui_core::text::{Line, Span};
+/// use tuika::components::HtmlBlockRenderer;
+/// use tuika::style::{StyleSheet, Theme};
+///
+/// /// A renderer that shows `<details>` as a collapsed summary line.
+/// struct Details;
+///
+/// impl HtmlBlockRenderer for Details {
+///     fn render(
+///         &self,
+///         source: &str,
+///         _width: u16,
+///         _theme: &Theme,
+///         sheet: &StyleSheet,
+///     ) -> Option<Vec<Line<'static>>> {
+///         let summary = source.split("<summary>").nth(1)?.split('<').next()?;
+///         let style = sheet.heading.to_style();
+///         Some(vec![Line::from(Span::styled(format!("▸ {summary}"), style))])
+///     }
+/// }
+///
+/// let theme = Theme::default();
+/// let sheet = StyleSheet::from_theme(&theme);
+/// let lines = tuika::components::markdown::to_lines_with(
+///     "<details><summary>Notes</summary>Body</details>",
+///     40,
+///     &theme,
+///     &sheet,
+///     tuika::highlight::CodeHighlighter::Plain,
+///     tuika::components::Renderers::new().html(&Details),
+/// );
+/// assert_eq!(lines[0].spans[0].content, "▸ Notes");
+/// ```
+///
+/// See the [markdown guide](https://github.com/everruns/tuika/blob/main/docs/markdown.md#block-html).
 pub trait HtmlBlockRenderer {
     /// Render a block of raw HTML, or return `None` to drop it.
     ///

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -108,6 +108,8 @@ impl<'a> Markdown<'a> {
     ///
     /// Without one, block HTML is dropped; the presentational *inline* tags
     /// (`<b>`, `<a>`, `<br>`, …) render either way and need no renderer.
+    ///
+    /// ![HTML blocks in markdown](https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_markdown/html.png)
     pub fn html_renderer(mut self, renderer: &'a dyn HtmlBlockRenderer) -> Self {
         self.html_renderer = Some(renderer);
         self


### PR DESCRIPTION
## What changed

HTML landed correctly across #28 and #29 and was then documented by accretion — each edit reasonable, the shape wrong:

- the block-seam recording sat as an **unlabeled hero** above the crate README's first section, so the thing it demonstrates was the one thing it was not next to;
- the `Html` component was **absent from the gallery** entirely, so a reader asking "does tuika have an HTML view?" could not answer it from the page that exists to answer that;
- the **README had grown** two code samples and two screenshots that belong in a guide.

Fixed, and then written down so it does not recur:

- **`docs/components.md` gains an `Html` entry** — description, API link, demo — so every component is in the gallery.
- **`docs/markdown.md` gains a `Block HTML` section** beside `Inline HTML`, in the TOC, carrying the detail: the recording, attaching a renderer, the streaming form, implementing the seam yourself, and the blank-line framing caveat.
- **The README drops the samples and images** for one paragraph linking to both, plus an `Html` row in the component table — reached the way every other component is.
- **Rustdoc carries its own weight**: `HtmlBlockRenderer` gains a worked implementation (a `<details>` renderer, asserted as a doctest) and the demo; `tuika-html`'s entry points gain demo embeds and the command that produces them; `to_lines` gains a second assertion showing block separation.
- **The crate README's recording** moves under the section it demonstrates, with a line saying which parts of the frame are raw HTML.

## Why

Nothing in the repo said where any of this goes, so each choice was made locally and the result did not add up. The gallery's integrity check enforces that assets *exist* and are referenced — never that they are placed where a reader will connect them to a feature — so CI stayed green throughout.

`knowledge/specs/documentation.md` now states four rules that were only ever implicit:

1. **Every public component is in the gallery**, including one that ships in a companion crate, whose entry names the crate. A component documented only in rustdoc is undiscoverable to someone who does not already know it exists.
2. **The README indexes; the guides explain.** A feature earns a short paragraph and a link, not a code sample per entry point. Two symptoms mean the boundary slipped: an example duplicated between README and guide, and a README section that grows every time the feature does.
3. **A demo sits with what it demonstrates** — immediately after the prose or API it depicts, with a line saying what to look at. A recording above the first section reads as chrome and gets skipped.
4. **Rustdoc carries a compiling example and the demo.** For a seam the example shows an *implementation*, not just how to attach one — the reader's question is what their `impl` has to do. docs.rs cannot follow a repo-relative link, so the demo is embedded by absolute URL.

`AGENTS.md` points at the spec from the gallery bullet, and the asset-split section is corrected from "all three" to four published crates.

## Before / After

**Discovering the `Html` component, before:** absent from `docs/components.md`; mentioned in one README sentence linking to a crate directory; its demo only in the crate's own README.

**After:** a gallery entry with the demo, a row in the README component table linking to it, a `Block HTML` section in the markdown guide, and rustdoc that shows both an example and the recording.

**README size:** two code samples and two `<img>` embeds removed; net −24 lines in that section.

**Evidence.** `cargo test --workspace --all-features` (14 suites, 0 failures — including the new `HtmlBlockRenderer` doctest), `fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo run --example demo -- check` (30 scenes in sync), the public-docs boundary check, and `validate_okf.py --strict --check-links`.

## Risk

- **Low.** Documentation and rustdoc only; the one code-adjacent change is a doctest that compiles and asserts.
- Relative links were re-checked in both directions: README → `docs/components.md#html`, gallery → `markdown.md#block-html` and the crate directory, guide → `components.md#html`. The gallery check passes, so no reference points at a missing asset.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

The new rustdoc example on `HtmlBlockRenderer` is a doctest, so the trait's documented usage is now compiled and asserted rather than prose. No other behavior to test — this is a docs change.

## API

No API change.

## Knowledge

`specs/documentation.md` gains the four placement rules above, the companion-crate recording rule (a crate with more than one entry point records more than one scene), and the four-crate correction. `log.md` records why: the rules were implicit, every individual edit looked reasonable, and no gate could catch the drift.

## Security

No security-relevant code changes — documentation, rustdoc, and one doctest.

## Follow-ups

Unchanged from #28, both for whoever cuts 0.7.0:

- **`HtmlBlockRenderer` returns `Vec<Line>`,** so block-HTML anchors carry no `BufferLink`s and are not clickable. Breaking to widen; the trait is on `main` but unpublished, so it is free now and impossible after the release.
- **`tuika-html`'s `tuika = "0.6.0"` requirement** must be bumped to the release carrying the seam, or the published crate resolves against a core without it.

Separately, and not from this work: `tests/pty_palette.rs` is flaky on macOS — it races the 100 ms `PROBE_TIMEOUT` in `examples/inherit.rs` from a 20 ms polling loop, and reddened `main` after #29 merged (green on re-run). Not fixed here; it wants the probe timeout to be overridable by the test rather than the test having to win the race.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HbTHk61ad4LXyS6fCCTJpK)_