### PR TITLE
chore(process): keep internal work out of issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ repository, so keep it short, factual, and project-specific.
 - Keep changes small, PR-sized, testable, and runnable locally.
 - For bug fixes, write or update a failing test before the fix when practical.
 - Important decisions belong as concise comments near the relevant code, not in scratch docs.
+- Never create GitHub issues for follow-ups discovered during internal or
+  maintainer work. Keep them in the current PR's **Follow-ups**, durable
+  knowledge, or local planning. Create an issue only when a maintainer
+  explicitly asks; otherwise update an existing externally reported issue.
 - tuika is pre-1.0, but it is a **published library**: every `pub` item is API. A
   breaking change is allowed in a minor release, and must be called out in the
   changelog rather than slipped in.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -16,6 +16,14 @@
   the following frame boundary. Dynamic component trees therefore cannot keep
   routing input to a stale target or resurrect it when it later returns.
 
+- **Internal follow-ups stay out of GitHub issues**
+
+- Work discovered during maintainer or agent tasks stays in the current PR,
+  durable knowledge, or local planning. A new GitHub issue requires an explicit
+  maintainer request; existing externally reported issues may still be updated.
+  This keeps the public tracker for intentional external coordination rather
+  than exposing internal scratch queues.
+
 ## 2026-07-30
 
 - **Render-time facts stay in render-time components**

--- a/knowledge/processes/shipping.md
+++ b/knowledge/processes/shipping.md
@@ -73,7 +73,10 @@ suggestions.
    unless the change is docs-only or config-only with explicit justification.
 9. **Follow-ups surfaced.** TODOs, partial fixes, declined suggestions, missed
    edges, and spec/doc drift are explicitly listed under **Follow-ups** in the PR
-   body (or `"No follow-ups."` if none).
+   body (or `"No follow-ups."` if none). Internally discovered follow-ups do not
+   become GitHub issues: keep them in the PR, durable knowledge, or local
+   planning. Create a new issue only when a maintainer explicitly requests it;
+   otherwise update an existing externally reported issue when one applies.
 10. **Safe landing.** CI is green before the change lands, and the change lands
     as a **single commit** — squash-merged from a PR, or squashed locally before
     a direct push. A branch's working history is the author's; `main`'s history


### PR DESCRIPTION
## What changed

Repository guidance now forbids creating GitHub issues for follow-ups discovered during internal or maintainer work. Those follow-ups stay in the current PR, durable knowledge, or local planning. A new issue requires an explicit maintainer request; existing externally reported issues may still be updated.

The mistaken internal issues from the component audit were deleted, and stale references were removed from PR #41.

## Why

The public issue tracker is for intentional external coordination, not an internal scratch queue.

## Before / After

Before: the shipping process required follow-ups in a PR but did not explicitly prohibit creating public issues for internal work.

After: both the always-read agent guidance and durable shipping process state the convention explicitly.

## Risk

- Low
- Process and documentation only; no runtime behavior or public Rust API changes.

## Checklist

- [x] Tests added or updated — not applicable, docs/process only
- [x] Backward compatibility considered — no runtime change
- [x] Knowledge concepts updated

## Knowledge

Updated the Shipping process and knowledge log.

## Security

No code, dependency, secret, parser, terminal, or runtime state changes.

## Follow-ups

No follow-ups.