### PR TITLE
feat(input): add single-line state and ui exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ block-HTML seam.
 - `KeyHints::from_keymap`, priority-aware whole-hint fitting, and `KeymapHelp`
   so one labeled keymap declaration drives dispatch, responsive footer hints,
   and a complete help view.
+- `SingleLineInputState` for search/command fields, with newline normalization,
+  Enter/Ctrl+J submission, and allocation-free borrowed text access.
+- `tuika::ui` re-exports `Rect`, `Color`, `Style`, `Modifier`, `Line`, and `Span`
+  for custom views without a direct `ratatui-core` dependency.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -250,12 +250,13 @@ scene.sync_focus(&mut focus);
 paint_scene(buffer, area, &theme, &scene);
 ```
 
+Custom views can import `Rect`, `Color`, `Style`, `Modifier`, `Line`, and `Span` from `tuika::ui` or the prelude without adding `ratatui-core` directly.
+
 `Element` is an owned, boxed view. When the base view reads a large host-owned
 model directly, `ScopedScene` borrows that concrete root for one paint while
 continuing to own ordinary `SceneOverlay`s and `Dialog`s:
 
 ```rust
-use ratatui_core::layout::Rect;
 use tuika::prelude::*;
 
 struct Dashboard<'a> {

--- a/docs/components.md
+++ b/docs/components.md
@@ -549,6 +549,10 @@ host-computed `TextSpan` ranges over the text. Cursor and span coordinates remai
 char indices for host interoperability; movement and deletion keep grapheme
 clusters intact, and wrapping/cursor placement use terminal-cell width so CJK
 and emoji align with the rendered grid.
+For search fields and command bars, `SingleLineInputState` wraps the same editor
+but guarantees one line: setters and paste normalize CR/LF to spaces, Enter and
+Ctrl+J submit, and `text()` returns a borrowed `&str` without allocation. Render
+it with `TextInput::new(state.as_text_input())`.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.TextInput.html)
 
 <img src="demos/textinput.gif" width="880" alt="TextInput demo">

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -15,6 +15,12 @@
 - Per-frame focus rings discard ids that disappeared and commit the fallback at
   the following frame boundary. Dynamic component trees therefore cannot keep
   routing input to a stale target or resurrect it when it later returns.
+- **Single-line input and custom-view vocabulary**
+  - Search/command state normalizes newline-bearing setters, paste, and key input
+    and exposes borrowed text, keeping render paths allocation-free and pure.
+  - `tuika::ui` provides the backend value types required to implement `View`,
+    avoiding an otherwise redundant direct host dependency.
+
 - **Keymap-derived responsive help**
   - Active labeled bindings drive whole-item, priority-aware footer fitting and
     a complete scrollable help view.

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -95,6 +95,10 @@ genuinely public helper module for *consumers*; see
 - Every `pub` item is API. Moving or renaming one is a breaking change, allowed
   in a minor release pre-1.0, and must be called out in `CHANGELOG.md` with a
   before/after migration line — never slipped in.
+- `ui` re-exports the narrow backend value vocabulary custom `View`
+  implementations must name (`Rect`, colors/styles, and text lines/spans), so a
+  host need not add a direct backend dependency merely to implement tuika's
+  trait. Backend operations and widgets remain private.
 - The prelude may grow, but adding to it is a judgement about frequency, not a
   convenience: a name that lands there is one a host should not have to think
   about. Terminal escapes, pixel canvases, probes, and width measurement are

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -38,6 +38,9 @@ rather than beside it.
 - **Key bindings are the help source of truth**: active labeled bindings expose
   layer priority, and component adapters derive responsive footer hints and
   complete help rows from the same declarations used for dispatch.
+- **Single-line input is a state invariant**: search/command inputs normalize
+  line boundaries at every public mutation boundary and expose borrowed text;
+  hosts do not repair multiline editor state during rendering.
 - **Owned scenes are frame descriptions, not retained UI.** `Scene` owns the
   root and overlay elements for one frame and resolves each overlay's
   `OverlaySpec` while rendering. This removes borrowed compositor plumbing

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -86,8 +86,8 @@ pub use table::{Column, Table};
 pub use tabs::{Tabs, TabsState};
 pub use text::{Paragraph, Text, Wrap};
 pub use textinput::{
-    TextInput, TextInputEvent, TextInputMode, TextInputState, TextSpan, Token, Trigger,
-    TriggerAnchor,
+    SingleLineInputState, TextInput, TextInputEvent, TextInputMode, TextInputState, TextSpan,
+    Token, Trigger, TriggerAnchor,
 };
 pub use toast::{ToastLevel, ToastList, Toasts};
 pub use viewport::Viewport;

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -965,6 +965,111 @@ fn wrap_visual_rows<'a>(lines: &'a [String], width: u16) -> Vec<VisualRow<'a>> {
     rows
 }
 
