### PR TITLE
feat(keymap): derive responsive help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ block-HTML seam.
 - `SelectNavigation` policies for optional j/k, Ctrl+N/P, Tab/Shift+Tab, and
   numeric selection aliases; explicit mouse hit-testing on `SelectState`; and
   `MultiSelectState` for toggleable multiple-selection workflows.
+- `KeyHints::from_keymap`, priority-aware whole-hint fitting, and `KeymapHelp`
+  so one labeled keymap declaration drives dispatch, responsive footer hints,
+  and a complete help view.
 
 ### Changed
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -679,6 +679,13 @@ fb.fill_rect(8, 8, 16, 16, [240, 90, 90, 255]);
 view! { node(FrameBufferView::new(&fb, 64, 16)) }
 ```
 
+## Key hints and help
+
+`KeyHint::priority` and `KeyHints::prioritized` fit only complete hints on narrow
+screens; higher priorities survive first. `KeyHints::from_keymap` and
+`KeymapHelp::from_keymap` turn the same labeled declarations used for dispatch
+into a responsive footer and a complete, scrollable help view.
+
 ## See also
 
 - [API documentation](https://docs.rs/tuika) — the complete component reference,

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -124,15 +124,21 @@ overlay layer can shadow a global binding while it is up.
 ## Querying for help
 
 `hints()` lists the currently-active bindings — key label, optional help text,
-and command — ready to feed a [`KeyHints`](components.md) row or a help overlay.
-Because activation is data-driven, the hints always reflect the current mode:
+command, layer name, and layer priority. The component adapters consume the same
+declarations directly, so dispatch, a responsive footer, and a complete help
+screen cannot drift apart:
 
 ```rust
