### PR TITLE
fix(components): unify layout, unicode, and focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ block-HTML seam.
 
 ### Changed
 
+- `Flex` measures padded children against their actual inner box and reports
+  fixed/percent child dimensions when the container itself is auto-sized, so
+  nested measurement matches the rects assigned during rendering.
+- `TextInputState` preserves grapheme clusters during cursor motion and
+  deletion. Text input wrapping, rendering, and terminal cursor placement now
+  share terminal-cell width, fixing CJK and multi-scalar emoji alignment while
+  keeping public cursor and span coordinates as char indices.
+- `FocusRegistry` immediately falls back to the first current registration when
+  a focused id disappears from a dynamic frame, and commits that fallback at
+  the next frame boundary instead of retaining or resurrecting a stale target.
 - **Breaking**: `SelectState::selected()` now returns `Option<usize>`, and
   `SelectState::select` takes `Option<usize>`, so lists and tables can render
   without a selected row. Migrate `state.select(index)` to

--- a/docs/components.md
+++ b/docs/components.md
@@ -220,8 +220,10 @@ view! {
 Need the child rects *before* (or without) painting — to size a scroll region
 to a pane's real height, hit-test a click, or decide what fits? `Flex::solve`
 runs the same measure-then-solve pass render uses and returns one `Rect` per
-child, painting nothing. The underlying flexbox solver is also callable directly
-as `tuika::layout::solve(area, &style, &items)` for layouts built without a `Flex`.
+child, painting nothing. Padded containers measure children against the inner
+box, and a `Flex` measured as an `Auto` child honors its own fixed and percent
+dimensions. The underlying flexbox solver is also callable directly as
+`tuika::layout::solve(area, &style, &items)` for layouts built without a `Flex`.
 
 ```rust
 use tuika::prelude::*;
@@ -539,7 +541,10 @@ renders a snapshot; the host places the terminal cursor from
 `TextInputMode` (`SubmitOnEnter` by default): the other chord inserts a newline.
 Ctrl+J always inserts a newline (raw-mode LF from terminals without enhanced
 keyboard reporting). `placeholder` fills an empty buffer, and `highlights` paints
-host-computed `TextSpan` ranges over the text.
+host-computed `TextSpan` ranges over the text. Cursor and span coordinates remain
+char indices for host interoperability; movement and deletion keep grapheme
+clusters intact, and wrapping/cursor placement use terminal-cell width so CJK
+and emoji align with the rendered grid.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.TextInput.html)
 
 <img src="demos/textinput.gif" width="880" alt="TextInput demo">

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,21 @@
 # Knowledge Log
 
+## 2026-07-31
+
+- **Component geometry uses the grid's real constraints**
+
+- Padded flex containers now measure children against the same inner box they
+  later assign, and a flex container's own intrinsic measurement respects its
+  declared fixed and percent dimensions. This restores one measure/solve
+  contract instead of letting padding and nesting create a second geometry.
+- Text input now shares the crate's grapheme-aware terminal-width model for
+  wrapping, painting, and cursor placement. Its public coordinates stay as char
+  indices, while cursor motion and deletion snap to grapheme boundaries so an
+  editing operation cannot split a visible cell.
+- Per-frame focus rings discard ids that disappeared and commit the fallback at
+  the following frame boundary. Dynamic component trees therefore cannot keep
+  routing input to a stale target or resurrect it when it later returns.
+
 ## 2026-07-30
 
 - **Render-time facts stay in render-time components**

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -48,7 +48,10 @@ rather than beside it.
 size in whole cells so the solver can allocate, `render` paints into the clipped
 region it was given. Sizes are whole cells throughout — there is no sub-cell
 layout — which is why image sizing is quantized to cells rather than driven by
-pixel geometry.
+pixel geometry. A container measures children against the content box they will
+actually receive after its own padding. When a `Flex` is itself measured, its
+declared fixed and percent dimensions contribute their resolved main-axis sizes;
+the child's intrinsic size is the basis only for auto and flexible children.
 
 ## Why the `ratatui-core` seam, not the umbrella
 
@@ -118,7 +121,17 @@ tuika types, which is what lets all of it be unit-tested without a PTY.
 
 Focus is a registry of scopes rather than a flag per component: a `FocusScope`
 claims input ownership for its subtree, so a modal or overlay can take input
-without every component learning about modality.
+without every component learning about modality. At each frame boundary the
+host calls `begin_frame`, registers the complete current ring, and then queries
+or routes focus. A focused id absent from that ring falls back immediately to
+its first registration; the next frame boundary commits that fallback, so a
+temporarily removed id cannot steal focus if it later returns.
+
+Text-input positions exposed to hosts remain char indices, matching token and
+highlight spans. Editing nevertheless moves and deletes by grapheme boundary,
+and soft-wrap plus cursor placement use grapheme display width in terminal
+cells. Keeping one cell-width model across measurement, painting, and cursor
+math prevents CJK and multi-scalar emoji from drifting apart.
 
 Inline composer tokens follow the same host-agnostic rule. A `Trigger` declares
 only *where* an opening character counts (`Anywhere`/`WordStart`/`LineStart`/

--- a/src/components/flex.rs
+++ b/src/components/flex.rs
@@ -114,11 +114,61 @@ impl Flex {
         self.child(Dimension::Fixed(cells), view)
     }
 
-    fn items(&self, available: Size) -> Vec<Item> {
-        self.children
+    fn space_for_children(&self, inner_available: Size) -> u16 {
+        let axis = self.style.direction.axis();
+        let total_gap = self
+            .style
+            .gap
+            .saturating_mul(self.children.len().saturating_sub(1) as u16);
+        axis.main(inner_available).saturating_sub(total_gap)
+    }
+
+    fn child_available(&self, inner_available: Size, dimension: Dimension) -> Size {
+        let axis = self.style.direction.axis();
+        let space_for_children = self.space_for_children(inner_available);
+        let main = match dimension {
+            Dimension::Fixed(cells) => cells.min(space_for_children),
+            Dimension::Percent(percent) => {
+                ((space_for_children as u32 * percent.min(100) as u32) / 100) as u16
+            }
+            Dimension::Auto | Dimension::Flex(_) => axis.main(inner_available),
+        };
+        axis.size(main, axis.cross(inner_available))
+    }
+
+    fn items(&self, area: Rect) -> Vec<Item> {
+        let inner_available = Size::from(self.style.padding.inner(area));
+        let mut items: Vec<Item> = self
+            .children
             .iter()
-            .map(|c| Item::new(c.dimension, c.view.measure(available)))
-            .collect()
+            .map(|child| {
+                let available = self.child_available(inner_available, child.dimension);
+                Item::new(child.dimension, child.view.measure(available))
+            })
+            .collect();
+
+        // Flex widths/heights are only known after auto/fixed/percent children
+        // have consumed their space. Refine flex intrinsic cross sizes against
+        // their actual main-axis allocation, then solve once more below.
+        if !matches!(self.style.align_items, crate::layout::Align::Stretch)
+            && self
+                .children
+                .iter()
+                .any(|child| matches!(child.dimension, Dimension::Flex(_)))
+        {
+            let preliminary = solve(area, &self.style, &items);
+            let axis = self.style.direction.axis();
+            for ((child, item), rect) in self.children.iter().zip(items.iter_mut()).zip(preliminary)
+            {
+                if matches!(child.dimension, Dimension::Flex(_)) {
+                    let main = axis.main(Size::from(rect));
+                    let available = axis.size(main, axis.cross(inner_available));
+                    item.intrinsic = child.view.measure(available);
+                }
+            }
+        }
+
+        items
     }
 
     /// Resolve the child rects this container would assign inside `area`,
@@ -143,7 +193,7 @@ impl Flex {
     /// assert_eq!(rects[1], Rect::new(4, 0, 6, 1)); // grows into the leftover
     /// ```
     pub fn solve(&self, area: Rect) -> Vec<Rect> {
-        solve(area, &self.style, &self.items(Size::from(area)))
+        solve(area, &self.style, &self.items(area))
     }
 }
 
