### PR TITLE
feat(view): compose borrowed component subtrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ block-HTML seam.
 
 ### Added
 
+- `ScopedElement<'view>`, the boxed frame-borrowed counterpart to owned
+  `Element`, for heterogeneous component subtrees that read host state without
+  cloning it.
 - **Inline HTML in markdown.** The presentational inline tags render instead of
   being dropped: `<b>`/`<strong>`, `<i>`/`<em>`/`<var>`/`<cite>`/`<dfn>`,
   `<code>`/`<kbd>`/`<samp>`/`<tt>`, `<s>`/`<del>`/`<strike>`, `<u>`/`<ins>`,
@@ -61,6 +64,9 @@ block-HTML seam.
 
 ### Changed
 
+- `element`, `view!`, and composition containers now preserve borrowed child
+  views at any depth. Existing owned trees continue to use `Element`; borrowed
+  trees use the same builders and are bounded to their frame lifetime.
 - `Flex` measures padded children against their actual inner box and reports
   fixed/percent child dimensions when the container itself is auto-sized, so
   nested measurement matches the rects assigned during rendering.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Four places, so you can guess where something is:
 
 | Path | Holds |
 | --- | --- |
-| `tuika::` | the framework spine — `View`, `Element`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
+| `tuika::` | the framework spine — `View`, `Element`, `ScopedElement`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
 | `tuika::components` | every widget: `Flex`, `Boxed`, `Text`, `Scroll`, `Markdown`, `Table`, … |
 | `tuika::term` | everything out-of-band: `clipboard` (OSC 52), `hyperlink` (OSC 8), `progress` (OSC 9;4), `pointer` (OSC 22), `image`, `capabilities`, `palette` (the terminal's own colors) |
 | `tuika::prelude` | the spine and the components in one glob import |
@@ -252,9 +252,10 @@ paint_scene(buffer, area, &theme, &scene);
 
 Custom views can import `Rect`, `Color`, `Style`, `Modifier`, `Line`, and `Span` from `tuika::ui` or the prelude without adding `ratatui-core` directly.
 
-`Element` is an owned, boxed view. When the base view reads a large host-owned
-model directly, `ScopedScene` borrows that concrete root for one paint while
-continuing to own ordinary `SceneOverlay`s and `Dialog`s:
+`Element` is an owned, boxed view. `ScopedElement<'_>` is its frame-borrowed
+counterpart: `element(view)` chooses the lifetime from `view`, and containers
+accept it at any depth. `ScopedScene` borrows the resulting root for one paint
+while continuing to own ordinary `SceneOverlay`s and `Dialog`s:
 
 ```rust
 use tuika::prelude::*;
@@ -286,10 +287,9 @@ paint(buffer, area, &theme, &scene, &[]);
 ```
 
 The borrow lasts only as long as the scoped scene, matching Tuika's
-frame-by-frame view model. No transcript clone, leaked allocation, or
-application compositor is needed. Nested component children are still owned
-`Element`s; when a whole borrowed subtree is needed, represent that subtree as
-one concrete `View` and use it as the scoped root.
+frame-by-frame view model. No transcript clone, leaked allocation, custom
+wrapper view, or application compositor is needed. The `view!` macro preserves
+the same lifetime through nested `Flex` and `Boxed` containers.
 
 `Form` lays out arbitrary control `Element`s beside responsive labels, stacking
 on narrow terminals. Help and validation rows are built in; `FormState` owns
@@ -475,8 +475,10 @@ Grammar (each keyword consumes exactly one node):
   ```
 
 `node(...)` accepts any type that already implements Tuika's `View`; it does
-not make a Ratatui `Widget` implement `View`. Use `RatatuiView` for Ratatui
-widgets. The `tuika-gallery` demo is built entirely with `view!`.
+not make a Ratatui `Widget` implement `View`. A node may borrow frame data; the
+macro returns `ScopedElement<'_>` in that case and naturally coerces an
+all-owned tree to `Element`. Use `RatatuiView` for Ratatui widgets. The
+`tuika-gallery` demo is built entirely with `view!`.
 
 ## Ratatui interoperability
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -202,7 +202,9 @@ view! {
 
 The flexbox container and composition primitive — `grow(n)` children share
 leftover space by weight, `fixed(n)` reserve exact size, with `gap` and
-`padding`. It *is* the `view!` DSL's `row`/`col`.
+`padding`. It *is* the `view!` DSL's `row`/`col`. `element` and `view!` preserve
+frame borrows through nested Flex and Boxed containers as `ScopedElement<'_>`;
+owned trees continue to use `Element` without lifetime annotations.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.Flex.html)
 
 <img src="demos/flex.png" width="880" alt="Flex demo">

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,13 @@
 
 ## 2026-07-31
 
+- **Borrowed views compose inside ordinary component trees**
+
+- `Element` remains the owned default, while `ScopedElement` carries a frame
+  borrow through the same `element`, `view!`, Flex, Boxed, form, viewport, and
+  collection composition paths. Hosts no longer need a custom root `View` just
+  to nest a borrowed renderer or large model reference.
+
 - **Component geometry uses the grid's real constraints**
 
 - Padded flex containers now measure children against the same inner box they
@@ -153,6 +160,9 @@
   Lifetime-generic elements would make every container and component carry the
   borrowing policy even though the motivating state naturally belongs at the
   frame root.
+- Superseded on 2026-07-31 by `ScopedElement`: containers now stay generic over
+  their child type, so borrowed subtrees compose without forcing lifetime
+  parameters onto the ordinary owned `Element` path.
 
 - **Positioned as the default Rust TUI application framework**
 

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`Element`/`RenderCtx`, owned or scoped scene composition, layout, events, `Theme`/`StyleSheet`, `Surface`, host seam, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`Element`/`ScopedElement`/`RenderCtx`, owned or scoped scene composition, layout, events, `Theme`/`StyleSheet`, `Surface`, host seam, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -45,11 +45,13 @@ rather than beside it.
   root and overlay elements for one frame and resolves each overlay's
   `OverlaySpec` while rendering. This removes borrowed compositor plumbing
   without adding identity, lifecycle, or hidden persistent state.
-- **Scoped scenes borrow only the frame root.** `ScopedScene` lets a concrete
-  root read large host-owned state directly while overlays remain owned
-  elements. It uses the same renderer and focus-owner resolution as `Scene`;
-  keeping the borrowing boundary at the root avoids making `Element` and every
-  component lifetime-generic.
+- **Scoped element trees borrow for one frame.** `Element` remains the owned,
+  `'static` box used by retained host seams, while `ScopedElement<'frame>` may
+  hold a borrowed view anywhere in the base component tree. Composition
+  containers are generic over their child view type and default to `Element`,
+  preserving the ordinary owned path without parallel scoped components.
+  `ScopedScene` composes a borrowed base tree with owned overlays and shares the
+  same renderer and focus-owner resolution as `Scene`.
 - **The host owns the terminal**: the screen mode (alternate screen or a split
   footer over live scrollback — see [screen-modes.md](./screen-modes.md)), raw
   mode, mouse capture, input translation, and frame compositing.
@@ -165,9 +167,9 @@ the child's logical extent is much larger.
 ## Rendering pipeline
 
 1. The host builds the view tree from application state (optionally through the
-   `view!` DSL, which expands to the same builder calls — no runtime cost). A
-   root may borrow that state for the frame through `ScopedScene`; owned
-   component subtrees remain `Element`s.
+   `view!` DSL, which expands to the same builder calls — no runtime cost).
+   `element` preserves frame borrows as `ScopedElement`, so borrowed views may
+   appear at any depth in the base tree; `ScopedScene` adds owned overlays.
 2. The solver resolves the tree to rects.
 3. Views paint into a clipped `Surface`; overlays composite over the base.
 4. The host calls out-of-band emitters (images, native progress) after the