+/// Strictly single-line editing state for search fields and command bars.
+///
+/// Newline input from setters, paste, Ctrl+J, or direct character insertion is
+/// normalized to one space. Enter always submits. Unlike
+/// [`TextInputState::text`], [`text`](Self::text) returns a borrowed string.
+#[derive(Clone, Debug, Default)]
+pub struct SingleLineInputState {
+    inner: TextInputState,
+}
+
+impl SingleLineInputState {
+    /// Create an empty single-line input.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed from text, normalizing every line boundary to one space.
+    pub fn from_text(text: &str) -> Self {
+        let mut state = Self::new();
+        state.set_text(text);
+        state
+    }
+
+    /// Borrow the current text without allocating.
+    pub fn text(&self) -> &str {
+        &self.inner.lines[0]
+    }
+
+    /// Whether the input is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Cursor column as a logical character index.
+    pub fn cursor(&self) -> usize {
+        self.inner.col
+    }
+
+    /// Replace the text, normalizing line boundaries to spaces.
+    pub fn set_text(&mut self, text: &str) {
+        self.inner.set_text(&normalize_single_line(text));
+    }
+
+    /// Clear the input.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
+    /// Insert one character, normalizing CR/LF to a space.
+    pub fn insert_char(&mut self, ch: char) {
+        self.inner
+            .insert_char(if matches!(ch, '\r' | '\n') { ' ' } else { ch });
+    }
+
+    /// Insert text, normalizing every line boundary to one space.
+    pub fn insert_str(&mut self, text: &str) {
+        self.inner.insert_str(&normalize_single_line(text));
+    }
+
+    /// Access the underlying state for [`TextInput`] rendering.
+    pub fn as_text_input(&self) -> &TextInputState {
+        &self.inner
+    }
+
+    /// Handle editing input. Enter and Ctrl+J always submit.
+    pub fn handle(&mut self, event: &Event) -> Option<TextInputEvent> {
+        match event {
+            Event::Paste(text) => {
+                self.insert_str(text);
+                Some(TextInputEvent::Changed)
+            }
+            Event::Key(key)
+                if key.plain()
+                    && matches!(key.code, KeyCode::Enter | KeyCode::Char('\n' | '\r')) =>
+            {
+                Some(TextInputEvent::Submit)
+            }
+            Event::Key(key)
+                if key.ctrl && !key.alt && !key.shift && key.code == KeyCode::Char('j') =>
+            {
+                Some(TextInputEvent::Submit)
+            }
+            _ => self.inner.handle(event),
+        }
+    }
+}
+
+fn normalize_single_line(text: &str) -> String {
+    let mut normalized = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                normalized.push(' ');
+            }
+            '\n' => normalized.push(' '),
+            _ => normalized.push(ch),
+        }
+    }
+    normalized
+}
+
 /// Renders a snapshot of a [`TextInputState`]'s wrapped text.
 ///
 /// Owns its lines (cloned from the state at construction, like [`Scroll`]) so it
