### PR TITLE
feat(runner): add stateful dirty updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ block-HTML seam.
 - `FocusRegistry` immediately falls back to the first current registration when
   a focused id disappears from a dynamic frame, and commits that fallback at
   the next frame boundary instead of retaining or resurrecting a stale target.
+- **Breaking:** synchronous `Runner::run` and `run_with_backend` now mirror the
+  state/view/update shape of `AsyncRunner`: pass `&mut State`, render through
+  `view(&State, frame)`, and handle `Signal` in `update(&mut State, Signal)`.
+  Updates return `UpdateResult::{Clean, Dirty, Exit}` instead of
+  `ControlFlow<()>`; ticks no longer repaint unless the update is dirty or a
+  `RedrawHandle` fires.
+
 - **Breaking**: `SelectState::selected()` now returns `Option<usize>`, and
   `SelectState::select` takes `Option<usize>`, so lists and tables can render
   without a selected row. Migrate `state.select(index)` to

--- a/README.md
+++ b/README.md
@@ -578,24 +578,16 @@ intentionally own raw mode, keyboard modes, and cursor visibility themselves.
 
 `Runner` is an optional synchronous event loop for dashboards and small tools.
 It owns `TerminalSession`, frame scheduling, Crossterm event translation, and
-data-driven redraw checks.
-
-`AsyncRunner` (behind `features = ["async"]`) is the same loop for applications
-that already have a Tokio runtime — anything doing network or disk I/O. It ties
-`TerminalSession`, `paint`, and `translate_event` to crossterm's async
-`EventStream` and a tick timer in one `tokio::select!`, so the host keeps a
-single event loop instead of bolting `spawn_blocking` + a shared `Live` +
-`Notify` + a stop flag onto the synchronous `Runner` to feed it. The loop threads
-one owned `state` value through a `view` closure (`&state` → the frame) and an
-`async` `update` closure (`&mut state` on each `Signal` — a tick or an event —
-and it may `.await`):
+state-driven redraws. It threads one state value through a pure `view(&State)`
+and an `update(&mut State, Signal)` function. The initial frame is painted once;
+a tick or input only repaints when update returns `UpdateResult::Dirty`, while a
+`RedrawHandle` can wake the loop from another thread:
 
 ```rust,ignore
-use std::ops::ControlFlow;
 use std::time::Duration;
 use tuika::prelude::*;
 
-let runner = AsyncRunner::new(RunnerConfig {
+let runner = Runner::new(RunnerConfig {
     tick_rate: Duration::from_secs(2),
     ..RunnerConfig::default()
 });
@@ -604,19 +596,27 @@ runner.run(
     &Theme::default(),
     &mut stats,
     |stats, _frame| element(Text::raw(stats.summary())),
-    async |stats, signal| match signal {
-        Signal::Tick => { stats.ingest(fetch(&url).await?); ControlFlow::Continue(()) }
+    |stats, signal| match signal {
+        Signal::Tick if stats.refresh() => UpdateResult::Dirty,
         Signal::Event(Event::Key(k)) if k.plain() && k.code == KeyCode::Char('q') =>
-            ControlFlow::Break(()),
-        _ => ControlFlow::Continue(()),
+            UpdateResult::Exit,
+        _ => UpdateResult::Clean,
     },
-).await?;
+)?;
 ```
+
+`AsyncRunner` (behind `features = ["async"]`) uses the same state/view/signal
+model for applications that already have a Tokio runtime — anything doing
+network or disk I/O — and lets its update closure `.await`. It ties
+`TerminalSession`, `paint`, and `translate_event` to crossterm's async
+`EventStream` and a tick timer in one `tokio::select!`, so the host keeps a
+single event loop. Its update closure returns `ControlFlow<()>`; asynchronous
+updates currently repaint after every delivered signal.
 
 Enabling `async` adds Tokio (timer + `select!`) and crossterm's `event-stream`
 feature; it stays off by default so sync-only hosts pull in no runtime. The