--- a/src/components/boxed.rs
+++ b/src/components/boxed.rs
@@ -56,8 +56,8 @@ use super::text::{aligned_x, line_width};
 /// ```
 ///
 /// ![boxed demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/boxed.png)
-pub struct Boxed {
-    child: Element,
+pub struct Boxed<V: View = Element> {
+    child: V,
     border: BorderStyle,
     border_color: Option<Color>,
     padding: Padding,
@@ -66,9 +66,9 @@ pub struct Boxed {
     background: Option<Style>,
 }
 
-impl Boxed {
+impl<V: View> Boxed<V> {
     /// Wrap `child` with default rounded border and symmetric horizontal padding.
-    pub fn new(child: Element) -> Self {
+    pub fn new(child: V) -> Self {
         Self {
             child,
             border: BorderStyle::Rounded,
@@ -164,7 +164,7 @@ impl Boxed {
     }
 }
 
-impl View for Boxed {
+impl<V: View> View for Boxed<V> {
     fn measure(&self, available: Size) -> Size {
         let chrome = self.chrome();
         let inner_avail = Size::new(

--- a/src/components/constrained.rs
+++ b/src/components/constrained.rs
@@ -5,15 +5,15 @@ use ratatui_core::layout::Rect;
 use crate::{Element, RenderCtx, Size, Surface, View};
 
 /// Clamp a child's measured size without changing its rendering contract.
-pub struct Constrained {
-    child: Element,
+pub struct Constrained<V: View = Element> {
+    child: V,
     min: Size,
     max: Size,
 }
 
-impl Constrained {
+impl<V: View> Constrained<V> {
     /// Wrap `child` with unconstrained defaults.
-    pub fn new(child: Element) -> Self {
+    pub fn new(child: V) -> Self {
         Self {
             child,
             min: Size::ZERO,
@@ -34,7 +34,7 @@ impl Constrained {
     }
 }
 
-impl View for Constrained {
+impl<V: View> View for Constrained<V> {
     fn measure(&self, available: Size) -> Size {
         let measured = self.child.measure(available);
         Size::new(

--- a/src/components/flex.rs
+++ b/src/components/flex.rs
@@ -12,10 +12,10 @@ use ratatui_core::style::Style;
 use crate::geometry::Size;
 use crate::layout::{Dimension, Item, LayoutStyle, solve};
 use crate::surface::Surface;
-use crate::view::{Element, RenderCtx, View};
+use crate::view::{Element, RenderCtx, ScopedElement, View};
 
-struct Child {
-    view: Element,
+struct Child<V: View> {
+    view: V,
     dimension: Dimension,
 }
 
@@ -37,30 +37,19 @@ struct Child {
 /// ```
 ///
 /// ![flex demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/flex.png)
-pub struct Flex {
+pub struct Flex<V: View = Element> {
     style: LayoutStyle,
-    children: Vec<Child>,
+    children: Vec<Child<V>>,
     background: Option<Style>,
 }
 
-impl Flex {
-    /// An empty flex container with the given layout style.
-    pub fn new(style: LayoutStyle) -> Self {
+impl<V: View> Flex<V> {
+    fn empty(style: LayoutStyle) -> Self {
         Self {
             style,
             children: Vec::new(),
             background: None,
         }
-    }
-
-    /// An empty container laying children left-to-right along the horizontal axis.
-    pub fn row() -> Self {
-        Self::new(LayoutStyle::row())
-    }
-
-    /// An empty container stacking children top-to-bottom along the vertical axis.
-    pub fn column() -> Self {
-        Self::new(LayoutStyle::column())
     }
 
     /// Fill the container area with `style` before drawing children.
@@ -94,23 +83,23 @@ impl Flex {
     }
 
     /// Add a child with an explicit main-axis dimension.
-    pub fn child(mut self, dimension: Dimension, view: Element) -> Self {
+    pub fn child(mut self, dimension: Dimension, view: V) -> Self {
         self.children.push(Child { view, dimension });
         self
     }
 
     /// Add an auto-sized child (sizes to its measured content).
-    pub fn auto(self, view: Element) -> Self {
+    pub fn auto(self, view: V) -> Self {
         self.child(Dimension::Auto, view)
     }
 
     /// Add a flexible child that grows to share leftover space.
-    pub fn grow(self, weight: u16, view: Element) -> Self {
+    pub fn grow(self, weight: u16, view: V) -> Self {
         self.child(Dimension::Flex(weight), view)
     }
 
     /// Add a fixed-size child.
-    pub fn fixed(self, cells: u16, view: Element) -> Self {
+    pub fn fixed(self, cells: u16, view: V) -> Self {
         self.child(Dimension::Fixed(cells), view)
     }
 
@@ -197,7 +186,39 @@ impl Flex {
     }
 }
 
-impl View for Flex {
+impl Flex<Element> {
+    /// An empty owned flex container with the given layout style.
+    pub fn new(style: LayoutStyle) -> Self {
+        Self::empty(style)
+    }
+
+    /// An empty owned row, laying children left-to-right.
+    pub fn row() -> Self {
+        Self::new(LayoutStyle::row())
+    }
+
+    /// An empty owned column, stacking children top-to-bottom.
+    pub fn column() -> Self {
+        Self::new(LayoutStyle::column())
+    }
+
+    /// An empty frame-borrowed flex container with the given layout style.
+    pub fn scoped<'view>(style: LayoutStyle) -> Flex<ScopedElement<'view>> {
+        Flex::empty(style)
+    }
+
+    /// An empty frame-borrowed row.
+    pub fn scoped_row<'view>() -> Flex<ScopedElement<'view>> {
+        Self::scoped(LayoutStyle::row())
+    }
+
+    /// An empty frame-borrowed column.
+    pub fn scoped_column<'view>() -> Flex<ScopedElement<'view>> {
+        Self::scoped(LayoutStyle::column())
+    }
+}
+
+impl<V: View> View for Flex<V> {
     fn measure(&self, available: Size) -> Size {
         // Sum children on the main axis, max on the cross axis, plus gaps and
         // padding. Used when this Flex is itself an Auto child.

--- a/src/components/focus_scope.rs
+++ b/src/components/focus_scope.rs
@@ -39,29 +39,29 @@ use crate::view::{Element, RenderCtx, View};
 /// let buffer = render(&panes, 24, 3, &Theme::default());
 /// # let _ = buffer;
 /// ```
-pub struct FocusScope {
+pub struct FocusScope<V: View = Element> {
     focused: bool,
-    child: Element,
+    child: V,
 }
 
-impl FocusScope {
+impl<V: View> FocusScope<V> {
     /// Render `child` with the given `focused` flag.
-    pub fn new(focused: bool, child: Element) -> Self {
+    pub fn new(focused: bool, child: V) -> Self {
         Self { focused, child }
     }
 
     /// Render `child` as focused. Shorthand for `FocusScope::new(true, child)`.
-    pub fn focused(child: Element) -> Self {
+    pub fn focused(child: V) -> Self {
         Self::new(true, child)
     }
 
     /// Render `child` as unfocused. Shorthand for `FocusScope::new(false, child)`.
-    pub fn unfocused(child: Element) -> Self {
+    pub fn unfocused(child: V) -> Self {
         Self::new(false, child)
     }
 }
 
-impl View for FocusScope {
+impl<V: View> View for FocusScope<V> {
     fn measure(&self, available: Size) -> Size {
         self.child.measure(available)
     }

--- a/src/components/form.rs
+++ b/src/components/form.rs
@@ -5,7 +5,7 @@ use ratatui_core::layout::Rect;
 use crate::event::{Event, EventFlow, KeyCode};
 use crate::geometry::Size;
 use crate::surface::Surface;
-use crate::view::{Element, RenderCtx, View};
+use crate::view::{Element, RenderCtx, ScopedElement, View};
 use crate::width::str_cols;
 
 /// Result of routing a form-level navigation event.
@@ -75,16 +75,16 @@ impl FormState {
 }
 
 /// One labeled control in a [`Form`].
-pub struct FormField {
+pub struct FormField<V: View = Element> {
     label: String,
-    control: Element,
+    control: V,
     help: Option<String>,
     error: Option<String>,
 }
 
-impl FormField {
+impl<V: View> FormField<V> {
     /// Create a labeled field around any control view.
-    pub fn new(label: impl Into<String>, control: Element) -> Self {
+    pub fn new(label: impl Into<String>, control: V) -> Self {
         Self {
             label: label.into(),
             control,
@@ -113,17 +113,16 @@ impl FormField {
 /// Responsive composition of labeled control views.
 ///
 /// ![form demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/primitives.gif)
-pub struct Form {
-    fields: Vec<FormField>,
+pub struct Form<V: View = Element> {
+    fields: Vec<FormField<V>>,
     focused: usize,
     stack_below: u16,
     gap: u16,
-    actions: Option<Element>,
+    actions: Option<V>,
 }
 
-impl Form {
-    /// Build a form and mirror the host-owned focused index from `state`.
-    pub fn new(fields: Vec<FormField>, state: &FormState) -> Self {
+impl<V: View> Form<V> {
+    fn build(fields: Vec<FormField<V>>, state: &FormState) -> Self {
         Self {
             fields,
             focused: state.focused(),
@@ -146,7 +145,7 @@ impl Form {
     }
 
     /// Add an actions row after all fields.
-    pub fn actions(mut self, actions: Element) -> Self {
+    pub fn actions(mut self, actions: V) -> Self {
         self.actions = Some(actions);
         self
     }
@@ -175,7 +174,22 @@ impl Form {
     }
 }
 
-impl View for Form {
+impl Form<Element> {
+    /// Build an owned form and mirror the host-owned focused index from `state`.
+    pub fn new(fields: Vec<FormField>, state: &FormState) -> Self {
+        Self::build(fields, state)
+    }
+
+    /// Build a form whose controls may borrow data for the current frame.
+    pub fn scoped<'view>(
+        fields: Vec<FormField<ScopedElement<'view>>>,
+        state: &FormState,
+    ) -> Form<ScopedElement<'view>> {
+        Form::build(fields, state)
+    }
+}
+
+impl<V: View> View for Form<V> {
     fn measure(&self, available: Size) -> Size {
         let stacked = self.stacked(available.width);
         let label_width = self.label_width(available.width);

--- a/src/components/item_scroll.rs
+++ b/src/components/item_scroll.rs
@@ -27,7 +27,7 @@ use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
-use crate::view::{Element, RenderCtx, View};
+use crate::view::{Element, RenderCtx, ScopedElement, View};
 
 use super::scroll::{ScrollState, draw_scrollbar};
 
@@ -51,10 +51,10 @@ use super::scroll::{ScrollState, draw_scrollbar};
 /// let buffer = render(&view, 6, 2, &Theme::default());
 /// assert_eq!(grid(&buffer), "first \nsecond");
 /// ```
-pub struct ItemScroll {
+pub struct ItemScroll<V: View = Element> {
     /// The items this view holds: all of them in [`new`](Self::new), or only the
     /// visible window in [`windowed`](Self::windowed).
-    items: Vec<Element>,
+    items: Vec<V>,
     /// Blank rows between two consecutive items.
     gap: u16,
     /// Content row of `items[0]`'s top edge. Zero for `new`.
@@ -70,11 +70,8 @@ pub struct ItemScroll {
     heights: RefCell<Option<(u16, Vec<u16>)>>,
 }
 
-impl ItemScroll {
-    /// A viewport over the whole `items`, painting the rows visible at `state`'s
-    /// offset. Every item is measured each frame; for a very long list prefer
-    /// [`windowed`](Self::windowed).
-    pub fn new(items: Vec<Element>, state: &ScrollState) -> Self {
+impl<V: View> ItemScroll<V> {
+    fn build(items: Vec<V>, state: &ScrollState) -> Self {
         Self {
             items,
             gap: 0,
@@ -94,8 +91,8 @@ impl ItemScroll {
     /// This is the O(viewport) path: the host keeps its own per-item height
     /// cache (heights only change when an item or the width changes) and hands
     /// over the slice, instead of tuika measuring every item every frame.
-    pub fn windowed(
-        window: Vec<Element>,
+    fn build_windowed(
+        window: Vec<V>,
         window_start_row: usize,
         content_height: usize,
         state: &ScrollState,
@@ -124,22 +121,6 @@ impl ItemScroll {
         self
     }
 
-    /// Total rows `items` occupy in a viewport `width` columns wide, including
-    /// `gap` rows between them.
-    ///
-    /// A host calls this **before** building the view, to reconcile its
-    /// [`ScrollState`] against the content it is about to paint (the state is
-    /// snapshotted into the view at construction, so clamping afterwards would
-    /// apply a frame late).
-    ///
-    /// `scrollbar` must match [`scrollbar`](Self::scrollbar) on the view: the
-    /// bar reserves the last column, and unlike a list of pre-wrapped lines, a
-    /// column of width changes where items wrap — and so how tall they are.
-    pub fn measure_height(items: &[Element], width: u16, gap: u16, scrollbar: bool) -> usize {
-        let heights = measure_items(items, content_width(width, scrollbar));
-        total_height(&heights, gap)
-    }
-
     /// Item heights at `width`, measuring (and memoizing) on first use.
     fn with_heights<R>(&self, width: u16, f: impl FnOnce(&[u16]) -> R) -> R {
         let mut cache = self.heights.borrow_mut();
@@ -160,6 +141,52 @@ impl ItemScroll {
     }
 }
 
+impl ItemScroll<Element> {
+    /// A viewport over all owned `items`, painting rows visible at `state`'s offset.
+    pub fn new(items: Vec<Element>, state: &ScrollState) -> Self {
+        Self::build(items, state)
+    }
+
+    /// A viewport over borrowed or owned items for the current frame.
+    pub fn scoped<'view>(
+        items: Vec<ScopedElement<'view>>,
+        state: &ScrollState,
+    ) -> ItemScroll<ScopedElement<'view>> {
+        ItemScroll::build(items, state)
+    }
+
+    /// An owned viewport that already holds only the visible item window.
+    pub fn windowed(
+        window: Vec<Element>,
+        window_start_row: usize,
+        content_height: usize,
+        state: &ScrollState,
+    ) -> Self {
+        Self::build_windowed(window, window_start_row, content_height, state)
+    }
+
+    /// A frame-borrowed viewport that already holds only the visible item window.
+    pub fn scoped_windowed<'view>(
+        window: Vec<ScopedElement<'view>>,
+        window_start_row: usize,
+        content_height: usize,
+        state: &ScrollState,
+    ) -> ItemScroll<ScopedElement<'view>> {
+        ItemScroll::build_windowed(window, window_start_row, content_height, state)
+    }
+
+    /// Total rows `items` occupy at `width`, including `gap` rows.
+    pub fn measure_height(items: &[Element], width: u16, gap: u16, scrollbar: bool) -> usize {
+        Self::measure_views(items, width, gap, scrollbar)
+    }
+
+    /// Total rows any owned or borrowed view slice occupies at `width`.
+    pub fn measure_views<V: View>(items: &[V], width: u16, gap: u16, scrollbar: bool) -> usize {
+        let heights = measure_items(items, content_width(width, scrollbar));
+        total_height(&heights, gap)
+    }
+}
+
 /// Columns left for content once the scrollbar has its column.
 ///
 /// The column is reserved whenever the bar is enabled, not only while the
@@ -174,7 +201,7 @@ fn content_width(width: u16, scrollbar: bool) -> u16 {
     }
 }
 
-fn measure_items(items: &[Element], width: u16) -> Vec<u16> {
+fn measure_items<V: View>(items: &[V], width: u16) -> Vec<u16> {
     items
         .iter()
         .map(|item| item.measure(Size::new(width, u16::MAX)).height)
@@ -187,7 +214,7 @@ fn total_height(heights: &[u16], gap: u16) -> usize {
     rows + gaps
 }
 
-impl View for ItemScroll {
+impl<V: View> View for ItemScroll<V> {
     fn measure(&self, available: Size) -> Size {
         // `Size` is a cell extent (`u16`); a transcript can be taller than that,
         // so saturate exactly as `Scroll` does.
@@ -261,8 +288,8 @@ impl View for ItemScroll {
 /// child does) would otherwise allocate a buffer of tens of megabytes to paint a
 /// handful of visible rows.
 #[allow(clippy::too_many_arguments)]
-fn render_scrolled(
-    item: &Element,
+fn render_scrolled<V: View>(
+    item: &V,
     x: u16,
     y: u16,
     width: u16,

--- a/src/components/responsive.rs
+++ b/src/components/responsive.rs
@@ -9,15 +9,15 @@ use crate::{Element, RenderCtx, Size, Surface, View};
 /// Each branch is a normal view tree, so an application can switch from a row
 /// to a column, omit secondary content, or choose a shorter status component
 /// without embedding breakpoint logic in individual leaves.
-pub struct Responsive {
+pub struct Responsive<V: View = Element> {
     breakpoint: u16,
-    compact: Element,
-    wide: Element,
+    compact: V,
+    wide: V,
 }
 
-impl Responsive {
+impl<V: View> Responsive<V> {
     /// Use `compact` below `breakpoint` columns and `wide` otherwise.
-    pub fn new(breakpoint: u16, compact: Element, wide: Element) -> Self {
+    pub fn new(breakpoint: u16, compact: V, wide: V) -> Self {
         Self {
             breakpoint,
             compact,
@@ -25,7 +25,7 @@ impl Responsive {
         }
     }
 
-    fn select(&self, width: u16) -> &Element {
+    fn select(&self, width: u16) -> &V {
         if width < self.breakpoint {
             &self.compact
         } else {
@@ -34,7 +34,7 @@ impl Responsive {
     }
 }
 
-impl View for Responsive {
+impl<V: View> View for Responsive<V> {
     fn measure(&self, available: Size) -> Size {
         self.select(available.width).measure(available)
     }

--- a/src/components/viewport.rs
+++ b/src/components/viewport.rs
@@ -19,8 +19,8 @@ use super::ScrollState;
 /// [`ScrollState`].
 ///
 /// ![viewport demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/primitives.gif)
-pub struct Viewport {
-    child: Element,
+pub struct Viewport<V: View = Element> {
+    child: V,
     content: Size,
     offset: usize,
     x_offset: usize,
@@ -28,9 +28,9 @@ pub struct Viewport {
     horizontal_scrollbar: bool,
 }
 
-impl Viewport {
+impl<V: View> Viewport<V> {
     /// Create a viewport for `child` with its full un-clipped `content` extent.
-    pub fn new(child: Element, content: Size, state: &ScrollState) -> Self {
+    pub fn new(child: V, content: Size, state: &ScrollState) -> Self {
         Self {
             child,
             content,
@@ -95,7 +95,7 @@ impl Viewport {
     }
 }
 
-impl View for Viewport {
+impl<V: View> View for Viewport<V> {
     fn measure(&self, available: Size) -> Size {
         Size::new(
             self.content.width.min(available.width),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@
 //! The crate root re-exports the **framework**: the view model, layout,
 //! events, styling, and the host seam — the types you compose *with*. The
 //! widgets themselves live in [`components`]. Owned [`Element`] trees use
-//! [`Scene`]; a concrete root that borrows large application state uses
-//! [`ScopedScene`] without cloning it. Everything that talks to the
+//! [`Scene`]; [`ScopedElement`] trees may borrow application state at any depth
+//! and use [`ScopedScene`] without cloning it. Everything that talks to the
 //! terminal outside the cell grid (clipboard, hyperlinks, images, native
 //! progress, capability detection) lives in [`term`].
 //!
@@ -58,7 +58,8 @@
 //! # Extending
 //!
 //! Add a component by implementing [`view::View`] in a new module under
-//! [`components`]. No registration step; containers accept any boxed `View`.
+//! [`components`]. No registration step; containers accept owned or
+//! frame-borrowed views.
 //!
 //! Existing ratatui widgets should normally be wrapped in
 //! [`RatatuiView`](interop::RatatuiView), which preserves Tuika clipping without
@@ -132,7 +133,7 @@ pub use scene::{Backdrop, Scene, SceneOverlay, ScopedScene};
 pub use screen::{ScreenMode, Scrollback};
 pub use style::{SemanticRole, StyleSheet, Theme};
 pub use surface::Surface;
-pub use view::{Element, RenderCtx, View, element};
+pub use view::{Element, RenderCtx, ScopedElement, View, element};
 
 #[cfg(test)]
 mod tests;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,8 +35,11 @@
 //! `MyWidget { … }` syntax for external components; the `node(expr)` escape
 //! hatch covers that case today.
 
-/// Build a tuika [`Element`](crate::view::Element) tree from a declarative,
-/// top-down layout description.
+/// Build a boxed view tree from a declarative, top-down layout description.
+///
+/// The returned [`ScopedElement`](crate::view::ScopedElement) keeps any borrows
+/// used by `node(expr)`, while a tree containing only owned views naturally
+/// coerces to [`Element`](crate::view::Element).
 ///
 /// Each keyword consumes exactly one node: `col`/`row` open flex containers
 /// (with optional `gap`/`padding`/`align`/`justify`/`background` attrs and a
@@ -57,13 +60,13 @@ macro_rules! view {
 
     // ---- @one: parse one node into an Element -------------------------------
     (@one col $(( $($attr:tt)* ))? { $($kids:tt)* }) => {{
-        let __flex = $crate::components::Flex::column();
+        let __flex = $crate::components::Flex::scoped_column();
         let __flex = $crate::view!(@attrs __flex; $($($attr)*)?);
         let __flex = $crate::view!(@kids __flex; $($kids)*);
         $crate::element(__flex)
     }};
     (@one row $(( $($attr:tt)* ))? { $($kids:tt)* }) => {{
-        let __flex = $crate::components::Flex::row();
+        let __flex = $crate::components::Flex::scoped_row();
         let __flex = $crate::view!(@attrs __flex; $($($attr)*)?);
         let __flex = $crate::view!(@kids __flex; $($kids)*);
         $crate::element(__flex)
@@ -239,5 +242,38 @@ mod tests {
         };
         let out = render_el(&tree, 5, 2);
         assert!(out[0].contains('★'), "foreign view should render: {out:?}");
+    }
+
+    struct BorrowedLabel<'a>(&'a str);
+
+    impl View for BorrowedLabel<'_> {
+        fn measure(&self, available: Size) -> Size {
+            Size::new(
+                (self.0.len() as u16).min(available.width),
+                available.height.min(1),
+            )
+        }
+
+        fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
+            surface.set_string(area.x, area.y, self.0, Style::default());
+        }
+    }
+
+    #[test]
+    fn view_macro_preserves_borrows_through_nested_containers() {
+        let label = String::from("borrowed");
+        let tree = crate::view! {
+            boxed(title = " frame ") {
+                col {
+                    node(BorrowedLabel(&label))
+                }
+            }
+        };
+
+        let rendered = crate::testing::render(&tree, 14, 3, &crate::Theme::default());
+        assert!(
+            crate::testing::grid(&rendered).contains("borrowed"),
+            "a borrow must survive node -> Flex -> Boxed composition"
+        );
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -22,9 +22,9 @@
 //! pair. When that happens, import the two you need by path instead; the glob is
 //! a convenience, never a requirement.
 //!
-//! Both ownership forms of frame composition are included: [`Scene`] owns its
-//! root, while [`ScopedScene`] borrows a concrete root that reads host-owned
-//! data for the duration of one paint.
+//! Both ownership forms of frame composition are included: [`Element`] owns a
+//! boxed view, [`ScopedElement`] may borrow data anywhere in a base subtree,
+//! and [`ScopedScene`] composes such a tree with owned overlays for one paint.
 
 pub use crate::anim::{Easing, Repeat, Timeline};
 pub use crate::components::*;
@@ -41,9 +41,9 @@ pub use crate::view;
 pub use crate::{
     Align, Backdrop, Dimension, Direction, Element, Event, EventFlow, Justify, Key, KeyCode,
     LayoutStyle, Mouse, MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx, Runner,
-    RunnerConfig, Scene, SceneOverlay, ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal,
-    Size, StyleSheet, Surface, TerminalSession, Theme, UpdateResult, View, element, paint,
-    paint_scene, paint_with_sheet, translate_event,
+    RunnerConfig, Scene, SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback,
+    SemanticRole, Signal, Size, StyleSheet, Surface, TerminalSession, Theme, UpdateResult, View,
+    element, paint, paint_scene, paint_with_sheet, translate_event,
 };
 
 #[cfg(feature = "async")]

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -27,7 +27,7 @@ use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
-use crate::view::{Element, RenderCtx, View, element};
+use crate::view::{Element, RenderCtx, ScopedElement, View, element};
 
 /// A shared handle that receives the screen [`Rect`] tuika assigned to a
 /// [`Probe`]-wrapped view during the last paint. Cheap to clone (shared cell);
@@ -51,7 +51,7 @@ impl RectProbe {
 
     /// Wrap `view` so its painted rect is reported here. Shorthand for
     /// [`Probe::new`].
-    pub fn wrap(&self, view: Element) -> Element {
+    pub fn wrap<'view, V: View + 'view>(&self, view: V) -> ScopedElement<'view> {
         element(Probe::new(view, self))
     }
 
@@ -63,14 +63,14 @@ impl RectProbe {
 /// A view that records the area it is painted into via a [`RectProbe`], then
 /// renders its inner view unchanged. Layout-transparent: it measures and draws
 /// exactly as the wrapped view does.
-pub struct Probe {
-    inner: Element,
+pub struct Probe<V: View = Element> {
+    inner: V,
     probe: RectProbe,
 }
 
-impl Probe {
+impl<V: View> Probe<V> {
     /// Wrap `inner` so its painted rect is reported to `probe`.
-    pub fn new(inner: Element, probe: &RectProbe) -> Self {
+    pub fn new(inner: V, probe: &RectProbe) -> Self {
         Self {
             inner,
             probe: probe.clone(),
@@ -78,7 +78,7 @@ impl Probe {
     }
 }
 
-impl View for Probe {
+impl<V: View> View for Probe<V> {
     fn measure(&self, available: Size) -> Size {
         self.inner.measure(available)
     }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -8,12 +8,11 @@
 //! painting. The borrowed root does not need to clone that state or become a
 //! boxed `'static` [`Element`].
 //!
-//! Only the root is borrowed. Overlay views remain owned [`Element`]s, so all
-//! existing components, [`Dialog`](crate::components::Dialog) compositions, and
-//! scene focus behavior work unchanged. If a nested container itself needs
-//! borrowed children, implement a concrete [`View`] for that borrowed subtree
-//! and use it as the scoped root; `Element` and existing component APIs remain
-//! deliberately non-generic over lifetimes.
+//! Overlay views remain owned [`Element`]s, so dialogs and scene focus behavior
+//! stay independent of the root borrow. The base tree may contain borrowed
+//! views at any depth: [`element`](crate::element) preserves the borrow as a
+//! [`ScopedElement`](crate::ScopedElement), and composition containers accept
+//! that scoped element without requiring a custom wrapper view.
 //!
 //! # Borrowed application data with an owned dialog
 //!

--- a/src/view.rs
+++ b/src/view.rs
@@ -71,14 +71,17 @@ pub trait View {
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx);
 }
 
-/// Boxed `'static` view, the element type stored by owned containers.
+/// A boxed view that may borrow data for `'view`.
 ///
-/// For a frame root that borrows host state, keep the concrete view on the
-/// stack and compose it with [`ScopedScene`](crate::ScopedScene) instead of
-/// cloning the state into an `Element`.
-pub type Element = Box<dyn View>;
+/// Composition containers are generic over their child view type and default
+/// to owned [`Element`]s. Use `ScopedElement<'_>` when a heterogeneous subtree
+/// contains frame-borrowed views.
+pub type ScopedElement<'view> = Box<dyn View + 'view>;
 
-impl View for Element {
+/// Boxed owned view used by retained values and cross-thread host seams.
+pub type Element = ScopedElement<'static>;
+
+impl View for Box<dyn View + '_> {
     fn measure(&self, available: Size) -> Size {
         (**self).measure(available)
     }
@@ -88,8 +91,11 @@ impl View for Element {
     }
 }
 
-/// Convenience to box any view into an [`Element`].
-pub fn element<V: View + 'static>(view: V) -> Element {
+/// Box a view while preserving any data it borrows.
+///
+/// A `'static` view naturally produces an owned [`Element`]. A borrowed view
+/// produces a [`ScopedElement`] whose lifetime cannot escape the current frame.
+pub fn element<'view, V: View + 'view>(view: V) -> ScopedElement<'view> {
     Box::new(view)
 }
 

--- a/tests/scoped_scene.rs
+++ b/tests/scoped_scene.rs
@@ -51,3 +51,20 @@ fn borrowed_transcript_and_owned_dialog_paint_as_one_root() {
     assert_eq!(focus.active(), Some("confirm"));
     assert_eq!(messages[1], "second message");
 }
+
+#[test]
+fn borrowed_view_composes_through_macro_flex_and_boxed() {
+    let source = String::from("# nested borrow");
+    let highlighter = PlainHighlighter;
+    let root: ScopedElement<'_> = view! {
+        boxed(title = " transcript ") {
+            col {
+                node(Markdown::new(&source).highlighter(&highlighter))
+            }
+        }
+    };
+    let scene = ScopedScene::new(root.as_ref());
+    let rendered = tuika::testing::render(&scene, 24, 3, &Theme::default());
+
+    assert!(grid(&rendered).contains("nested borrow"));
+}


### PR DESCRIPTION
## What changed

`element` now preserves a view borrow as `ScopedElement`, and composition containers accept borrowed child trees without separate scoped component types. Owned `Element` remains the default for existing builders and retained host seams.

`view!` carries frame borrows through nested Flex and Boxed nodes. Forms, item viewports, probes, responsive/constrained wrappers, focus scopes, and two-dimensional viewports use the same child-generic model.

Public API change: additive `ScopedElement`, scoped Flex/Form/ItemScroll constructors, and child-type parameters with owned defaults on composition components. Existing owned calls and type names remain source-compatible.

## Why

`ScopedScene` previously allowed borrowing only at the root. A borrowed Markdown highlighter or large frame model nested inside ordinary layout required cloning data or writing a custom root View, making composition depend on ownership policy.

## Before / After

Before: `view! { boxed { col { node(Markdown::new(&source).highlighter(&highlighter)) } } }` could not compile because nested `element` required `static`.

After: the same tree compiles as `ScopedElement`, renders through `ScopedScene`, and keeps both source and highlighter borrowed for exactly the frame lifetime. A consumer integration test exercises Markdown through node -> Flex -> Boxed.

The Flex demo dump is visually unchanged and `demo -- check` reports all 30 scenes in sync.

## Risk

- Medium
- Composition structs now have defaulted child type parameters. Existing owned construction is unchanged; downstream code relying on the exact monomorphic type identity may need to name the default `Element` parameter explicitly.
- Borrowed trees cannot enter retained or cross-thread APIs, enforced by Rust lifetimes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

Validation:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo +1.88 check -p tuika --all-targets --all-features
- python3 scripts/validate_okf.py knowledge --check-links
- cargo run --example demo -- flex --dump
- cargo run --example demo -- check

## Knowledge

Updated Rendering Architecture, Public API Surface, the knowledge log, README, component guide, rustdoc, and changelog.

## Security

Reviewed TM-CLIP, TM-STATE, TM-PARSE, TM-ESC, and TM-DEP. The change only broadens compile-time ownership and generic dispatch: render geometry, clipping, allocations, parser inputs, escape emission, and terminal lifecycle are unchanged. No dependencies, unsafe code, filesystem/network access, or credentials were added.

## Follow-ups

No follow-ups.