-for hint in keymap.hints() {
-    println!("{:<8} {}", hint.keys, hint.label.as_deref().unwrap_or(""));
-    // e.g.  "Ctrl+R   search"
-}
+use tuika::components::{KeyHints, KeymapHelp};
+
+let footer = KeyHints::from_keymap(&keymap);
+let help = KeymapHelp::from_keymap(&keymap);
 ```
+
+`KeyHints` fits only complete hints: it keeps higher-priority layer bindings
+first on narrow screens and never clips halfway through a key/action pair.
+`KeymapHelp::offset` supports a vertically scrollable help overlay. Because both
+query active bindings, changing keymap runtime data updates the displayed mode.
 
 ## Testing
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -15,6 +15,12 @@
 - Per-frame focus rings discard ids that disappeared and commit the fallback at
   the following frame boundary. Dynamic component trees therefore cannot keep
   routing input to a stale target or resurrect it when it later returns.
+- **Keymap-derived responsive help**
+  - Active labeled bindings drive whole-item, priority-aware footer fitting and
+    a complete scrollable help view.
+  - Layer priority is display priority, keeping contextual/modal actions visible
+    before global actions when width is constrained.
+
 - **Configurable selection behavior**
   - Selection state now supports opt-in terminal-picker aliases, explicit mouse
     hit-testing, and a separate multiple-selection state.

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -35,6 +35,9 @@ rather than beside it.
   checked-item transitions, while aliases and mouse geometry are explicit
   inputs. Hosts can share picker behavior without inheriting hard-coded keys or
   layout assumptions.
+- **Key bindings are the help source of truth**: active labeled bindings expose
+  layer priority, and component adapters derive responsive footer hints and
+  complete help rows from the same declarations used for dispatch.
 - **Owned scenes are frame descriptions, not retained UI.** `Scene` owns the
   root and overlay elements for one frame and resolves each overlay's
   `OverlaySpec` while rendering. This removes borrowed compositor plumbing

--- a/src/components/key_hints.rs
+++ b/src/components/key_hints.rs
@@ -1,29 +1,104 @@
-//! Compact, responsive key/action hints.
+//! Compact, responsive key/action hints and complete keymap help.
 
 use ratatui_core::layout::Rect;
 use ratatui_core::style::{Color, Style};
 
+use crate::keymap::{Hint, Keymap};
 use crate::width::str_cols;
 use crate::{RenderCtx, Size, Surface, View};
 
+/// A key/action hint with a responsive fitting priority.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeyHint {
+    /// Display-ready key sequence.
+    pub key: String,
+    /// Human-readable action label.
+    pub label: String,
+    /// Higher values are retained first when horizontal space is tight.
+    pub priority: i32,
+}
+
+impl KeyHint {
+    /// Create a hint at the default priority (`0`).
+    pub fn new(key: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            key: key.into(),
+            label: label.into(),
+            priority: 0,
+        }
+    }
+
+    /// Assign a fitting priority.
+    pub fn priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    fn width(&self) -> usize {
+        usize::from(str_cols(&self.key)) + usize::from(str_cols(&self.label)) + 3
+    }
+}
+
 /// A one-line sequence of styled key and action labels.
+///
+/// A narrow area never paints half a hint. The highest-priority complete hints
+/// that fit are retained, while their original declaration order is preserved.
 pub struct KeyHints {
-    hints: Vec<(String, String)>,
+    hints: Vec<KeyHint>,
 }
 
 impl KeyHints {
-    /// Build hints from `(key, action)` pairs.
+    /// Build hints from `(key, action)` pairs at equal priority.
     pub fn new<K, L>(hints: impl IntoIterator<Item = (K, L)>) -> Self
     where
         K: Into<String>,
         L: Into<String>,
     {
-        Self {
-            hints: hints
+        Self::prioritized(
+            hints
                 .into_iter()
-                .map(|(key, label)| (key.into(), label.into()))
-                .collect(),
+                .map(|(key, label)| KeyHint::new(key, label)),
+        )
+    }
+
+    /// Build hints with explicit priorities.
+    pub fn prioritized(hints: impl IntoIterator<Item = KeyHint>) -> Self {
+        Self {
+            hints: hints.into_iter().collect(),
         }
+    }
+
+    /// Build footer hints from active, labeled keymap bindings.
+    ///
+    /// Layer priority doubles as fitting priority, so modal or contextual
+    /// actions survive before global actions on narrow screens.
+    pub fn from_keymap<C: Clone>(keymap: &Keymap<C>) -> Self {
+        Self::prioritized(
+            keymap.hints().into_iter().filter_map(|hint| {
+                Some(KeyHint::new(hint.keys, hint.label?).priority(hint.priority))
+            }),
+        )
+    }
+
+    fn fitted(&self, width: usize) -> Vec<usize> {
+        let mut candidates: Vec<usize> = (0..self.hints.len()).collect();
+        candidates.sort_by(|&a, &b| {
+            self.hints[b]
+                .priority
+                .cmp(&self.hints[a].priority)
+                .then_with(|| a.cmp(&b))
+        });
+        let mut used = 0usize;
+        let mut selected = Vec::new();
+        for index in candidates {
+            let extra = self.hints[index].width() + usize::from(!selected.is_empty()) * 2;
+            if used.saturating_add(extra) <= width {
+                used += extra;
+                selected.push(index);
+            }
+        }
+        selected.sort_unstable();
+        selected
     }
 }
 
@@ -32,8 +107,9 @@ impl View for KeyHints {
         let width = self
             .hints
             .iter()
-            .map(|(key, label)| (str_cols(key) + str_cols(label)) as usize + 3)
+            .map(KeyHint::width)
             .sum::<usize>()
+            .saturating_add(self.hints.len().saturating_sub(1) * 2)
             .min(available.width as usize) as u16;
         Size::new(width, u16::from(available.height > 0))
     }
@@ -43,21 +119,114 @@ impl View for KeyHints {
             return;
         }
         let mut x = area.x;
-        for (index, (key, label)) in self.hints.iter().enumerate() {
-            if index > 0 {
+        for (position, index) in self.fitted(usize::from(area.width)).into_iter().enumerate() {
+            let hint = &self.hints[index];
+            if position > 0 {
                 x = surface.set_string(x, area.y, "  ", ctx.theme.muted_style());
             }
             x = surface.set_string(
                 x,
                 area.y,
-                &format!(" {key} "),
+                &format!(" {} ", hint.key),
                 Style::default().fg(Color::Black).bg(ctx.theme.accent),
             );
             x = surface.set_string(x, area.y, " ", ctx.theme.muted_style());
-            x = surface.set_string(x, area.y, label, ctx.theme.muted_style());
-            if x >= area.right() {
-                break;
-            }
+            x = surface.set_string(x, area.y, &hint.label, ctx.theme.muted_style());
+        }
+    }
+}
+
+/// Complete, vertically scrollable help generated from active keymap bindings.
+pub struct KeymapHelp {
+    hints: Vec<HelpHint>,
+    offset: usize,
+}
+
+struct HelpHint {
+    keys: String,
+    label: String,
+}
+
+impl KeymapHelp {
+    /// Build help rows from active, labeled bindings in a keymap.
+    pub fn from_keymap<C: Clone>(keymap: &Keymap<C>) -> Self {
+        Self::from_hints(keymap.hints())
+    }
+
+    /// Build help rows from discovered bindings.
+    pub fn from_hints<C>(hints: impl IntoIterator<Item = Hint<C>>) -> Self {
+        Self {
+            hints: hints
+                .into_iter()
+                .filter_map(|hint| {
+                    Some(HelpHint {
+                        keys: hint.keys,
+                        label: hint.label?,
+                    })
+                })
+                .collect(),
+            offset: 0,
+        }
+    }
+
+    /// Skip the first `offset` help rows.
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
+}
+
+impl View for KeymapHelp {
+    fn measure(&self, available: Size) -> Size {
+        let key_width = self
+            .hints
+            .iter()
+            .map(|hint| str_cols(&hint.keys))
+            .max()
+            .unwrap_or(0);
+        let width = self
+            .hints
+            .iter()
+            .map(|hint| key_width + 2 + str_cols(&hint.label))
+            .max()
+            .unwrap_or(0)
+            .min(available.width);
+        Size::new(
+            width,
+            self.hints
+                .len()
+                .saturating_sub(self.offset)
+                .min(usize::from(available.height)) as u16,
+        )
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        let key_width = self
+            .hints
+            .iter()
+            .map(|hint| str_cols(&hint.keys))
+            .max()
+            .unwrap_or(0);
+        for (row, hint) in self
+            .hints
+            .iter()
+            .skip(self.offset)
+            .take(usize::from(area.height))
+            .enumerate()
+        {
+            let y = area.y.saturating_add(row as u16);
+            surface.set_string(
+                area.x,
+                y,
+                &hint.keys,
+                Style::default().fg(Color::Black).bg(ctx.theme.accent),
+            );
+            surface.set_string(
+                area.x.saturating_add(key_width).saturating_add(2),
+                y,
+                &hint.label,
+                ctx.theme.muted_style(),
+            );
         }
     }
 }
@@ -65,12 +234,54 @@ impl View for KeyHints {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Size;
-    use crate::view::View;
+    use crate::keymap::Layer;
+    use crate::testing::{grid, render};
+    use crate::{Size, Theme};
 
     #[test]
     fn key_hints_measure_unicode_by_terminal_width() {
         let hints = KeyHints::new([("⌘", "開く")]);
         assert_eq!(hints.measure(Size::new(20, 1)), Size::new(8, 1));
+    }
+
+    #[test]
+    fn narrow_hints_keep_whole_high_priority_items() {
+        let hints = KeyHints::prioritized([
+            KeyHint::new("A", "alpha"),
+            KeyHint::new("Q", "quit").priority(10),
+            KeyHint::new("?", "help").priority(5),
+        ]);
+        assert_eq!(
+            grid(&render(&hints, 18, 1, &Theme::default())),
+            " Q  quit   ?  help"
+        );
+        assert_eq!(grid(&render(&hints, 8, 1, &Theme::default())), " Q  quit");
+        assert_eq!(grid(&render(&hints, 3, 1, &Theme::default())), "   ");
+    }
+
+    #[derive(Clone)]
+    enum Action {
+        Open,
+        Quit,
+    }
+
+    #[test]
+    fn one_keymap_declaration_drives_footer_and_help() {
+        let keymap = Keymap::new().layer(
+            Layer::new("global")
+                .priority(4)
+                .bind_labeled("enter", "open", Action::Open)
+                .bind_labeled("q", "quit", Action::Quit),
+        );
+        let footer = KeyHints::from_keymap(&keymap);
+        assert_eq!(
+            grid(&render(&footer, 30, 1, &Theme::default())),
+            " Enter  open   Q  quit        "
+        );
+        let help = KeymapHelp::from_keymap(&keymap);
+        assert_eq!(
+            grid(&render(&help, 20, 2, &Theme::default())),
+            "Enter  open         \nQ      quit         "
+        );
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -63,7 +63,7 @@ pub use focus_scope::FocusScope;
 pub use form::{Form, FormField, FormOutcome, FormState};
 pub use image::Image;
 pub use item_scroll::ItemScroll;
-pub use key_hints::KeyHints;
+pub use key_hints::{KeyHint, KeyHints, KeymapHelp};
 pub use loader::Loader;
 pub use markdown::{
     FencedBlockRenderer, HtmlBlockRenderer, ImageResolver, Markdown, MarkdownImage, MarkdownState,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -415,6 +415,10 @@ pub struct Hint<C> {
     pub label: Option<String>,
     /// The command the binding runs.
     pub command: C,
+    /// Name of the active layer that declared this binding.
+    pub layer: String,
+    /// Layer priority, suitable for responsive hint fitting.
+    pub priority: i32,
 }
 
 /// The keymap engine: a set of [`Layer`]s, a runtime-data store used to gate
@@ -546,11 +550,14 @@ impl<C: Clone> Keymap<C> {
         layers.sort_by(|a, b| b.priority.cmp(&a.priority));
         layers
             .iter()
-            .flat_map(|layer| layer.bindings.iter())
-            .map(|binding| Hint {
-                keys: binding.sequence.display(),
-                label: binding.label.clone(),
-                command: binding.command.clone(),
+            .flat_map(|layer| {
+                layer.bindings.iter().map(|binding| Hint {
+                    keys: binding.sequence.display(),
+                    label: binding.label.clone(),
+                    command: binding.command.clone(),
+                    layer: layer.name.clone(),
+                    priority: layer.priority,
+                })
             })
             .collect()
     }


### PR DESCRIPTION
## Summary

- derive responsive footer hints and a complete help view from active labeled keymap bindings
- fit only complete hints, retaining higher-priority layer actions first on narrow screens
- expose layer name and priority in discovered keymap hints

## Why

Dispatch, footer labels, and help screens currently duplicate the same binding information, while `KeyHints` can clip halfway through an item. One labeled keymap declaration now drives all three surfaces and remains readable at constrained widths.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --example demo -- check`
- `cargo run --example demo -- status_bar --dump`