@@ -1107,6 +1212,44 @@ mod tests {
     use crate::view::{RenderCtx, element};
     use ratatui_core::layout::Rect;
     use ratatui_core::style::Color;
+
+    #[test]
+    fn single_line_normalizes_setter_and_paste_newlines() {
+        let mut state = SingleLineInputState::from_text("alpha\r\nbeta\ngamma\rdelta");
+        assert_eq!(state.text(), "alpha beta gamma delta");
+        assert_eq!(
+            state.handle(&Event::Paste(" one\r\ntwo\nthree".into())),
+            Some(TextInputEvent::Changed)
+        );
+        assert_eq!(state.text(), "alpha beta gamma delta one two three");
+    }
+
+    #[test]
+    fn single_line_text_is_borrowed_and_cursor_stays_on_one_row() {
+        let mut state = SingleLineInputState::new();
+        state.insert_str("café");
+        let borrowed: &str = state.text();
+        assert_eq!(borrowed, "café");
+        assert_eq!(state.cursor(), 4);
+        assert_eq!(state.as_text_input().cursor(), (0, 4));
+    }
+
+    #[test]
+    fn single_line_enter_and_ctrl_j_submit_without_mutating() {
+        let mut state = SingleLineInputState::from_text("query");
+        for event in [
+            Event::Key(Key::new(KeyCode::Enter)),
+            Event::Key(Key {
+                code: KeyCode::Char('j'),
+                ctrl: true,
+                alt: false,
+                shift: false,
+            }),
+        ] {
+            assert_eq!(state.handle(&event), Some(TextInputEvent::Submit));
+            assert_eq!(state.text(), "query");
+        }
+    }
 
     fn press(state: &mut TextInputState, code: KeyCode) -> bool {
         matches!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,16 @@ pub mod themes;
 pub mod view;
 pub mod width;
 
+/// Backend UI vocabulary re-exported for custom [`View`] implementations.
+///
+/// Applications can use these canonical types without depending on
+/// `ratatui-core` directly. More specialized backend internals remain private.
+pub mod ui {
+    pub use ratatui_core::layout::Rect;
+    pub use ratatui_core::style::{Color, Modifier, Style};
+    pub use ratatui_core::text::{Line, Span};
+}
+
 // The framework spine: the types a host composes with on essentially every
 // frame. Widgets are not here on purpose — they live in `components`, and
 // `prelude` is the one-line import that brings both. Anything reachable only

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -34,6 +34,7 @@ pub use crate::interop::RatatuiView;
 pub use crate::keymap::{Binding, Chord, Dispatch, Hint, KeySequence, Keymap, Layer};
 pub use crate::live::{Live, LiveView, RedrawHandle};
 pub use crate::style::{BorderStyle, CodeTheme, Role, StyleBundle};
+pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // The `view!` macro plus the module it is named for; the macro expands to
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.
 pub use crate::view;

--- a/tests/ui_api.rs
+++ b/tests/ui_api.rs
@@ -1,0 +1,13 @@
+use tuika::ui::{Color, Line, Modifier, Rect, Span, Style};
+
+#[test]
+fn ui_module_exposes_custom_view_vocabulary() {
+    let rect = Rect::new(1, 2, 3, 4);
+    let style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let line = Line::from(vec![Span::styled("value", style)]);
+
+    assert_eq!(rect.width, 3);
+    assert_eq!(line.width(), 5);
+}


### PR DESCRIPTION
## Summary

- add strict single-line input state for search fields and command bars
- normalize line boundaries from setters, paste, and direct character input; submit on Enter or Ctrl+J
- expose borrowed text and re-export custom-view UI vocabulary through `tuika::ui`

## Why

Search inputs currently require hosts to synchronize and clean a multiline editor during rendering, while reading text allocates. Custom views also force an otherwise unnecessary direct `ratatui-core` dependency just to name basic value types.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --example demo -- check`
- `cargo run --example demo -- textinput --dump`

## Before / After

**Before:** hosts repaired newline-bearing `TextInputState` values and cloned text for every query; custom views imported basic geometry/style/text types directly from ratatui-core.

**After:** `SingleLineInputState` enforces its invariant at every mutation boundary, returns `&str`, and renders through the existing `TextInput`. `tuika::ui` and the prelude expose the canonical custom-view vocabulary.

The existing TextInput appearance is unchanged, so no recording regeneration was required; `demo -- check` passed.

## API changes

Additive public API: `SingleLineInputState` and `tuika::ui::{Rect, Color, Style, Modifier, Line, Span}`. The UI values are also available from the prelude. No existing signatures changed and no dependencies were added.

## Knowledge and docs

Updated README, component docs, changelog, API-surface and architecture specifications, and knowledge log.

## Security

- **TM-PARSE:** all public single-line mutation paths normalize CR, LF, and CRLF before storing; Unicode editing remains delegated to the grapheme-aware editor.
- **TM-CLIP:** rendering remains the tested existing `TextInput` renderer; UI re-exports are value types only.
- **TM-ESC / TM-STATE / TM-DEP:** no escape emission, terminal lifecycle, or dependency changes.
- Normalization allocates at most proportional to caller-provided input and uses no recursion or unchecked indexing.

## Follow-ups

No follow-ups from the requested highest-value improvement set.

Produced by [yolop](https://everruns.com/yolop)