-[`async_dashboard`](examples/async_dashboard.rs) example is the runnable
-counterpart to `ratatui_dashboard` with no shared state at all.
+[`async_dashboard`](examples/async_dashboard.rs) example demonstrates that
+variant with no shared state at all.
 
 ## Native terminal progress
 

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -10,8 +10,6 @@
 //! bold header — and a plain-text dump throws every bit of that away.
 //! `scripts/gen-html-demo.sh` records this same binary.
 
-use std::ops::ControlFlow;
-
 use tuika::components::Markdown;
 use tuika::prelude::*;
 use tuika::testing::{grid, render};
@@ -61,12 +59,15 @@ fn main() -> std::io::Result<()> {
     let runner = Runner::new(RunnerConfig::default());
     runner.run(
         &theme,
-        |_frame| scene(),
-        |event| match event {
-            Event::Key(key) if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) => {
-                ControlFlow::Break(())
+        &mut (),
+        |(), _frame| scene(),
+        |(), signal| match signal {
+            Signal::Event(Event::Key(key))
+                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+            {
+                UpdateResult::Exit
             }
-            _ => ControlFlow::Continue(()),
+            _ => UpdateResult::Clean,
         },
     )
 }

--- a/crates/tuika-html/examples/html_view/main.rs
+++ b/crates/tuika-html/examples/html_view/main.rs
@@ -10,8 +10,6 @@
 //! anywhere, `Html` placed in a layout exactly like `Markdown` would be, fitting
 //! its content to whatever width the pane gives it.
 
-use std::ops::ControlFlow;
-
 use tuika::prelude::*;
 use tuika::testing::{grid, render};
 use tuika_html::Html;
@@ -44,12 +42,15 @@ fn main() -> std::io::Result<()> {
     let runner = Runner::new(RunnerConfig::default());
     runner.run(
         &theme,
-        |_frame| scene(),
-        |event| match event {
-            Event::Key(key) if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) => {
-                ControlFlow::Break(())
+        &mut (),
+        |(), _frame| scene(),
+        |(), signal| match signal {
+            Signal::Event(Event::Key(key))
+                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+            {
+                UpdateResult::Exit
             }
-            _ => ControlFlow::Continue(()),
+            _ => UpdateResult::Clean,
         },
     )
 }

--- a/examples/inherit.rs
+++ b/examples/inherit.rs
@@ -25,7 +25,6 @@
 //! ```
 
 use std::io;
-use std::ops::ControlFlow;
 use std::time::Duration;
 
 use ratatui::style::{Color, Style};
@@ -33,7 +32,9 @@ use ratatui::text::{Line, Span};
 
 use tuika::components::{Flex, Rule, Text};
 use tuika::term::capabilities::Capabilities;
-use tuika::{Event, KeyCode, Padding, Runner, RunnerConfig, Theme, themes, view};
+use tuika::{
+    Event, KeyCode, Padding, Runner, RunnerConfig, Signal, Theme, UpdateResult, themes, view,
+};
 
 /// How long to wait for the terminal to answer. A real tty replies to the
 /// Device Attributes fence immediately, so this is only reached on a terminal
@@ -161,12 +162,15 @@ fn main() -> io::Result<()> {
     let runner = Runner::new(RunnerConfig::default());
     runner.run(
         &theme,
-        |_frame| build(&theme, source),
-        |event| match event {
-            Event::Key(key) if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) => {
-                ControlFlow::Break(())
+        &mut (),
+        |(), _frame| build(&theme, source),
+        |(), signal| match signal {
+            Signal::Event(Event::Key(key))
+                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+            {
+                UpdateResult::Exit
             }
-            _ => ControlFlow::Continue(()),
+            _ => UpdateResult::Clean,
         },
     )
 }

--- a/examples/ratatui_dashboard.rs
+++ b/examples/ratatui_dashboard.rs
@@ -4,7 +4,6 @@
 //! terminal runner, and semantic key hints. Run with:
 //! `cargo run --example ratatui_dashboard`.
 
-use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
@@ -117,14 +116,15 @@ fn main() -> std::io::Result<()> {
     let live_view = metrics.clone();
     let result = runner.run(
         &Theme::default(),
-        move |_| element(LiveView::new(live_view.clone(), dashboard)),
-        |event| match event {
-            Event::Key(key)
+        &mut (),
+        move |(), _frame| element(LiveView::new(live_view.clone(), dashboard)),
+        |(), signal| match signal {
+            Signal::Event(Event::Key(key))
                 if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
             {
-                ControlFlow::Break(())
+                UpdateResult::Exit
             }
-            _ => ControlFlow::Continue(()),
+            _ => UpdateResult::Clean,
         },
     );
 

--- a/examples/split_footer.rs
+++ b/examples/split_footer.rs
@@ -14,7 +14,6 @@
 //! cargo run --example split_footer -- --mouse # the footer captures it instead
 //! ```
 
-use std::ops::ControlFlow;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
@@ -134,28 +133,30 @@ fn main() -> std::io::Result<()> {
     });
 
     let view_status = status.clone();
+    let mut state = ();
     let result = runner.run(
         &theme,
-        move |frame| {
+        &mut state,
+        move |(), frame| {
             element(LiveView::new(view_status.clone(), move |status| {
                 footer(status, frame, &theme)
             }))
         },
-        |event| match event {
-            Event::Key(key) if key.plain() => match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => ControlFlow::Break(()),
+        |(), signal| match signal {
+            Signal::Event(Event::Key(key)) if key.plain() => match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
                 KeyCode::Char('p') => {
                     status.update(|status| status.paused = !status.paused);
-                    ControlFlow::Continue(())
+                    UpdateResult::Clean
                 }
                 KeyCode::Char(' ') | KeyCode::Enter => {
                     publish(&scrollback, seq.fetch_add(1, Ordering::AcqRel), &theme);
                     status.update(|status| status.published += 1);
-                    ControlFlow::Continue(())
+                    UpdateResult::Clean
                 }
-                _ => ControlFlow::Continue(()),
+                _ => UpdateResult::Clean,
             },
-            _ => ControlFlow::Continue(()),
+            _ => UpdateResult::Clean,
         },
     );
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -15,6 +15,12 @@
 - Per-frame focus rings discard ids that disappeared and commit the fallback at
   the following frame boundary. Dynamic component trees therefore cannot keep
   routing input to a stale target or resurrect it when it later returns.
+- **Synchronous runner state and invalidation model**
+  - `Runner` now mirrors the asynchronous runner's owned-state split: immutable
+    view construction and mutable signal updates.
+  - Repainting is explicit (`UpdateResult::Dirty`) or externally requested;
+    periodic ticks alone no longer repaint. This keeps rendering pure and makes
+    idle CPU/terminal work proportional to actual changes.
 
 - **Internal follow-ups stay out of GitHub issues**
 

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -43,6 +43,10 @@ rather than beside it.
 - **The host owns the terminal**: the screen mode (alternate screen or a split
   footer over live scrollback — see [screen-modes.md](./screen-modes.md)), raw
   mode, mouse capture, input translation, and frame compositing.
+- **The synchronous runner owns application state directly**: rendering receives
+  `&State`, updates receive `&mut State` plus a tick or input signal, and repaint
+  is an explicit dirty result or an external redraw request. Rendering stays
+  pure, and idle ticks do not churn the terminal.
 
 `measure` and `render` are the two halves of every view: `measure` reports a
 size in whole cells so the solver can allocate, `render` paints into the clipped

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,8 @@ pub use host::{TerminalSession, paint, paint_scene, paint_with_sheet, translate_
 pub use layout::{Align, Dimension, Direction, Justify, LayoutStyle};
 pub use overlay::{Overlay, OverlaySpec};
 #[cfg(feature = "async")]
-pub use runner::{AsyncRunner, Signal};
-pub use runner::{Runner, RunnerConfig};
+pub use runner::AsyncRunner;
+pub use runner::{Runner, RunnerConfig, Signal, UpdateResult};
 pub use scene::{Backdrop, Scene, SceneOverlay, ScopedScene};
 pub use screen::{ScreenMode, Scrollback};
 pub use style::{SemanticRole, StyleSheet, Theme};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -40,10 +40,10 @@ pub use crate::view;
 pub use crate::{
     Align, Backdrop, Dimension, Direction, Element, Event, EventFlow, Justify, Key, KeyCode,
     LayoutStyle, Mouse, MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx, Runner,
-    RunnerConfig, Scene, SceneOverlay, ScopedScene, ScreenMode, Scrollback, SemanticRole, Size,
-    StyleSheet, Surface, TerminalSession, Theme, View, element, paint, paint_scene,
-    paint_with_sheet, translate_event,
+    RunnerConfig, Scene, SceneOverlay, ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal,
+    Size, StyleSheet, Surface, TerminalSession, Theme, UpdateResult, View, element, paint,
+    paint_scene, paint_with_sheet, translate_event,
 };
 
 #[cfg(feature = "async")]
-pub use crate::{AsyncRunner, Signal};
+pub use crate::AsyncRunner;

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -68,21 +68,9 @@ use ratatui_crossterm::CrosstermBackend;
 use tokio::time::{MissedTickBehavior, interval};
 use tokio_stream::{Stream, StreamExt};
 
+use super::Signal;
 use crate::screen::{Scrollback, close_footer, pin_footer};
 use crate::{Element, Event, RunnerConfig, TerminalSession, Theme, paint, translate_event};
-
-/// A tick or an input event delivered to an [`AsyncRunner`]'s update callback.
-#[derive(Clone, Debug)]
-pub enum Signal {
-    /// The periodic tick fired. Its interval is [`RunnerConfig::tick_rate`]; the
-    /// first tick fires immediately after the initial frame is painted, so a
-    /// data-polling app loads on start without a special case.
-    Tick,
-    /// An input event arrived, already translated to a tuika [`Event`]. Events
-    /// crossterm reports but tuika does not model (key-release, unmapped codes)
-    /// are dropped before they reach here.
-    Event(Event),
-}
 
 /// An asynchronous Crossterm event and rendering loop.
 ///

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -20,10 +20,9 @@
 mod asynchronous;
 
 #[cfg(feature = "async")]
-pub use asynchronous::{AsyncRunner, Signal};
+pub use asynchronous::AsyncRunner;
 
 use std::io;
-use std::ops::ControlFlow;
 use std::time::{Duration, Instant};
 
 use crossterm::event;
@@ -52,6 +51,27 @@ impl Default for RunnerConfig {
             screen_mode: ScreenMode::default(),
         }
     }
+}
+
+/// A signal delivered to a runner update function.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Signal {
+    /// The configured tick interval elapsed.
+    Tick,
+    /// A translated terminal input event arrived.
+    Event(Event),
+}
+
+/// What a runner should do after an update.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum UpdateResult {
+    /// Keep waiting without rebuilding or repainting the view.
+    #[default]
+    Clean,
+    /// Rebuild and repaint the view from the updated state.
+    Dirty,
+    /// Stop the runner without painting another frame.
+    Exit,
 }
 
 /// A synchronous Crossterm event and rendering loop.
@@ -88,27 +108,39 @@ impl Runner {
         self.redraw.clone()
     }
 
-    /// Run until `on_event` returns [`ControlFlow::Break`].
-    pub fn run(
-        &self,
-        theme: &Theme,
-        build: impl FnMut(u64) -> Element,
-        on_event: impl FnMut(Event) -> ControlFlow<()>,
-    ) -> io::Result<()> {
-        self.run_with_backend(theme, CrosstermBackend::new(io::stdout()), build, on_event)
+    /// Run until `update` returns [`UpdateResult::Exit`].
+    ///
+    /// The runner paints once initially. It then delivers input and periodic
+    /// [`Signal::Tick`] values to `update`, repainting only when `update`
+    /// returns [`UpdateResult::Dirty`] or a [`RedrawHandle`] requests it.
+    pub fn run<S, V, U>(&self, theme: &Theme, state: &mut S, view: V, update: U) -> io::Result<()>
+    where
+        V: FnMut(&S, u64) -> Element,
+        U: FnMut(&mut S, Signal) -> UpdateResult,
+    {
+        self.run_with_backend(
+            theme,
+            CrosstermBackend::new(io::stdout()),
+            state,
+            view,
+            update,
+        )
     }
 
     /// Run with a caller-provided backend, such as
     /// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend).
-    pub fn run_with_backend<B>(
+    pub fn run_with_backend<S, B, V, U>(
         &self,
         theme: &Theme,
         backend: B,
-        mut build: impl FnMut(u64) -> Element,
-        mut on_event: impl FnMut(Event) -> ControlFlow<()>,
+        state: &mut S,
+        mut view: V,
+        mut update: U,
     ) -> io::Result<()>
     where
         B: Backend<Error = io::Error>,
+        V: FnMut(&S, u64) -> Element,
+        U: FnMut(&mut S, Signal) -> UpdateResult,
     {
         let mode = self.config.screen_mode;
         let split = !mode.is_alternate();
@@ -120,54 +152,56 @@ impl Runner {
             },
         )?;
         let mut frame = 0u64;
-        let mut last_draw = Instant::now();
-        self.redraw.request();
+        let mut last_tick = Instant::now();
 
-        loop {
+        if split {
+            pin_footer(&mut terminal)?;
+        }
+        draw(&mut terminal, theme, &mut view, state, &mut frame)?;
+
+        'running: loop {
+            let mut dirty = self.redraw.take();
             if split {
-                // Publishing scrolls the terminal and (on the portable path)
-                // clears the viewport, so a block that went out means the footer
-                // owes a repaint on this iteration rather than at the next tick.
-                if self.scrollback.flush(&mut terminal, theme)? {
-                    self.redraw.request();
-                }
+                // Publishing scrolls the terminal and may clear the viewport,
+                // so a committed block always makes the footer dirty.
+                dirty |= self.scrollback.flush(&mut terminal, theme)?;
             } else {
                 self.scrollback.clear();
             }
 
-            let due = last_draw.elapsed() >= self.config.tick_rate;
-            let requested = self.redraw.take();
-            if due || requested {
+            if last_tick.elapsed() >= self.config.tick_rate {
+                last_tick = Instant::now();
+                if apply_update(update(state, Signal::Tick), &mut dirty) {
+                    break;
+                }
+            }
+
+            if dirty {
                 if split {
-                    // Resolve any resize first so the footer is pinned against
-                    // the new screen height, not the previous one.
                     terminal.autoresize()?;
                     pin_footer(&mut terminal)?;
                 }
-                terminal.draw(|terminal_frame| {
-                    let area = terminal_frame.area();
-                    let root = build(frame);
-                    paint(terminal_frame.buffer_mut(), area, theme, root.as_ref(), &[]);
-                })?;
-                frame = frame.wrapping_add(1);
-                last_draw = Instant::now();
+                draw(&mut terminal, theme, &mut view, state, &mut frame)?;
             }
 
-            let timeout = self.config.tick_rate.saturating_sub(last_draw.elapsed());
+            let timeout = self.config.tick_rate.saturating_sub(last_tick.elapsed());
             if event::poll(timeout)?
                 && let Some(event) = translate_event(event::read()?)
-                && on_event(event).is_break()
             {
-                break;
+                let mut event_dirty = false;
+                if apply_update(update(state, Signal::Event(event)), &mut event_dirty) {
+                    break 'running;
+                }
+                if event_dirty {
+                    self.redraw.request();
+                }
             }
         }
 
         // Some terminal emulators do not answer the cursor-position query used
         // by `clear`. Session restoration must still succeed and a cosmetic
         // cleanup failure must not turn a completed run into an application
-        // error. A split footer gives its rows back instead: the scrollback
-        // above it is the user's, and only the reserved region is ours to
-        // clear.
+        // error.
         if split {
             let _ = close_footer(&mut terminal);
         } else {
@@ -177,9 +211,62 @@ impl Runner {
     }
 }
 
+fn apply_update(result: UpdateResult, dirty: &mut bool) -> bool {
+    match result {
+        UpdateResult::Clean => false,
+        UpdateResult::Dirty => {
+            *dirty = true;
+            false
+        }
+        UpdateResult::Exit => true,
+    }
+}
+
+/// Paint one frame from immutable state and advance the animation frame.
+fn draw<S, B, V, Er>(
+    terminal: &mut Terminal<B>,
+    theme: &Theme,
+    view: &mut V,
+    state: &S,
+    frame: &mut u64,
+) -> Result<(), Er>
+where
+    B: Backend<Error = Er>,
+    V: FnMut(&S, u64) -> Element,
+{
+    terminal.draw(|terminal_frame| {
+        let area = terminal_frame.area();
+        let root = view(state, *frame);
+        paint(terminal_frame.buffer_mut(), area, theme, root.as_ref(), &[]);
+    })?;
+    *frame = frame.wrapping_add(1);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clean_updates_do_not_request_a_repaint() {
+        let mut dirty = false;
+        assert!(!apply_update(UpdateResult::Clean, &mut dirty));
+        assert!(!dirty);
+    }
+
+    #[test]
+    fn dirty_updates_request_a_repaint() {
+        let mut dirty = false;
+        assert!(!apply_update(UpdateResult::Dirty, &mut dirty));
+        assert!(dirty);
+    }
+
+    #[test]
+    fn exit_updates_stop_without_forcing_a_repaint() {
+        let mut dirty = false;
+        assert!(apply_update(UpdateResult::Exit, &mut dirty));
+        assert!(!dirty);
+    }
 
     #[test]
     fn zero_tick_rate_is_clamped() {


### PR DESCRIPTION
## Summary

- make the synchronous runner own a caller-provided state value, matching the view/update split of `AsyncRunner`
- deliver input and ticks as `Signal` values and repaint only for `UpdateResult::Dirty` or an external `RedrawHandle`
- migrate synchronous examples and document the breaking API migration

## Why

Hosts currently need shared interior mutability or state mutation during rendering to use the synchronous runner. They also pay for a full terminal repaint on every tick even when nothing changed. The new model keeps rendering immutable, centralizes state mutation in update, and makes idle terminal work proportional to actual changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo check --workspace --all-targets`
- `cargo check --workspace --all-targets --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --example demo -- select --dump`

## Before / After

**Before:** `Runner` rebuilt and painted every tick, and handlers received only an event with no owned state.

**After:** `Runner` paints initially, then rebuilds only for dirty updates, redraw requests, or split-footer publication; views receive immutable state and updates receive mutable state plus a tick or event signal.

## API changes

**Breaking:** `Runner::run` and `Runner::run_with_backend` now take `&mut State`, `view(&State, frame)`, and `update(&mut State, Signal)`. Update returns `UpdateResult::{Clean, Dirty, Exit}` instead of `ControlFlow<()>`. `Signal` is now available without the `async` feature.

Migration: move mutable application data into the supplied state, build the view from `&State`, mutate only in update, return `Dirty` after visible changes, and return `Exit` to stop.

No dependencies were added.

## Knowledge and docs

Updated the README, changelog, architecture specification, and knowledge log to record the state ownership and explicit invalidation model.

## Security

- **TM-STATE:** terminal-session enter/restore and footer cleanup paths are unchanged; exit updates still reach normal teardown.
- **TM-CLIP:** rendering continues through the existing clipped painter; no geometry or cell-writing behavior changed.
- **TM-ESC / TM-PARSE / TM-DEP:** no new escape emission, parser surface, untrusted-input handling, or dependency changes.
- Reviewed loop timing for busy-loop and resource-exhaustion risk; zero tick intervals remain clamped and clean ticks no longer allocate or repaint.

## Follow-ups

- Add richer selection navigation policies and multi-selection.
- Connect keymap declarations to responsive footer hints and help rendering.
- Add strict single-line input behavior and borrowed text access.
- Re-export common backend UI types through `tuika::ui`.

Produced by [yolop](https://everruns.com/yolop)