@@ -157,11 +207,23 @@ impl View for Flex {
             .padding
             .inner(Rect::new(0, 0, available.width, available.height));
         let inner_avail = Size::from(inner);
+        let space_for_children = self.space_for_children(inner_avail);
         let mut main_total: u16 = 0;
         let mut cross_max: u16 = 0;
         for (i, c) in self.children.iter().enumerate() {
-            let sz = c.view.measure(inner_avail);
-            main_total = main_total.saturating_add(axis.main(sz));
+            let sz = c
+                .view
+                .measure(self.child_available(inner_avail, c.dimension));
+            let intrinsic_main = axis.main(sz);
+            let resolved_main = match c.dimension {
+                Dimension::Auto | Dimension::Flex(_) => intrinsic_main,
+                Dimension::Fixed(cells) => cells,
+                Dimension::Percent(percent) => {
+                    ((space_for_children as u32 * percent.min(100) as u32) / 100) as u16
+                }
+            }
+            .min(space_for_children);
+            main_total = main_total.saturating_add(resolved_main);
             if i > 0 {
                 main_total = main_total.saturating_add(self.style.gap);
             }
@@ -174,6 +236,7 @@ impl View for Flex {
                 .saturating_add(self.style.padding.horizontal()),
             content.height.saturating_add(self.style.padding.vertical()),
         )
+        .clamp_to(available)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -193,9 +256,20 @@ impl View for Flex {
 mod tests {
     use super::*;
     use crate::components::Text;
+    use crate::geometry::Padding;
     use crate::probe::RectProbe;
     use crate::style::Theme;
     use crate::view::element;
+
+    struct WidthSensitive;
+
+    impl View for WidthSensitive {
+        fn measure(&self, available: Size) -> Size {
+            Size::new(available.width, if available.width < 10 { 2 } else { 1 })
+        }
+
+        fn render(&self, _area: Rect, _surface: &mut Surface, _ctx: &RenderCtx) {}
+    }
 
     #[test]
     fn solve_matches_the_rects_render_paints_into() {
@@ -226,6 +300,42 @@ mod tests {
     fn solve_of_empty_container_is_empty() {
         let flex = Flex::row();
         assert!(flex.solve(Rect::new(0, 0, 10, 3)).is_empty());
+    }
+
+    #[test]
+    fn fixed_child_is_measured_at_its_declared_main_size() {
+        let flex = Flex::row()
+            .align(crate::layout::Align::Start)
+            .fixed(5, element(WidthSensitive));
+
+        assert_eq!(flex.measure(Size::new(10, 4)), Size::new(5, 2));
+        assert_eq!(flex.solve(Rect::new(0, 0, 10, 4))[0], Rect::new(0, 0, 5, 2));
+    }
+
+    #[test]
+    fn measure_resolves_declared_percent_main_size() {
+        let flex = Flex::row().child(Dimension::Percent(50), element(Text::raw("x")));
+
+        assert_eq!(flex.measure(Size::new(10, 2)), Size::new(5, 1));
+    }
+
+    #[test]
+    fn solve_measures_children_against_the_padded_inner_box() {
+        let flex = Flex::column()
+            .padding(Padding::symmetric(1, 0))
+            .auto(element(WidthSensitive));
+
+        assert_eq!(flex.solve(Rect::new(0, 0, 10, 4))[0].height, 2);
+    }
+
+    #[test]
+    fn non_stretch_flex_child_is_remeasured_at_its_allocated_main_size() {
+        let flex = Flex::row()
+            .align(crate::layout::Align::Start)
+            .fixed(5, element(Text::raw("fixed")))
+            .grow(1, element(WidthSensitive));
+
+        assert_eq!(flex.solve(Rect::new(0, 0, 10, 4))[1], Rect::new(5, 0, 5, 2));
     }
 
     #[test]

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -7,7 +7,8 @@
 //! and renders. The view is word-soft-wrapped to the render width — a logical
 //! line longer than the area breaks at the last space that fits (hard-breaking a
 //! word longer than the width), and a line that fills the width exactly wraps the
-//! cursor onto a fresh row, like a real editor.
+//! cursor onto a fresh row, like a real editor. Wrapping and cursor placement
+//! count terminal cells, while editing moves and deletes whole grapheme clusters.
 //!
 //! It is a *rendering + edit model*, not a terminal: the host reads
 //! [`TextInputState::cursor_screen`] after layout and calls the backend's
@@ -16,12 +17,13 @@
 
 use ratatui_core::layout::Rect;
 use ratatui_core::style::Style;
-use unicode_width::UnicodeWidthChar;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::event::{Event, KeyCode};
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
+use crate::width::grapheme_cols;
 
 /// The editable text and cursor of a [`TextInput`].
 #[derive(Clone, Debug)]
@@ -311,11 +313,12 @@ impl TextInputState {
         self.mode = mode;
     }
 
-    /// Move the cursor to `(row, col)`, clamped into the buffer. Lets a host
-    /// mirror an external editor's cursor into this state for rendering.
+    /// Move the cursor to `(row, col)`, clamped into the buffer and to the
+    /// preceding grapheme boundary. Lets a host mirror an external editor's
+    /// cursor into this state for rendering.
     pub fn set_cursor(&mut self, row: usize, col: usize) {
         self.row = row.min(self.lines.len().saturating_sub(1));
-        self.col = col.min(self.lines[self.row].chars().count());
+        self.col = grapheme_boundary_at_or_before(&self.lines[self.row], col);
     }
 
     fn row_chars(&self, row: usize) -> Vec<char> {
@@ -358,12 +361,13 @@ impl TextInputState {
         self.col = 0;
     }
 
-    /// Delete the char before the cursor (joining lines at column 0).
+    /// Delete the grapheme before the cursor (joining lines at column 0).
     pub fn backspace(&mut self) {
         if self.col > 0 {
             let mut chars = self.row_chars(self.row);
-            chars.remove(self.col - 1);
-            self.col -= 1;
+            let start = previous_grapheme_boundary(&self.lines[self.row], self.col);
+            chars.drain(start..self.col);
+            self.col = start;
             self.set_row(self.row, chars);
         } else if self.row > 0 {
             let cur = self.lines.remove(self.row);
@@ -373,11 +377,12 @@ impl TextInputState {
         }
     }
 
-    /// Delete the char at the cursor (joining the next line at line end).
+    /// Delete the grapheme at the cursor (joining the next line at line end).
     pub fn delete(&mut self) {
         let mut chars = self.row_chars(self.row);
         if self.col < chars.len() {
-            chars.remove(self.col);
+            let end = next_grapheme_boundary(&self.lines[self.row], self.col);
+            chars.drain(self.col..end);
             self.set_row(self.row, chars);
         } else if self.row + 1 < self.lines.len() {
             let next = self.lines.remove(self.row + 1);
@@ -386,24 +391,24 @@ impl TextInputState {
     }
 
     fn clamp_col(&mut self) {
-        self.col = self.col.min(self.lines[self.row].chars().count());
+        self.col = grapheme_boundary_at_or_before(&self.lines[self.row], self.col);
     }
 
-    /// Move one char left, wrapping to the end of the previous line.
+    /// Move one grapheme left, wrapping to the end of the previous line.
     pub fn move_left(&mut self) {
         if self.col > 0 {
-            self.col -= 1;
+            self.col = previous_grapheme_boundary(&self.lines[self.row], self.col);
         } else if self.row > 0 {
             self.row -= 1;
             self.col = self.lines[self.row].chars().count();
         }
     }
 
-    /// Move one char right, wrapping to the start of the next line.
+    /// Move one grapheme right, wrapping to the start of the next line.
     pub fn move_right(&mut self) {
         let len = self.lines[self.row].chars().count();
         if self.col < len {
-            self.col += 1;
+            self.col = next_grapheme_boundary(&self.lines[self.row], self.col);
         } else if self.row + 1 < self.lines.len() {
             self.row += 1;
             self.col = 0;
@@ -783,12 +788,59 @@ impl TextInputState {
     }
 }
 
-/// One wrapped visual row: which logical line it came from, the char index in
-/// that line where it starts, and its chars.
-struct VisualRow {
+/// Char-index boundaries between grapheme clusters, including 0 and line end.
+fn grapheme_boundaries(line: &str) -> Vec<usize> {
+    let mut boundaries = Vec::with_capacity(line.graphemes(true).count() + 1);
+    boundaries.push(0);
+    let mut col = 0;
+    for grapheme in line.graphemes(true) {
+        col += grapheme.chars().count();
+        boundaries.push(col);
+    }
+    boundaries
+}
+
+fn grapheme_boundary_at_or_before(line: &str, col: usize) -> usize {
+    let col = col.min(line.chars().count());
+    grapheme_boundaries(line)
+        .into_iter()
+        .take_while(|boundary| *boundary <= col)
+        .last()
+        .unwrap_or(0)
+}
+
+fn previous_grapheme_boundary(line: &str, col: usize) -> usize {
+    grapheme_boundaries(line)
+        .into_iter()
+        .take_while(|boundary| *boundary < col)
+        .last()
+        .unwrap_or(0)
+}
+
+fn next_grapheme_boundary(line: &str, col: usize) -> usize {
+    grapheme_boundaries(line)
+        .into_iter()
+        .find(|boundary| *boundary > col)
+        .unwrap_or_else(|| line.chars().count())
+}
+
+/// One terminal grapheme cell and its logical char-index range.
+#[derive(Clone, Copy)]
+struct VisualCell<'a> {
+    text: &'a str,
+    start: usize,
+    end: usize,
+    width: u16,
+}
+
+/// One wrapped visual row: its logical line, char-index range, grapheme cells,
+/// and measured terminal-cell width.
+struct VisualRow<'a> {
     logical: usize,
     start: usize,
-    chars: Vec<char>,
+    end: usize,
+    cells: Vec<VisualCell<'a>>,
+    width: u16,
 }
 
 /// The cursor's visual `(row, col)` for `lines` with the logical cursor at
@@ -796,7 +848,7 @@ struct VisualRow {
 /// rendered scroll offset and the placed cursor always agree with what's drawn.
 fn visual_cursor_at(lines: &[String], row: usize, col: usize, width: u16) -> (u16, u16) {
     let rows = wrap_visual_rows(lines, width);
-    let mut last_on_line: Option<(usize, usize)> = None; // (visual index, start col)
+    let mut last_on_line: Option<(usize, &VisualRow)> = None;
     for (vi, vr) in rows.iter().enumerate() {
         if vr.logical > row {
             break;
@@ -804,67 +856,109 @@ fn visual_cursor_at(lines: &[String], row: usize, col: usize, width: u16) -> (u1
         if vr.logical != row {
             continue;
         }
-        let end = vr.start + vr.chars.len();
-        last_on_line = Some((vi, vr.start));
+        last_on_line = Some((vi, vr));
         // A col at this row's end belongs to the next row's start, so only claim
         // it here when it falls strictly inside — except the line's last row,
         // handled below.
-        if col >= vr.start && col < end {
-            return (vi as u16, (col - vr.start) as u16);
+        if col >= vr.start && col < vr.end {
+            let visual_col = vr
+                .cells
+                .iter()
+                .take_while(|cell| cell.end <= col)
+                .map(|cell| cell.width)
+                .fold(0, u16::saturating_add);
+            return (vi as u16, visual_col);
         }
     }
     // Cursor at the end of the logical line: rest at the end of its last row
     // (which is an empty trailing row when the text filled the width exactly).
-    if let Some((vi, start)) = last_on_line {
-        return (vi as u16, col.saturating_sub(start) as u16);
+    if let Some((vi, vr)) = last_on_line {
+        return (vi as u16, vr.width);
     }
     (rows.len().saturating_sub(1) as u16, 0)
 }
 
 /// Word-soft-wrap `lines` to `width`: each logical line breaks at the last space
-/// that fits, falling back to a hard char-break for a word longer than `width`.
+/// that fits, falling back to a hard grapheme break for a word longer than
+/// `width`. Width is measured in terminal cells, not Unicode scalar count.
 /// A line whose final row fills the width exactly emits a trailing empty row so
 /// the cursor can rest on a fresh line. Shared by [`visual_cursor_at`] (cursor
 /// math) and [`TextInput`] (rendering) so both wrap identically.
-fn wrap_visual_rows(lines: &[String], width: u16) -> Vec<VisualRow> {
-    let width = width.max(1) as usize;
+fn wrap_visual_rows<'a>(lines: &'a [String], width: u16) -> Vec<VisualRow<'a>> {
+    let width = width.max(1);
     let mut rows = Vec::new();
     for (r, line) in lines.iter().enumerate() {
-        let chars: Vec<char> = line.chars().collect();
-        if chars.is_empty() {
+        let mut char_col = 0;
+        let cells: Vec<VisualCell<'a>> = line
+            .graphemes(true)
+            .map(|grapheme| {
+                let start = char_col;
+                char_col += grapheme.chars().count();
+                VisualCell {
+                    text: grapheme,
+                    start,
+                    end: char_col,
+                    width: grapheme_cols(grapheme),
+                }
+            })
+            .collect();
+        if cells.is_empty() {
             rows.push(VisualRow {
                 logical: r,
                 start: 0,
-                chars: Vec::new(),
+                end: 0,
+                cells: Vec::new(),
+                width: 0,
             });
             continue;
         }
         let mut start = 0;
         let mut last_filled = false;
-        while start < chars.len() {
-            let remaining = chars.len() - start;
-            let end = if remaining <= width {
-                chars.len()
+        while start < cells.len() {
+            let mut hard_end = start;
+            let mut hard_width = 0u16;
+            while hard_end < cells.len() {
+                let next_width = hard_width.saturating_add(cells[hard_end].width);
+                if hard_end > start && next_width > width {
+                    break;
+                }
+                hard_width = next_width;
+                hard_end += 1;
+                if hard_width >= width {
+                    break;
+                }
+            }
+
+            let end = if hard_end == cells.len() {
+                hard_end
             } else {
-                // Break after the last space within the width window; if the
-                // window holds no space, hard-break at the width boundary.
-                let hard = start + width;
-                let brk = (start + 1..hard).rev().find(|&i| chars[i] == ' ');
-                brk.map(|i| i + 1).unwrap_or(hard)
+                (start + 1..hard_end)
+                    .rev()
+                    .find(|&i| cells[i].text.chars().all(char::is_whitespace))
+                    .map(|i| i + 1)
+                    .unwrap_or(hard_end)
             };
-            last_filled = end - start == width;
+            let row_width = cells[start..end]
+                .iter()
+                .map(|cell| cell.width)
+                .fold(0, u16::saturating_add);
+            last_filled = row_width == width;
             rows.push(VisualRow {
                 logical: r,
-                start,
-                chars: chars[start..end].to_vec(),
+                start: cells[start].start,
+                end: cells[end - 1].end,
+                cells: cells[start..end].to_vec(),
+                width: row_width,
             });
             start = end;
         }
         if last_filled {
             rows.push(VisualRow {
                 logical: r,
-                start: chars.len(),
-                chars: Vec::new(),
+                start: char_col,
+                end: char_col,
+                cells: Vec::new(),
+                width: 0,
             });
         }
     }
@@ -992,13 +1086,12 @@ impl View for TextInput {
                 break;
             }
             let mut x = area.x;
-            for (n, ch) in vr.chars.into_iter().enumerate() {
-                let w = UnicodeWidthChar::width(ch).unwrap_or(0) as u16;
-                if w == 0 || x >= area.right() {
+            for cell in vr.cells {
+                if cell.width == 0 || x >= area.right() {
                     continue;
                 }
-                surface.set(x, y, ch, self.style_at(vr.logical, vr.start + n));
-                x = x.saturating_add(w);
+                surface.set_string(x, y, cell.text, self.style_at(vr.logical, cell.start));
+                x = x.saturating_add(cell.width);
             }
         }
     }
@@ -1278,6 +1371,46 @@ mod tests {
         let out = render_view_rows(&TextInput::new(&state), 4, 2);
         assert_eq!(out[0], "abcd");
         assert_eq!(out[1], "ef");
+    }
+
+    #[test]
+    fn text_input_wraps_and_places_the_cursor_by_terminal_cells() {
+        let state = TextInputState::from_text("界界界");
+
+        assert_eq!(state.visual_height(4), 2);
+        assert_eq!(state.cursor_screen(Rect::new(0, 0, 4, 2)), (2, 1));
+        assert_eq!(
+            render_view_rows(&TextInput::new(&state), 4, 2),
+            vec!["界 界", "界"]
+        );
+
+        let emoji = TextInputState::from_text("👩‍💻x");
+        assert_eq!(
+            render_view_rows(&TextInput::new(&emoji), 3, 2),
+            vec!["👩‍💻 x", ""]
+        );
+    }
+
+    #[test]
+    fn text_input_moves_and_deletes_whole_graphemes() {
+        let mut state = TextInputState::from_text("a\u{301}b");
+
+        state.move_left();
+        assert_eq!(state.cursor(), (0, 2));
+        state.move_left();
+        assert_eq!(state.cursor(), (0, 0));
+
+        state.set_cursor(0, 2);
+        state.backspace();
+        assert_eq!(state.text(), "b");
+        assert_eq!(state.cursor(), (0, 0));
+
+        let mut state = TextInputState::from_text("👩‍💻x");
+        state.move_left();
+        assert_eq!(state.cursor(), (0, 3));
+        state.backspace();
+        assert_eq!(state.text(), "x");
+        assert_eq!(state.cursor(), (0, 0));
     }
 
     #[test]

--- a/src/focus.rs
+++ b/src/focus.rs
@@ -24,8 +24,18 @@ impl FocusRegistry {
         Self::default()
     }
 
-    /// Begin a frame: clear the per-frame focus ring. Registrations follow.
+    /// Begin a frame: reconcile focus against the preceding frame, then clear
+    /// the per-frame focus ring. Registrations for the new frame follow.
     pub fn begin_frame(&mut self) {
+        if self.order.is_empty() {
+            self.focused = None;
+        } else if !self
+            .focused
+            .as_ref()
+            .is_some_and(|focused| self.order.contains(focused))
+        {
+            self.focused = self.order.first().cloned();
+        }
         self.order.clear();
     }
 
@@ -48,9 +58,18 @@ impl FocusRegistry {
         self.owner = None;
     }
 
+    fn ring_focus(&self) -> Option<&str> {
+        self.focused
+            .as_deref()
+            .filter(|focused| self.order.iter().any(|id| id == focused))
+            .or_else(|| self.order.first().map(String::as_str))
+    }
+
     /// The id that should receive input: the owner if any, else the focused id.
+    /// If a focused region disappeared this frame, the first current
+    /// registration is used immediately.
     pub fn active(&self) -> Option<&str> {
-        self.owner.as_deref().or(self.focused.as_deref())
+        self.owner.as_deref().or_else(|| self.ring_focus())
     }
 
     /// Whether `id` is the active input target.
@@ -60,7 +79,7 @@ impl FocusRegistry {
 
     /// Whether `id` holds focus in the base ring (ignores overlay ownership).
     pub fn is_focused(&self, id: &str) -> bool {
-        self.focused.as_deref() == Some(id)
+        self.ring_focus() == Some(id)
     }
 
     fn advance(&mut self, delta: isize) {
@@ -69,9 +88,8 @@ impl FocusRegistry {
         }
         let len = self.order.len() as isize;
         let current = self
-            .focused
-            .as_ref()
-            .and_then(|f| self.order.iter().position(|id| id == f))
+            .ring_focus()
+            .and_then(|focused| self.order.iter().position(|id| id == focused))
             .map(|p| p as isize)
             .unwrap_or(0);
         let next = ((current + delta) % len + len) % len;
@@ -137,5 +155,25 @@ mod tests {
         assert_eq!(f.handle(&tab), EventFlow::Ignored);
         f.clear_owner();
         assert!(f.is_active("composer"));
+    }
+
+    #[test]
+    fn removed_focus_target_falls_back_to_the_current_ring() {
+        let mut f = FocusRegistry::new();
+        f.begin_frame();
+        f.register("old");
+        assert_eq!(f.active(), Some("old"));
+
+        f.begin_frame();
+        f.register("new");
+        assert_eq!(f.active(), Some("new"));
+        assert!(f.is_focused("new"));
+
+        // Starting another frame commits the fallback, so reintroducing the old
+        // target cannot steal focus back.
+        f.begin_frame();
+        f.register("old");
+        f.register("new");
+        assert_eq!(f.active(), Some("new"));
     }
 }


### PR DESCRIPTION
## What changed

Flex now measures children against the constraints they are actually assigned: padding is removed before child measurement, fixed and percent dimensions participate in intrinsic container size, and non-stretch flex children are refined at their allocated main-axis size.

TextInput now uses the shared grapheme-aware cell-width model for wrapping, painting, and cursor placement. Cursor motion and deletion preserve combining and ZWJ clusters while public coordinates remain char indices.

FocusRegistry now rejects focused ids absent from the current frame ring, falls back immediately, and commits that fallback at the next frame boundary.

## Why

The previous contracts diverged inside nested and dynamic component trees. Width-sensitive children could be measured at a width they never received, wide text wrapped by scalar count while painting by cell width, and removed focus targets continued receiving input.

## Before / After

Before:
- A fixed 5-cell child could report a 1-cell intrinsic width, and padded or non-stretch children could report the wrong cross size.
- The text 界界界 at width 4 reported one row with the cursor on row 0 even though rendering needs two rows.
- Replacing the only registered focus id left the removed id active.

After:
- Dedicated regressions pin fixed, percent, padded, and non-stretch flex constraints.
- CJK and multi-scalar emoji render, wrap, navigate, delete, and place the terminal cursor by one grapheme/cell model.
- Dynamic focus fallback is immediate and stable if a removed id returns later.
- Flex and TextInput demo dumps remain visually stable; demo integrity reports 30 scenes in sync.

## Risk

- Medium
- Flex can intentionally allocate a different auto cross size where the old result came from the wrong width.
- Text cursor movement now advances by visible grapheme rather than individual scalar.
- No public signatures were added, removed, or renamed.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- python3 scripts/validate_okf.py knowledge --check-links
- cargo run --example demo -- check
- Flex and TextInput demo dumps

## Knowledge

Updated Rendering Architecture and the knowledge log. Updated the public component guide and changelog for the refined behavior.

## Security

Reviewed TM-CLIP, TM-STATE, and TM-PARSE. Geometry remains saturating and clipped; wide-cell rendering is covered at the buffer boundary; focus state cannot route to an id outside the current ring; Unicode processing is linear over bounded in-memory text operations. No terminal escape, secret, unsafe-code, or dependency surface changed.

## Follow-ups

Broader pre-1.0 redesigns remain internal planning rather than public GitHub issues, per maintainer convention.