## Before / After

**Before:** hosts copied binding labels into footer and help views, and a narrow `KeyHints` area clipped arbitrary cells.

**After:** `KeyHints::from_keymap` and `KeymapHelp::from_keymap` consume active labeled bindings. Footer fitting retains complete high-priority hints, and help rows can be vertically offset for scrolling.

Existing demo geometry still renders identically at its declared width, so no recording regeneration was required; `demo -- check` passed.

## API changes

Additive public API: `KeyHint`, `KeyHints::prioritized`, `KeyHints::from_keymap`, and `KeymapHelp`. `Hint` adds public `layer` and `priority` metadata. No existing method signatures changed and no dependencies were added.

## Knowledge and docs

Updated the keymap guide, component docs, changelog, architecture specification, and knowledge log.

## Security

- **TM-CLIP:** responsive fitting measures complete items before painting; `Surface` retains the final clip boundary for all writes.
- **TM-PARSE:** widths use terminal-column measurement and saturating arithmetic; narrow and Unicode cases have direct tests.
- **TM-ESC / TM-STATE / TM-DEP:** no terminal escapes, lifecycle changes, parsing, or dependency additions.
- Help rows are bounded by viewport height and offset; fitting is linearithmic in the finite host-declared binding count.

## Follow-ups

- Add strict single-line input behavior and borrowed text access.
- Re-export common backend UI types through `tuika::ui`.

Produced by [yolop](https://everruns.com/yolop)
