### PR TITLE
feat(view): measure with render context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,20 @@ block-HTML seam.
   Enter/Ctrl+J submission, and allocation-free borrowed text access.
 - `tuika::ui` re-exports `Rect`, `Color`, `Style`, `Modifier`, `Line`, and `Span`
   for custom views without a direct `ratatui-core` dependency.
+- `testing::render_with_sheet` renders consumer views under an explicit
+  stylesheet in the same hermetic buffer harness as `testing::render`.
 
 ### Changed
 
+- **Breaking:** `View::measure` now takes `&RenderCtx`, and every composition
+  container forwards the frame's active theme, stylesheet, and focus state.
+  Migrate `fn measure(&self, available: Size)` implementations to
+  `fn measure(&self, available: Size, ctx: &RenderCtx)`; callers likewise pass
+  the context used for rendering. `Flex::solve` now takes that context, and
+  `ItemScroll::{measure_height, measure_views}` take it as their final argument.
+- `Markdown` and the companion `tuika-html::Html` view now measure with the same
+  theme and stylesheet they render with. `Boxed` implements stylesheet panel
+  padding as real layout; an explicit `.padding(...)` wins over the stylesheet.
 - `element`, `view!`, and composition containers now preserve borrowed child
   views at any depth. Existing owned trees continue to use `Element`; borrowed
   trees use the same builders and are bounded to their frame lifetime.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ struct Dashboard<'a> {
 }
 
 impl View for Dashboard<'_> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         available
     }
 
@@ -290,6 +290,10 @@ The borrow lasts only as long as the scoped scene, matching Tuika's
 frame-by-frame view model. No transcript clone, leaked allocation, custom
 wrapper view, or application compositor is needed. The `view!` macro preserves
 the same lifetime through nested `Flex` and `Boxed` containers.
+
+Measurement receives the same `RenderCtx` as rendering. A custom view whose
+geometry depends on the active theme or stylesheet resolves it there, and every
+container passes that context to the children it measures.
 
 `Form` lays out arbitrary control `Element`s beside responsive labels, stacking
 on narrow terminals. Help and validation rows are built in; `FormState` owns
@@ -413,7 +417,9 @@ Where a `Theme` is the color *tokens*, a `StyleSheet` is the *rules* — a mappi
 from a semantic role (heading, link, inline code, a panel's border and fill, …)
 onto the style it draws with. Override a role in one place and every element with
 that role restyles at once; markdown parts and bare URLs are role-driven too. See
-the [styling guide](docs/styling.md).
+the [styling guide](docs/styling.md). `StyleBundle::padding` is layout, not a
+paint-only hint: `Boxed` resolves panel padding during both measurement and
+rendering; an explicit `Boxed::padding` remains the per-instance override.
 
 ## Runnable examples
 
@@ -715,6 +721,8 @@ terminal or `TestBackend` setup. The [`testing`](https://docs.rs/tuika/latest/tu
 module draws a `View` into an in-memory ratatui `Buffer` and reads it back:
 
 - `render(view, width, height, &theme) -> Buffer` — draw once at a fixed size.
+- `render_with_sheet(view, width, height, &theme, sheet) -> Buffer` — the same
+  harness with an explicit stylesheet.
 - `grid(&buffer) -> String` — the buffer as a plain glyph grid, ready for a
   snapshot assertion.
 - `render_sizes(view, sizes, &theme) -> Vec<Buffer>` — the same view across a set

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -28,7 +28,7 @@ fn scene() -> Element {
 struct Padded;
 
 impl View for Padded {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         available
     }
 

--- a/crates/tuika-html/src/view.rs
+++ b/crates/tuika-html/src/view.rs
@@ -59,8 +59,8 @@ impl Html {
 }
 
 impl View for Html {
-    fn measure(&self, available: Size) -> Size {
-        let lines = self.lines(available.width, &Theme::default(), &StyleSheet::default());
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        let lines = self.lines(available.width, ctx.theme, &ctx.sheet);
         let width = lines.iter().map(line_width).max().unwrap_or(0);
         Size::new(width.min(available.width), lines.len() as u16)
     }
@@ -89,7 +89,9 @@ impl View for Html {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tuika::testing::{grid, render};
+    use ratatui_core::style::Color;
+    use tuika::style::StyleBundle;
+    use tuika::testing::{grid, render, render_with_sheet};
 
     #[test]
     fn the_view_paints_its_fragment() {
@@ -100,10 +102,22 @@ mod tests {
 
     #[test]
     fn the_view_measures_its_rendered_size() {
-        let view = Html::new("<p>one two</p>");
-        let size = view.measure(Size::new(4, 10));
-        assert!(size.height >= 2, "wrapped to two rows: {size:?}");
-        assert!(size.width <= 4);
+        let view = Html::new("<h1>Title</h1><p>body</p>");
+        let theme = Theme {
+            accent: Color::Cyan,
+            ..Theme::default()
+        };
+        let sheet = StyleSheet {
+            heading: StyleBundle::new().fg(Color::Magenta),
+            ..StyleSheet::from_theme(&theme)
+        };
+        let ctx = RenderCtx::new(&theme).with_sheet(sheet);
+        let size = view.measure(Size::new(12, 10), &ctx);
+
+        assert_eq!(size, Size::new(5, 3));
+        let painted = render_with_sheet(&view, 12, size.height, &theme, sheet);
+        assert_eq!(grid(&painted), "Title       \n            \nbody        ");
+        assert_eq!(painted[(0, 0)].fg, Color::Magenta);
     }
 
     #[test]

--- a/docs/components.md
+++ b/docs/components.md
@@ -234,7 +234,9 @@ use ratatui::layout::Rect;
 let flex = Flex::row()
     .fixed(8, element(Text::raw("sidebar")))
     .grow(1, element(Text::raw("content")));
-let rects = flex.solve(Rect::new(0, 0, 40, 10)); // [sidebar_rect, content_rect]
+let theme = Theme::default();
+let ctx = RenderCtx::new(&theme);
+let rects = flex.solve(Rect::new(0, 0, 40, 10), &ctx); // [sidebar_rect, content_rect]
 ```
 
 ### `Boxed`
@@ -247,6 +249,8 @@ bottom border — the slot for a `1 of 3` position counter, a footer legend, or 
 hint. Both titles honor their `Line` alignment; unset, the top title is
 flush-left and the bottom title flush-right. Titles begin one cell after the
 corner and truncate before the opposite corner, matching ratatui `Block`.
+The stylesheet's panel padding participates in measurement and rendering;
+`.padding(...)` on this instance takes precedence.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.Boxed.html)
 
 <img src="demos/boxed.png" width="880" alt="Boxed demo">
@@ -366,7 +370,8 @@ plus the true height for lists too long to measure every frame.
 ```rust
 use tuika::prelude::*;
 let items: Vec<Element> = history.iter().map(|entry| entry.view()).collect();
-let content_h = ItemScroll::measure_height(&items, width, 1, true);
+let ctx = RenderCtx::new(&theme).with_sheet(sheet);
+let content_h = ItemScroll::measure_height(&items, width, 1, true, &ctx);
 state.clamp(content_h, viewport_h);          // reconcile before the paint
 view! { node(ItemScroll::new(items, &state).gap(1)) }
 ```

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -126,16 +126,19 @@ use tuika::prelude::*;
 
 let theme = Theme::default();
 let sheet = StyleSheet {
-    panel: StyleBundle::new().fg(theme.accent_alt).bg(theme.surface),
+    panel: StyleBundle::new()
+        .fg(theme.accent_alt)
+        .bg(theme.surface)
+        .padding(Padding::all(2)),
     ..StyleSheet::from_theme(&theme)
 };
 ```
 
-Only **paint-time** attributes are stylesheet-owned. A component's `measure`
-runs without a render context, so choices that change a component's footprint —
-whether a border exists, how much padding — stay instance-level (e.g.
-`Boxed::border`, `Boxed::padding`); the sheet owns color, background, and text
-modifiers.
+Measurement and rendering receive the same context, so the panel role's padding
+changes both the size a `Boxed` requests and the inner rectangle it paints.
+`Boxed::padding` is the local override when one panel needs different spacing.
+Whether a border exists remains instance-level (`Boxed::border`); color and
+text modifiers remain ordinary paint-time rules.
 
 ## Side by side
 

--- a/examples/codex/ui.rs
+++ b/examples/codex/ui.rs
@@ -63,7 +63,8 @@ pub fn build(
     // Item heights are measured the way the viewport will measure them — same
     // width, same scrollbar setting — so the offset can't drift from the paint.
     let items = app.transcript(width, theme, sheet);
-    app.content_h = ItemScroll::measure_height(&items, width, TRANSCRIPT_GAP, true);
+    let ctx = RenderCtx::new(theme).with_sheet(*sheet);
+    app.content_h = ItemScroll::measure_height(&items, width, TRANSCRIPT_GAP, true, &ctx);
     app.viewport_h = transcript_h as usize;
     app.scroll.clamp(app.content_h, app.viewport_h);
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1155,7 +1155,7 @@ fn scene_item_scroll(frame: u64, theme: &Theme) -> Element {
         })
         .collect();
     let viewport_h = 8usize;
-    let content_h = ItemScroll::measure_height(&items, 60, 1, true);
+    let content_h = ItemScroll::measure_height(&items, 60, 1, true, &RenderCtx::new(theme));
     let mut state = ScrollState::new();
     let reach = tuika::anim::ping_pong(frame, 200);
     let steps = (reach * (content_h.saturating_sub(viewport_h) as f32 / 3.0 + 1.0)) as u32;

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,17 @@
 
 ## 2026-07-31
 
+- **Measurement and rendering share one frame context**
+
+- `View::measure` now receives the active `RenderCtx`, and composition helpers
+  forward it through the whole tree. Layout can no longer use the default theme
+  or stylesheet while the same view renders with host policy.
+- Markdown and the companion HTML view resolve one theme/stylesheet pair for
+  both halves. `Boxed` now treats stylesheet panel padding as real geometry,
+  with an explicit instance padding as the local override.
+- Consumer tests can use `testing::render_with_sheet`, so a custom stylesheet is
+  asserted through the same in-memory buffer path as production rendering.
+
 - **Borrowed views compose inside ordinary component trees**
 
 - `Element` remains the owned default, while `ScopedElement` carries a frame

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -45,9 +45,10 @@ identically. `.gitattributes` pins the files to LF and the comparison normalizes
 line endings, so neither a Windows CI leg nor a contributor's `core.autocrlf`
 can turn a green suite red.
 
-The consumer-facing subset of this machinery — `testing::{render, render_sizes,
-grid}` — is public API, so hosts test their own views the same way. Changes to
-it are API changes.
+The consumer-facing subset of this machinery — `testing::{render,
+render_with_sheet, render_sizes, grid}` — is public API, so hosts test their own
+views with the same theme and stylesheet contexts used in production. Changes
+to it are API changes.
 
 ## Why a PTY layer exists at all
 

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -99,6 +99,10 @@ genuinely public helper module for *consumers*; see
   implementations must name (`Rect`, colors/styles, and text lines/spans), so a
   host need not add a direct backend dependency merely to implement tuika's
   trait. Backend operations and widgets remain private.
+- `View::measure` and `View::render` receive the same `RenderCtx`. Any public
+  helper that measures a component tree (`Flex::solve`, item-height helpers,
+  split-footer publication) must require or already own that context; it may not
+  synthesize default styling behind the host's back.
 - The prelude may grow, but adding to it is a judgement about frequency, not a
   convenience: a name that lands there is one a host should not have to think
   about. Terminal escapes, pixel canvases, probes, and width measurement are

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -60,12 +60,15 @@ rather than beside it.
   is an explicit dirty result or an external redraw request. Rendering stays
   pure, and idle ticks do not churn the terminal.
 
-`measure` and `render` are the two halves of every view: `measure` reports a
-size in whole cells so the solver can allocate, `render` paints into the clipped
-region it was given. Sizes are whole cells throughout — there is no sub-cell
-layout — which is why image sizing is quantized to cells rather than driven by
-pixel geometry. A container measures children against the content box they will
-actually receive after its own padding. When a `Flex` is itself measured, its
+`measure` and `render` are the two halves of every view, and both receive the
+same `RenderCtx`: `measure` reports a size in whole cells so the solver can
+allocate, while `render` paints into the clipped region it was given. Theme,
+stylesheet, and focus therefore cannot silently fall back to defaults during
+layout. Sizes are whole cells throughout — there is no sub-cell layout — which
+is why image sizing is quantized to cells rather than driven by pixel geometry.
+A container forwards the context while measuring children against the content
+box they will actually receive after its own resolved padding. An explicit
+component padding overrides stylesheet padding. When a `Flex` is itself measured, its
 declared fixed and percent dimensions contribute their resolved main-axis sizes;
 the child's intrinsic size is the basis only for auto and flexible children.
 
@@ -170,7 +173,7 @@ the child's logical extent is much larger.
    `view!` DSL, which expands to the same builder calls — no runtime cost).
    `element` preserves frame borrows as `ScopedElement`, so borrowed views may
    appear at any depth in the base tree; `ScopedScene` adds owned overlays.
-2. The solver resolves the tree to rects.
+2. The solver resolves the tree to rects using the frame's active `RenderCtx`.
 3. Views paint into a clipped `Surface`; overlays composite over the base.
 4. The host calls out-of-band emitters (images, native progress) after the
    frame, because those escapes paint outside the cell model.

--- a/src/components/ascii_font.rs
+++ b/src/components/ascii_font.rs
@@ -136,7 +136,7 @@ impl AsciiFont {
 }
 
 impl View for AsciiFont {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let width = self.total_width().min(available.width);
         let height = if self.text.is_empty() {
             0
@@ -183,10 +183,15 @@ mod tests {
     #[test]
     fn measures_five_rows_and_summed_width() {
         let font = AsciiFont::new("HI");
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
         // 'H' and 'I' are each 5 wide, plus one spacing column = 11.
-        assert_eq!(font.measure(Size::new(80, 24)), Size::new(11, 5));
+        assert_eq!(font.measure(Size::new(80, 24), &ctx), Size::new(11, 5));
         // Empty string has no height.
-        assert_eq!(AsciiFont::new("").measure(Size::new(80, 24)).height, 0);
+        assert_eq!(
+            AsciiFont::new("").measure(Size::new(80, 24), &ctx).height,
+            0
+        );
     }
 
     #[test]

--- a/src/components/boxed.rs
+++ b/src/components/boxed.rs
@@ -60,7 +60,7 @@ pub struct Boxed<V: View = Element> {
     child: V,
     border: BorderStyle,
     border_color: Option<Color>,
-    padding: Padding,
+    padding: Option<Padding>,
     title: Option<Line<'static>>,
     title_bottom: Option<Line<'static>>,
     background: Option<Style>,
@@ -73,7 +73,7 @@ impl<V: View> Boxed<V> {
             child,
             border: BorderStyle::Rounded,
             border_color: None,
-            padding: Padding::symmetric(1, 0),
+            padding: None,
             title: None,
             title_bottom: None,
             background: None,
@@ -102,8 +102,12 @@ impl<V: View> Boxed<V> {
     }
 
     /// Set the padding between the border and the child.
+    ///
+    /// This explicit value takes precedence over the stylesheet's
+    /// [`Role::Panel`] padding. Without either, panels retain the default of one
+    /// horizontal cell and no vertical padding.
     pub fn padding(mut self, padding: Padding) -> Self {
-        self.padding = padding;
+        self.padding = Some(padding);
         self
     }
 
@@ -141,7 +145,13 @@ impl<V: View> Boxed<V> {
     }
 
     /// Interior rect available to the child after border + padding.
-    fn inner(&self, area: Rect) -> Rect {
+    fn resolved_padding(&self, ctx: &RenderCtx) -> Padding {
+        self.padding
+            .or(ctx.sheet.resolve(Role::Panel).padding)
+            .unwrap_or_else(|| Padding::symmetric(1, 0))
+    }
+
+    fn inner(&self, area: Rect, padding: Padding) -> Rect {
         let bordered = if self.has_border() {
             Rect {
                 x: area.x.saturating_add(1),
@@ -152,30 +162,31 @@ impl<V: View> Boxed<V> {
         } else {
             area
         };
-        self.padding.inner(bordered)
+        padding.inner(bordered)
     }
 
-    fn chrome(&self) -> Size {
+    fn chrome(&self, padding: Padding) -> Size {
         let border = if self.has_border() { 2 } else { 0 };
         Size::new(
-            self.padding.horizontal().saturating_add(border),
-            self.padding.vertical().saturating_add(border),
+            padding.horizontal().saturating_add(border),
+            padding.vertical().saturating_add(border),
         )
     }
 }
 
 impl<V: View> View for Boxed<V> {
-    fn measure(&self, available: Size) -> Size {
-        let chrome = self.chrome();
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        let chrome = self.chrome(self.resolved_padding(ctx));
         let inner_avail = Size::new(
             available.width.saturating_sub(chrome.width),
             available.height.saturating_sub(chrome.height),
         );
-        let content = self.child.measure(inner_avail);
+        let content = self.child.measure(inner_avail, ctx);
         Size::new(
             content.width.saturating_add(chrome.width),
             content.height.saturating_add(chrome.height),
         )
+        .clamp_to(available)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -217,7 +228,7 @@ impl<V: View> View for Boxed<V> {
                 draw_title(surface, area, bottom, title, Alignment::Right);
             }
         }
-        let inner = self.inner(area);
+        let inner = self.inner(area, self.resolved_padding(ctx));
         let mut inner_surface = surface.child(inner);
         self.child.render(inner, &mut inner_surface, ctx);
     }
@@ -255,7 +266,7 @@ mod tests {
     use super::*;
     use crate::Surface;
     use crate::components::Text;
-    use crate::style::Theme;
+    use crate::style::{StyleBundle, StyleSheet, Theme};
     use crate::tests::support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View, element};
     use ratatui_core::style::{Color, Modifier};
@@ -277,6 +288,40 @@ mod tests {
                 assert_eq!(buf[(w - 1, h - 1)].symbol(), "╯", "bottom-right at {w}x{h}");
             }
         }
+    }
+
+    #[test]
+    fn stylesheet_padding_affects_measurement_and_render_with_instance_precedence() {
+        let theme = Theme::default();
+        let sheet = StyleSheet {
+            panel: StyleBundle::new().padding(Padding::all(2)),
+            ..StyleSheet::from_theme(&theme)
+        };
+        let ctx = RenderCtx::new(&theme).with_sheet(sheet);
+        let styled = Boxed::new(element(Text::raw("x")));
+        assert_eq!(styled.measure(Size::new(20, 20), &ctx), Size::new(7, 7));
+
+        let mut buf = buffer(7, 7);
+        let area = buf.area;
+        styled.render(area, &mut Surface::new(&mut buf, area), &ctx);
+        assert_eq!(buf[(3, 3)].symbol(), "x");
+
+        let explicit = Boxed::new(element(Text::raw("x"))).padding(Padding::ZERO);
+        assert_eq!(explicit.measure(Size::new(20, 20), &ctx), Size::new(3, 3));
+        let mut buf = buffer(3, 3);
+        let area = buf.area;
+        explicit.render(area, &mut Surface::new(&mut buf, area), &ctx);
+        assert_eq!(buf[(1, 1)].symbol(), "x");
+
+        let oversized_sheet = StyleSheet {
+            panel: StyleBundle::new().padding(Padding::all(u16::MAX)),
+            ..StyleSheet::from_theme(&theme)
+        };
+        let oversized_ctx = RenderCtx::new(&theme).with_sheet(oversized_sheet);
+        assert_eq!(
+            styled.measure(Size::new(2, 2), &oversized_ctx),
+            Size::new(2, 2)
+        );
     }
 
     #[test]

--- a/src/components/code_block.rs
+++ b/src/components/code_block.rs
@@ -197,7 +197,7 @@ impl<'a> CodeBlock<'a> {
 }
 
 impl View for CodeBlock<'_> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let theme = Theme::default();
         let lines = self.lines(&theme);
         let width = lines

--- a/src/components/console.rs
+++ b/src/components/console.rs
@@ -170,7 +170,7 @@ impl<'a> Console<'a> {
 }
 
 impl View for Console<'_> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         available
     }
 

--- a/src/components/constrained.rs
+++ b/src/components/constrained.rs
@@ -35,8 +35,8 @@ impl<V: View> Constrained<V> {
 }
 
 impl<V: View> View for Constrained<V> {
-    fn measure(&self, available: Size) -> Size {
-        let measured = self.child.measure(available);
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        let measured = self.child.measure(available, ctx);
         Size::new(
             measured
                 .width
@@ -65,10 +65,15 @@ mod tests {
 
     #[test]
     fn constrained_clamps_intrinsic_measurement() {
+        let theme = crate::Theme::default();
+        let ctx = RenderCtx::new(&theme);
         let constrained = Constrained::new(element(Text::raw("long content")))
             .min_size(4, 1)
             .max_size(6, 2);
-        assert_eq!(constrained.measure(Size::new(20, 10)), Size::new(6, 1));
-        assert_eq!(constrained.measure(Size::new(3, 1)), Size::new(3, 1));
+        assert_eq!(
+            constrained.measure(Size::new(20, 10), &ctx),
+            Size::new(6, 1)
+        );
+        assert_eq!(constrained.measure(Size::new(3, 1), &ctx), Size::new(3, 1));
     }
 }

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -409,7 +409,7 @@ impl Diff {
 }
 
 impl View for Diff {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(
             self.intrinsic_width().min(available.width),
             (self.rows.len() as u16).min(available.height),

--- a/src/components/flex.rs
+++ b/src/components/flex.rs
@@ -125,14 +125,14 @@ impl<V: View> Flex<V> {
         axis.size(main, axis.cross(inner_available))
     }
 
-    fn items(&self, area: Rect) -> Vec<Item> {
+    fn items(&self, area: Rect, ctx: &RenderCtx) -> Vec<Item> {
         let inner_available = Size::from(self.style.padding.inner(area));
         let mut items: Vec<Item> = self
             .children
             .iter()
             .map(|child| {
                 let available = self.child_available(inner_available, child.dimension);
-                Item::new(child.dimension, child.view.measure(available))
+                Item::new(child.dimension, child.view.measure(available, ctx))
             })
             .collect();
 
@@ -152,7 +152,7 @@ impl<V: View> Flex<V> {
                 if matches!(child.dimension, Dimension::Flex(_)) {
                     let main = axis.main(Size::from(rect));
                     let available = axis.size(main, axis.cross(inner_available));
-                    item.intrinsic = child.view.measure(available);
+                    item.intrinsic = child.view.measure(available, ctx);
                 }
             }
         }
@@ -176,13 +176,15 @@ impl<V: View> Flex<V> {
     /// let flex = Flex::row()
     ///     .fixed(4, element(Text::raw("abcd")))
     ///     .grow(1, element(Text::raw("rest")));
-    /// let rects = flex.solve(Rect::new(0, 0, 10, 1));
+    /// let theme = Theme::default();
+    /// let ctx = RenderCtx::new(&theme);
+    /// let rects = flex.solve(Rect::new(0, 0, 10, 1), &ctx);
     /// assert_eq!(rects.len(), 2);
     /// assert_eq!(rects[0], Rect::new(0, 0, 4, 1));
     /// assert_eq!(rects[1], Rect::new(4, 0, 6, 1)); // grows into the leftover
     /// ```
-    pub fn solve(&self, area: Rect) -> Vec<Rect> {
-        solve(area, &self.style, &self.items(area))
+    pub fn solve(&self, area: Rect, ctx: &RenderCtx) -> Vec<Rect> {
+        solve(area, &self.style, &self.items(area, ctx))
     }
 }
 
@@ -219,7 +221,7 @@ impl Flex<Element> {
 }
 
 impl<V: View> View for Flex<V> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
         // Sum children on the main axis, max on the cross axis, plus gaps and
         // padding. Used when this Flex is itself an Auto child.
         let axis = self.style.direction.axis();
@@ -234,7 +236,7 @@ impl<V: View> View for Flex<V> {
         for (i, c) in self.children.iter().enumerate() {
             let sz = c
                 .view
-                .measure(self.child_available(inner_avail, c.dimension));
+                .measure(self.child_available(inner_avail, c.dimension), ctx);
             let intrinsic_main = axis.main(sz);
             let resolved_main = match c.dimension {
                 Dimension::Auto | Dimension::Flex(_) => intrinsic_main,
@@ -265,7 +267,7 @@ impl<V: View> View for Flex<V> {
             let mut fill = surface.child(area);
             fill.fill(bg);
         }
-        let rects = self.solve(area);
+        let rects = self.solve(area, ctx);
         for (child, rect) in self.children.iter().zip(rects) {
             let mut child_surface = surface.child(rect);
             child.view.render(rect, &mut child_surface, ctx);
@@ -285,7 +287,7 @@ mod tests {
     struct WidthSensitive;
 
     impl View for WidthSensitive {
-        fn measure(&self, available: Size) -> Size {
+        fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
             Size::new(available.width, if available.width < 10 { 2 } else { 1 })
         }
 
@@ -303,8 +305,10 @@ mod tests {
             .grow(1, probes[1].wrap(element(Text::raw("body"))))
             .fixed(2, probes[2].wrap(element(Text::raw("footer"))));
 
-        let precomputed = flex.solve(area);
-        let _ = crate::testing::render(&flex, area.width, area.height, &Theme::default());
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        let precomputed = flex.solve(area, &ctx);
+        let _ = crate::testing::render(&flex, area.width, area.height, &theme);
 
         let painted: Vec<Rect> = probes.iter().map(|p| p.rect()).collect();
         assert_eq!(
@@ -320,7 +324,11 @@ mod tests {
     #[test]
     fn solve_of_empty_container_is_empty() {
         let flex = Flex::row();
-        assert!(flex.solve(Rect::new(0, 0, 10, 3)).is_empty());
+        let theme = Theme::default();
+        assert!(
+            flex.solve(Rect::new(0, 0, 10, 3), &RenderCtx::new(&theme))
+                .is_empty()
+        );
     }
 
     #[test]
@@ -329,15 +337,23 @@ mod tests {
             .align(crate::layout::Align::Start)
             .fixed(5, element(WidthSensitive));
 
-        assert_eq!(flex.measure(Size::new(10, 4)), Size::new(5, 2));
-        assert_eq!(flex.solve(Rect::new(0, 0, 10, 4))[0], Rect::new(0, 0, 5, 2));
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        assert_eq!(flex.measure(Size::new(10, 4), &ctx), Size::new(5, 2));
+        assert_eq!(
+            flex.solve(Rect::new(0, 0, 10, 4), &ctx)[0],
+            Rect::new(0, 0, 5, 2)
+        );
     }
 
     #[test]
     fn measure_resolves_declared_percent_main_size() {
         let flex = Flex::row().child(Dimension::Percent(50), element(Text::raw("x")));
-
-        assert_eq!(flex.measure(Size::new(10, 2)), Size::new(5, 1));
+        let theme = Theme::default();
+        assert_eq!(
+            flex.measure(Size::new(10, 2), &RenderCtx::new(&theme)),
+            Size::new(5, 1)
+        );
     }
 
     #[test]
@@ -346,7 +362,11 @@ mod tests {
             .padding(Padding::symmetric(1, 0))
             .auto(element(WidthSensitive));
 
-        assert_eq!(flex.solve(Rect::new(0, 0, 10, 4))[0].height, 2);
+        let theme = Theme::default();
+        assert_eq!(
+            flex.solve(Rect::new(0, 0, 10, 4), &RenderCtx::new(&theme))[0].height,
+            2
+        );
     }
 
     #[test]
@@ -356,7 +376,11 @@ mod tests {
             .fixed(5, element(Text::raw("fixed")))
             .grow(1, element(WidthSensitive));
 
-        assert_eq!(flex.solve(Rect::new(0, 0, 10, 4))[1], Rect::new(5, 0, 5, 2));
+        let theme = Theme::default();
+        assert_eq!(
+            flex.solve(Rect::new(0, 0, 10, 4), &RenderCtx::new(&theme))[1],
+            Rect::new(5, 0, 5, 2)
+        );
     }
 
     #[test]

--- a/src/components/focus_scope.rs
+++ b/src/components/focus_scope.rs
@@ -62,8 +62,8 @@ impl<V: View> FocusScope<V> {
 }
 
 impl<V: View> View for FocusScope<V> {
-    fn measure(&self, available: Size) -> Size {
-        self.child.measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        self.child.measure(available, &ctx.with_focus(self.focused))
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -105,9 +105,11 @@ mod tests {
     #[test]
     fn focus_scope_is_layout_transparent() {
         // measure() passes straight through to the child.
+        let theme = rainbow_theme();
+        let ctx = RenderCtx::new(&theme);
         let inner = Boxed::new(element(Text::raw("hello")));
-        let want = inner.measure(Size::new(40, 10));
+        let want = inner.measure(Size::new(40, 10), &ctx.with_focus(true));
         let scoped = FocusScope::focused(element(Boxed::new(element(Text::raw("hello")))));
-        assert_eq!(scoped.measure(Size::new(40, 10)), want);
+        assert_eq!(scoped.measure(Size::new(40, 10), &ctx), want);
     }
 }

--- a/src/components/form.rs
+++ b/src/components/form.rs
@@ -190,7 +190,7 @@ impl Form<Element> {
 }
 
 impl<V: View> View for Form<V> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
         let stacked = self.stacked(available.width);
         let label_width = self.label_width(available.width);
         let control_width = if stacked {
@@ -205,16 +205,17 @@ impl<V: View> View for Form<V> {
             if index > 0 {
                 height = height.saturating_add(self.gap);
             }
-            let control = field
-                .control
-                .measure(Size::new(control_width, available.height));
+            let control = field.control.measure(
+                Size::new(control_width, available.height),
+                &ctx.with_focus(index == self.focused),
+            );
             height = height
                 .saturating_add(control.height.max(1))
                 .saturating_add(field.message_rows())
                 .saturating_add(u16::from(stacked));
         }
         if let Some(actions) = &self.actions {
-            height = height.saturating_add(actions.measure(available).height.max(1));
+            height = height.saturating_add(actions.measure(available, ctx).height.max(1));
         }
         Size::new(available.width, height.min(available.height))
     }
@@ -247,16 +248,16 @@ impl<V: View> View for Form<V> {
                     break;
                 }
             }
-            let measured = field
-                .control
-                .measure(Size::new(control_width, area.bottom().saturating_sub(y)));
+            let control_ctx = ctx.with_focus(index == self.focused);
+            let measured = field.control.measure(
+                Size::new(control_width, area.bottom().saturating_sub(y)),
+                &control_ctx,
+            );
             let control_height = measured.height.max(1).min(area.bottom().saturating_sub(y));
             let control_area = Rect::new(control_x, y, control_width, control_height);
-            field.control.render(
-                control_area,
-                &mut surface.child(control_area),
-                &ctx.with_focus(index == self.focused),
-            );
+            field
+                .control
+                .render(control_area, &mut surface.child(control_area), &control_ctx);
             y = y.saturating_add(control_height);
             if let Some(help) = &field.help
                 && y < area.bottom()

--- a/src/components/image.rs
+++ b/src/components/image.rs
@@ -77,7 +77,7 @@ impl Image {
 }
 
 impl View for Image {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(self.cols, self.rows).clamp_to(available)
     }
 
@@ -139,9 +139,11 @@ mod tests {
     #[test]
     fn image_reserves_its_cell_footprint() {
         let img = Image::new(solid(2, 2, [0, 0, 0, 255]), 6, 3);
-        assert_eq!(img.measure(Size::new(80, 24)), Size::new(6, 3));
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        assert_eq!(img.measure(Size::new(80, 24), &ctx), Size::new(6, 3));
         // Clamped to the available area.
-        assert_eq!(img.measure(Size::new(4, 2)), Size::new(4, 2));
+        assert_eq!(img.measure(Size::new(4, 2), &ctx), Size::new(4, 2));
     }
 
     #[test]

--- a/src/components/item_scroll.rs
+++ b/src/components/item_scroll.rs
@@ -26,6 +26,7 @@ use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 
 use crate::geometry::Size;
+use crate::style::{StyleSheet, Theme};
 use crate::surface::Surface;
 use crate::view::{Element, RenderCtx, ScopedElement, View};
 
@@ -44,7 +45,9 @@ use super::scroll::{ScrollState, draw_scrollbar};
 ///     element(Text::raw("second")),
 /// ];
 /// // Total rows the items occupy at this width — what the host clamps against.
-/// assert_eq!(ItemScroll::measure_height(&items, 10, 0, false), 2);
+/// let theme = Theme::default();
+/// let ctx = RenderCtx::new(&theme);
+/// assert_eq!(ItemScroll::measure_height(&items, 10, 0, false, &ctx), 2);
 ///
 /// let state = ScrollState::new();
 /// let view = ItemScroll::new(items, &state).scrollbar(false);
@@ -67,7 +70,26 @@ pub struct ItemScroll<V: View = Element> {
     scrollbar: bool,
     /// Item heights memoized for the width they were measured at, so `measure`
     /// and `render` in the same frame don't measure the tree twice.
-    heights: RefCell<Option<(u16, Vec<u16>)>>,
+    heights: RefCell<Option<(MeasureKey, Vec<u16>)>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MeasureKey {
+    width: u16,
+    theme: Theme,
+    sheet: StyleSheet,
+    focused: bool,
+}
+
+impl MeasureKey {
+    fn new(width: u16, ctx: &RenderCtx) -> Self {
+        Self {
+            width,
+            theme: *ctx.theme,
+            sheet: ctx.sheet,
+            focused: ctx.focused,
+        }
+    }
 }
 
 impl<V: View> ItemScroll<V> {
@@ -122,21 +144,22 @@ impl<V: View> ItemScroll<V> {
     }
 
     /// Item heights at `width`, measuring (and memoizing) on first use.
-    fn with_heights<R>(&self, width: u16, f: impl FnOnce(&[u16]) -> R) -> R {
+    fn with_heights<R>(&self, width: u16, ctx: &RenderCtx, f: impl FnOnce(&[u16]) -> R) -> R {
         let mut cache = self.heights.borrow_mut();
-        let fresh = !matches!(cache.as_ref(), Some((w, _)) if *w == width);
+        let key = MeasureKey::new(width, ctx);
+        let fresh = !matches!(cache.as_ref(), Some((cached, _)) if *cached == key);
         if fresh {
-            *cache = Some((width, measure_items(&self.items, width)));
+            *cache = Some((key, measure_items(&self.items, width, ctx)));
         }
         let (_, heights) = cache.as_ref().expect("heights measured above");
         f(heights)
     }
 
     /// Content height in rows: the host's number when windowed, else measured.
-    fn content_height(&self, width: u16) -> usize {
+    fn content_height(&self, width: u16, ctx: &RenderCtx) -> usize {
         match self.content_height {
             Some(h) => h,
-            None => self.with_heights(width, |h| total_height(h, self.gap)),
+            None => self.with_heights(width, ctx, |h| total_height(h, self.gap)),
         }
     }
 }
@@ -176,13 +199,25 @@ impl ItemScroll<Element> {
     }
 
     /// Total rows `items` occupy at `width`, including `gap` rows.
-    pub fn measure_height(items: &[Element], width: u16, gap: u16, scrollbar: bool) -> usize {
-        Self::measure_views(items, width, gap, scrollbar)
+    pub fn measure_height(
+        items: &[Element],
+        width: u16,
+        gap: u16,
+        scrollbar: bool,
+        ctx: &RenderCtx,
+    ) -> usize {
+        Self::measure_views(items, width, gap, scrollbar, ctx)
     }
 
     /// Total rows any owned or borrowed view slice occupies at `width`.
-    pub fn measure_views<V: View>(items: &[V], width: u16, gap: u16, scrollbar: bool) -> usize {
-        let heights = measure_items(items, content_width(width, scrollbar));
+    pub fn measure_views<V: View>(
+        items: &[V],
+        width: u16,
+        gap: u16,
+        scrollbar: bool,
+        ctx: &RenderCtx,
+    ) -> usize {
+        let heights = measure_items(items, content_width(width, scrollbar), ctx);
         total_height(&heights, gap)
     }
 }
@@ -201,10 +236,10 @@ fn content_width(width: u16, scrollbar: bool) -> u16 {
     }
 }
 
-fn measure_items<V: View>(items: &[V], width: u16) -> Vec<u16> {
+fn measure_items<V: View>(items: &[V], width: u16, ctx: &RenderCtx) -> Vec<u16> {
     items
         .iter()
-        .map(|item| item.measure(Size::new(width, u16::MAX)).height)
+        .map(|item| item.measure(Size::new(width, u16::MAX), ctx).height)
         .collect()
 }
 
@@ -215,11 +250,11 @@ fn total_height(heights: &[u16], gap: u16) -> usize {
 }
 
 impl<V: View> View for ItemScroll<V> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
         // `Size` is a cell extent (`u16`); a transcript can be taller than that,
         // so saturate exactly as `Scroll` does.
         let height = self
-            .content_height(content_width(available.width, self.scrollbar))
+            .content_height(content_width(available.width, self.scrollbar), ctx)
             .min(u16::MAX as usize) as u16;
         Size::new(available.width, height)
     }
@@ -232,12 +267,12 @@ impl<V: View> View for ItemScroll<V> {
         if text_width == 0 {
             return;
         }
-        let content_h = self.content_height(text_width);
+        let content_h = self.content_height(text_width, ctx);
         let overflow = content_h > area.height as usize;
 
         let viewport_top = self.offset;
         let viewport_bottom = self.offset + area.height as usize;
-        self.with_heights(text_width, |heights| {
+        self.with_heights(text_width, ctx, |heights| {
             let mut top = self.window_start_row;
             for (item, height) in self.items.iter().zip(heights) {
                 let height = *height;
@@ -362,8 +397,40 @@ mod tests {
     #[test]
     fn measure_height_sums_items_and_gaps() {
         let items = blocks(3, 2);
-        assert_eq!(ItemScroll::measure_height(&items, 20, 0, false), 6);
-        assert_eq!(ItemScroll::measure_height(&items, 20, 1, false), 8);
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
+        assert_eq!(ItemScroll::measure_height(&items, 20, 0, false, &ctx), 6);
+        assert_eq!(ItemScroll::measure_height(&items, 20, 1, false, &ctx), 8);
+    }
+
+    #[test]
+    fn cached_heights_are_invalidated_when_the_measurement_context_changes() {
+        struct StyledHeight;
+        impl View for StyledHeight {
+            fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+                let vertical = ctx
+                    .sheet
+                    .panel
+                    .padding
+                    .map_or(0, |padding| padding.vertical());
+                Size::new(1, 1u16.saturating_add(vertical)).clamp_to(available)
+            }
+
+            fn render(&self, _area: Rect, _surface: &mut Surface, _ctx: &RenderCtx) {}
+        }
+
+        let state = ScrollState::new();
+        let view = ItemScroll::new(vec![element(StyledHeight)], &state).scrollbar(false);
+        let theme = Theme::default();
+        let base = RenderCtx::new(&theme);
+        assert_eq!(view.measure(Size::new(10, 10), &base).height, 1);
+
+        let sheet = StyleSheet {
+            panel: crate::style::StyleBundle::new().padding(crate::Padding::all(2)),
+            ..StyleSheet::from_theme(&theme)
+        };
+        let styled = RenderCtx::new(&theme).with_sheet(sheet);
+        assert_eq!(view.measure(Size::new(10, 10), &styled).height, 5);
     }
 
     #[test]
@@ -425,7 +492,7 @@ mod tests {
     fn a_greedy_item_scrolls_without_allocating_its_measured_height() {
         struct Greedy;
         impl View for Greedy {
-            fn measure(&self, available: Size) -> Size {
+            fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
                 // What `Spacer` and any `grow` child do: take everything.
                 available
             }

--- a/src/components/key_hints.rs
+++ b/src/components/key_hints.rs
@@ -103,7 +103,7 @@ impl KeyHints {
 }
 
 impl View for KeyHints {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let width = self
             .hints
             .iter()
@@ -177,7 +177,7 @@ impl KeymapHelp {
 }
 
 impl View for KeymapHelp {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let key_width = self
             .hints
             .iter()
@@ -241,7 +241,11 @@ mod tests {
     #[test]
     fn key_hints_measure_unicode_by_terminal_width() {
         let hints = KeyHints::new([("⌘", "開く")]);
-        assert_eq!(hints.measure(Size::new(20, 1)), Size::new(8, 1));
+        let theme = Theme::default();
+        assert_eq!(
+            hints.measure(Size::new(20, 1), &RenderCtx::new(&theme)),
+            Size::new(8, 1)
+        );
     }
 
     #[test]

--- a/src/components/loader.rs
+++ b/src/components/loader.rs
@@ -47,7 +47,7 @@ impl Loader {
 }
 
 impl View for Loader {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(available.width, 1)
     }
 

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -168,9 +168,8 @@ impl<'a> Markdown<'a> {
 }
 
 impl View for Markdown<'_> {
-    fn measure(&self, available: Size) -> Size {
-        let (lines, _, _) =
-            self.lines_images_links(available.width, &Theme::default(), &StyleSheet::default());
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        let (lines, _, _) = self.lines_images_links(available.width, ctx.theme, &ctx.sheet);
         let width = lines.iter().map(line_width).max().unwrap_or(0);
         Size::new(width.min(available.width), lines.len() as u16)
     }
@@ -223,5 +222,58 @@ impl View for Markdown<'_> {
             }
             image.render(rect, surface, ctx);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::HtmlBlockRenderer;
+    use crate::style::StyleBundle;
+    use crate::testing::{grid, render_with_sheet};
+    use ratatui_core::style::Color;
+    use ratatui_core::text::{Line, Span};
+
+    struct ContextBlock;
+
+    impl HtmlBlockRenderer for ContextBlock {
+        fn render(
+            &self,
+            _source: &str,
+            _width: u16,
+            theme: &Theme,
+            sheet: &StyleSheet,
+        ) -> Option<Vec<Line<'static>>> {
+            if theme.accent == Color::Cyan && sheet.heading.fg == Some(Color::Magenta) {
+                Some(vec![
+                    Line::from(Span::raw("alpha")),
+                    Line::from(Span::raw("beta")),
+                    Line::from(Span::raw("omega")),
+                ])
+            } else {
+                Some(vec![Line::from(Span::raw("wrong context"))])
+            }
+        }
+    }
+
+    #[test]
+    fn measurement_and_render_share_the_active_theme_and_sheet() {
+        let theme = Theme {
+            accent: Color::Cyan,
+            ..Theme::default()
+        };
+        let sheet = StyleSheet {
+            heading: StyleBundle::new().fg(Color::Magenta),
+            ..StyleSheet::from_theme(&theme)
+        };
+        let renderer = ContextBlock;
+        let view = Markdown::new("<div>context</div>").html_renderer(&renderer);
+        let ctx = RenderCtx::new(&theme).with_sheet(sheet);
+
+        assert_eq!(view.measure(Size::new(10, 10), &ctx), Size::new(5, 3));
+        assert_eq!(
+            grid(&render_with_sheet(&view, 10, 3, &theme, sheet)),
+            "alpha     \nbeta      \nomega     "
+        );
     }
 }

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -182,7 +182,7 @@ impl ProgressBar {
 }
 
 impl View for ProgressBar {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(available.width, 1)
     }
 

--- a/src/components/qr.rs
+++ b/src/components/qr.rs
@@ -549,7 +549,7 @@ impl QrCode {
 }
 
 impl View for QrCode {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let side = self.full_size();
         // Two module rows per terminal row via the half-block glyph.
         Size::new(side, side.div_ceil(2)).clamp_to(available)
@@ -684,9 +684,10 @@ mod tests {
     #[test]
     fn renders_half_blocks_with_quiet_zone() {
         let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
         let qr = QrCode::encode("HI", QrEcc::Low).unwrap();
         // 21 modules + 8 quiet = 29 wide; 15 rows tall (ceil(29/2)).
-        assert_eq!(qr.measure(Size::new(80, 40)), Size::new(29, 15));
+        assert_eq!(qr.measure(Size::new(80, 40), &ctx), Size::new(29, 15));
         let buf = crate::testing::render(&qr, 29, 15, &theme);
         // The top-left cell is quiet zone → light background, half-block glyph.
         assert_eq!(buf[(0, 0)].symbol(), "▀");

--- a/src/components/responsive.rs
+++ b/src/components/responsive.rs
@@ -35,8 +35,8 @@ impl<V: View> Responsive<V> {
 }
 
 impl<V: View> View for Responsive<V> {
-    fn measure(&self, available: Size) -> Size {
-        self.select(available.width).measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        self.select(available.width).measure(available, ctx)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {

--- a/src/components/rule.rs
+++ b/src/components/rule.rs
@@ -73,7 +73,7 @@ impl Default for Rule {
 }
 
 impl View for Rule {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(available.width, 1)
     }
 

--- a/src/components/scroll.rs
+++ b/src/components/scroll.rs
@@ -302,7 +302,7 @@ impl Scroll {
 }
 
 impl View for Scroll {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         // `Size` is a terminal-cell extent (`u16`); a transcript can be taller
         // than that. Saturate — the intrinsic hint only matters when the scroll
         // is not a flex `grow` child, and a viewport is never `u16::MAX` tall.

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -402,7 +402,7 @@ impl SelectList {
 }
 
 impl View for SelectList {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let width = self
             .items
             .iter()
@@ -712,9 +712,10 @@ mod tests {
         let mut state = SelectState::new();
         state.select(Some(12));
         let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
         let list = SelectList::new(items.clone(), &state).viewport(4);
         // Windowed height is the viewport, not the full list.
-        assert_eq!(list.measure(Size::new(20, 40)).height, 4);
+        assert_eq!(list.measure(Size::new(20, 40), &ctx).height, 4);
         let rendered = crate::testing::render(&list, 20, 4, &theme);
         let text = crate::testing::grid(&rendered);
         assert!(
@@ -738,9 +739,13 @@ mod tests {
         let items: Vec<Line> = (0..3).map(|i| Line::from(format!("item{i}"))).collect();
         let state = SelectState::new();
         let list = SelectList::new(items, &state).viewport(8);
-        // Fits within the viewport → no windowing, height is the item count.
-        assert_eq!(list.measure(Size::new(20, 40)).height, 3);
         let theme = Theme::default();
+        // Fits within the viewport → no windowing, height is the item count.
+        assert_eq!(
+            list.measure(Size::new(20, 40), &RenderCtx::new(&theme))
+                .height,
+            3
+        );
         let text = crate::testing::grid(&crate::testing::render(&list, 20, 3, &theme));
         assert!(text.contains("item0") && text.contains("item2"));
     }

--- a/src/components/slider.rs
+++ b/src/components/slider.rs
@@ -179,7 +179,7 @@ fn format_value(value: f32) -> String {
 }
 
 impl View for Slider {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(available.width, 1)
     }
 

--- a/src/components/spacer.rs
+++ b/src/components/spacer.rs
@@ -11,7 +11,7 @@ use crate::view::{RenderCtx, View};
 pub struct Spacer;
 
 impl View for Spacer {
-    fn measure(&self, _available: Size) -> Size {
+    fn measure(&self, _available: Size, _ctx: &RenderCtx) -> Size {
         Size::ZERO
     }
 

--- a/src/components/spinner.rs
+++ b/src/components/spinner.rs
@@ -73,7 +73,7 @@ impl Spinner {
 }
 
 impl View for Spinner {
-    fn measure(&self, _available: Size) -> Size {
+    fn measure(&self, _available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(1, 1)
     }
 

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -62,7 +62,7 @@ fn spans_width(spans: &[Span]) -> u16 {
 }
 
 impl View for StatusBar {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(available.width, 1)
     }
 

--- a/src/components/tab_select.rs
+++ b/src/components/tab_select.rs
@@ -112,7 +112,7 @@ impl TabSelect {
 const PILL_PAD: u16 = 1;
 
 impl View for TabSelect {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         // Each pill is label width plus a cell of padding on each side; pills abut
         // with no separator.
         let width = self

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -285,7 +285,7 @@ impl Table {
 }
 
 impl View for Table {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let available_rows = available.height.saturating_sub(self.header_rows());
         let (_, rows) = self.window(available_rows);
         let cols_w: u16 = (0..self.columns.len())
@@ -513,7 +513,12 @@ mod tests {
         let table = Table::new(cols, rows, &state).viewport(4);
         let theme = Theme::default();
         // Height = header (1) + viewport (4).
-        assert_eq!(table.measure(Size::new(30, 40)).height, 5);
+        assert_eq!(
+            table
+                .measure(Size::new(30, 40), &RenderCtx::new(&theme))
+                .height,
+            5
+        );
         let text = crate::testing::grid(&crate::testing::render(&table, 30, 5, &theme));
         assert!(text.contains("row15"), "selection visible:\n{text}");
         assert!(!text.contains("row0\n"), "far rows windowed out:\n{text}");

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -69,7 +69,7 @@ impl Tabs {
 }
 
 impl View for Tabs {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let labels = self
             .labels
             .iter()

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -107,7 +107,7 @@ impl Text {
 }
 
 impl View for Text {
-    fn measure(&self, _available: Size) -> Size {
+    fn measure(&self, _available: Size, _ctx: &RenderCtx) -> Size {
         let width = self.lines.iter().map(line_width).max().unwrap_or(0);
         Size::new(width, self.lines.len() as u16)
     }
@@ -161,7 +161,7 @@ impl Paragraph {
 }
 
 impl View for Paragraph {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let lines = self.wrap(available.width);
         let width = lines
             .iter()
@@ -339,7 +339,7 @@ impl Wrap {
 }
 
 impl View for Wrap {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let wrapped = wrap_lines(&self.lines, available.width);
         let width = wrapped.iter().map(line_width).max().unwrap_or(0);
         Size::new(width.min(available.width), wrapped.len() as u16)
@@ -397,7 +397,8 @@ mod tests {
     #[test]
     fn paragraph_wraps_to_width() {
         let p = Paragraph::new("the quick brown fox", Style::default());
-        let size = p.measure(Size::new(10, 10));
+        let theme = Theme::default();
+        let size = p.measure(Size::new(10, 10), &RenderCtx::new(&theme));
         assert!(size.height >= 2, "expected wrap, got {size:?}");
         assert!(size.width <= 10);
     }

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -1165,7 +1165,7 @@ impl TextInput {
 }
 
 impl View for TextInput {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let height = wrap_visual_rows(&self.lines, available.width).len().max(1) as u16;
         Size::new(available.width, height)
     }

--- a/src/components/toast.rs
+++ b/src/components/toast.rs
@@ -165,7 +165,7 @@ impl<'a> ToastList<'a> {
 }
 
 impl View for ToastList<'_> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let width = self
             .toasts
             .items
@@ -271,7 +271,12 @@ mod tests {
     fn empty_and_tiny_areas_do_not_panic() {
         let theme = Theme::default();
         let empty = Toasts::new(4);
-        assert_eq!(ToastList::new(&empty).measure(Size::new(40, 10)).height, 0);
+        assert_eq!(
+            ToastList::new(&empty)
+                .measure(Size::new(40, 10), &RenderCtx::new(&theme))
+                .height,
+            0
+        );
         let mut t = Toasts::new(4);
         t.push(ToastLevel::Info, "a very long notification message");
         for (w, h) in [(0u16, 0u16), (1, 1), (3, 1)] {

--- a/src/components/viewport.rs
+++ b/src/components/viewport.rs
@@ -96,7 +96,7 @@ impl<V: View> Viewport<V> {
 }
 
 impl<V: View> View for Viewport<V> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(
             self.content.width.min(available.width),
             self.content.height.min(available.height),

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -302,7 +302,7 @@ fn composite(px: Rgba, bg: Color) -> Color {
 }
 
 impl View for FrameBufferView<'_> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(self.cols, self.rows).clamp_to(available)
     }
 
@@ -430,7 +430,10 @@ mod tests {
         let mut fb = FrameBuffer::new(4, 4);
         fb.clear(RED);
         let view = FrameBufferView::new(&fb, 4, 2);
-        assert_eq!(view.measure(Size::new(80, 24)), Size::new(4, 2));
+        assert_eq!(
+            view.measure(Size::new(80, 24), &RenderCtx::new(&theme)),
+            Size::new(4, 2)
+        );
         let buf = crate::testing::render(&view, 4, 2, &theme);
         // Every cell is the half-block glyph; a fully-red buffer paints red fg/bg.
         assert_eq!(buf[(0, 0)].symbol(), "▀");

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -59,7 +59,7 @@ impl<F> View for RatatuiView<F>
 where
     F: Fn(Rect, &mut Buffer),
 {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         match self.measure {
             Measure::Fill => available,
             Measure::Fixed(size) => Size::new(

--- a/src/live.rs
+++ b/src/live.rs
@@ -112,8 +112,8 @@ impl<T, F> View for LiveView<T, F>
 where
     F: Fn(&T) -> Element,
 {
-    fn measure(&self, available: Size) -> Size {
-        self.current().measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        self.current().measure(available, ctx)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -223,7 +223,7 @@ mod tests {
     /// A `View` standing in for a component defined in some other crate.
     struct Star;
     impl View for Star {
-        fn measure(&self, _available: Size) -> Size {
+        fn measure(&self, _available: Size, _ctx: &RenderCtx) -> Size {
             Size::new(1, 1)
         }
         fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
@@ -247,7 +247,7 @@ mod tests {
     struct BorrowedLabel<'a>(&'a str);
 
     impl View for BorrowedLabel<'_> {
-        fn measure(&self, available: Size) -> Size {
+        fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
             Size::new(
                 (self.0.len() as u16).min(available.width),
                 available.height.min(1),

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -79,8 +79,8 @@ impl<V: View> Probe<V> {
 }
 
 impl<V: View> View for Probe<V> {
-    fn measure(&self, available: Size) -> Size {
-        self.inner.measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        self.inner.measure(available, ctx)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -25,7 +25,7 @@
 //! }
 //!
 //! impl View for Dashboard<'_> {
-//!     fn measure(&self, available: Size) -> Size {
+//!     fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
 //!         Size::new(available.width, (self.messages.len() as u16).min(available.height))
 //!     }
 //!
@@ -62,7 +62,7 @@
 //!
 //! struct Count<'data>(&'data [String]);
 //! impl View for Count<'_> {
-//!     fn measure(&self, available: Size) -> Size {
+//!     fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
 //!         Size::new(available.width.min(8), available.height.min(1))
 //!     }
 //!     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -215,8 +215,8 @@ impl Scene {
 }
 
 impl View for Scene {
-    fn measure(&self, available: Size) -> Size {
-        self.root.measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        self.root.measure(available, ctx)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -297,8 +297,8 @@ impl<'view, V: View + ?Sized> ScopedScene<'view, V> {
 }
 
 impl<V: View + ?Sized> View for ScopedScene<'_, V> {
-    fn measure(&self, available: Size) -> Size {
-        self.root.measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        self.root.measure(available, ctx)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -358,7 +358,7 @@ mod tests {
     struct FocusProbe(Rc<RefCell<Vec<bool>>>);
 
     impl View for FocusProbe {
-        fn measure(&self, available: Size) -> Size {
+        fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
             available
         }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -319,7 +319,7 @@ fn commit<B: Backend>(
     if width == 0 || terminal.size()?.height == 0 {
         return Ok(());
     }
-    let rows = block_rows(rows, view, width);
+    let rows = block_rows(rows, view, width, ctx);
     terminal.insert_before(rows, |buffer| paint_block(buffer, view, ctx))
 }
 
@@ -329,10 +329,10 @@ fn commit<B: Backend>(
 /// publishes nothing) and never more than [`Scrollback::MAX_BLOCK_ROWS`], which
 /// bounds the scratch buffer a single block can allocate — a view is free to
 /// measure itself as `u16::MAX` tall.
-fn block_rows(requested: Option<u16>, view: &dyn View, width: u16) -> u16 {
+fn block_rows(requested: Option<u16>, view: &dyn View, width: u16, ctx: &RenderCtx) -> u16 {
     requested
         .unwrap_or_else(|| {
-            view.measure(Size::new(width, Scrollback::MAX_BLOCK_ROWS))
+            view.measure(Size::new(width, Scrollback::MAX_BLOCK_ROWS), ctx)
                 .height
         })
         .clamp(1, Scrollback::MAX_BLOCK_ROWS)
@@ -508,7 +508,11 @@ mod tests {
     #[test]
     fn a_measured_block_takes_the_rows_its_view_asks_for() {
         let view = element(Text::new(vec![Line::from("a"), Line::from("b")]));
-        assert_eq!(block_rows(None, view.as_ref(), 10), 2);
+        let theme = Theme::default();
+        assert_eq!(
+            block_rows(None, view.as_ref(), 10, &RenderCtx::new(&theme)),
+            2
+        );
     }
 
     #[test]
@@ -516,27 +520,33 @@ mod tests {
         // A block that publishes nothing is a queue entry that did nothing;
         // clamping keeps `write_rows(0)` meaning "one row", not "silently drop".
         let view = element(Text::raw("x"));
-        assert_eq!(block_rows(Some(0), view.as_ref(), 10), 1);
+        let theme = Theme::default();
+        assert_eq!(
+            block_rows(Some(0), view.as_ref(), 10, &RenderCtx::new(&theme)),
+            1
+        );
     }
 
     #[test]
     fn an_oversized_block_is_clamped_to_the_row_ceiling() {
         struct Tall;
         impl View for Tall {
-            fn measure(&self, _available: Size) -> Size {
+            fn measure(&self, _available: Size, _ctx: &RenderCtx) -> Size {
                 Size::new(1, u16::MAX)
             }
             fn render(&self, _area: Rect, _surface: &mut Surface, _ctx: &RenderCtx) {}
         }
         // Both a view that measures itself absurdly tall and a caller that asks
         // for it are bounded, so one block cannot allocate an unbounded buffer.
+        let theme = Theme::default();
+        let ctx = RenderCtx::new(&theme);
         assert_eq!(
-            block_rows(None, &Tall, 10),
+            block_rows(None, &Tall, 10, &ctx),
             Scrollback::MAX_BLOCK_ROWS,
             "a measured height is clamped"
         );
         assert_eq!(
-            block_rows(Some(u16::MAX), &Tall, 10),
+            block_rows(Some(u16::MAX), &Tall, 10, &ctx),
             Scrollback::MAX_BLOCK_ROWS,
             "a requested height is clamped"
         );

--- a/src/style.rs
+++ b/src/style.rs
@@ -296,11 +296,11 @@ pub enum SemanticRole {
 /// rather than replace a whole [`Style`]: [`apply`](Self::apply) overlays only
 /// the fields it sets onto a base style, and adds its modifiers.
 ///
-/// Only paint-time attributes belong here. A component's [`measure`] runs
-/// without a [`RenderCtx`], so layout-affecting choices (whether a border
-/// exists, how much padding) stay instance-level; the stylesheet owns color,
-/// background, modifiers, and — where they do not change a cell's footprint —
-/// border glyphs.
+/// A component resolves layout-affecting fields from the same [`RenderCtx`] in
+/// both [`measure`] and render. Border *presence* remains instance-level;
+/// container padding may come from a role, with an explicit component value
+/// taking precedence. Color, background, modifiers, and border glyph choice are
+/// paint attributes.
 ///
 /// [`measure`]: crate::View::measure
 /// [`RenderCtx`]: crate::RenderCtx
@@ -316,7 +316,8 @@ pub struct StyleBundle {
     /// change a component's footprint, so it selects the glyph set, not whether
     /// a border exists).
     pub border: Option<BorderStyle>,
-    /// Padding for container roles, when the role sets one.
+    /// Padding for container roles, when the role sets one. Components that
+    /// consume it resolve it during both measurement and rendering.
     pub padding: Option<Padding>,
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -3,13 +3,27 @@
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 
-use crate::{Theme, View, paint};
+use crate::{StyleSheet, Theme, View, paint, paint_with_sheet};
 
 /// Render `view` into a zero-origin in-memory buffer.
 pub fn render(view: &dyn View, width: u16, height: u16, theme: &Theme) -> Buffer {
     let area = Rect::new(0, 0, width, height);
     let mut buffer = Buffer::empty(area);
     paint(&mut buffer, area, theme, view, &[]);
+    buffer
+}
+
+/// Render `view` with an explicit stylesheet into a zero-origin in-memory buffer.
+pub fn render_with_sheet(
+    view: &dyn View,
+    width: u16,
+    height: u16,
+    theme: &Theme,
+    sheet: StyleSheet,
+) -> Buffer {
+    let area = Rect::new(0, 0, width, height);
+    let mut buffer = Buffer::empty(area);
+    paint_with_sheet(&mut buffer, area, theme, sheet, view, &[]);
     buffer
 }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -16,7 +16,7 @@ use super::geometry::Size;
 use super::style::{StyleSheet, Theme};
 use super::surface::Surface;
 
-/// Context threaded to every `View::render`.
+/// Context threaded to every [`View::measure`] and [`View::render`] call.
 pub struct RenderCtx<'a> {
     /// The active theme supplying colors for this frame.
     pub theme: &'a Theme,
@@ -60,13 +60,14 @@ impl<'a> RenderCtx<'a> {
 /// A drawable, measurable UI element.
 ///
 /// `measure` reports the intrinsic content size the view would like given
-/// `available`; the flex solver uses it for `Dimension::Auto` sizing.
+/// `available` and the same active theme, stylesheet, and focus state that its
+/// render will receive; the flex solver uses it for `Dimension::Auto` sizing.
 /// `render` paints into the `area` the layout assigned, through the clipped
 /// `surface`. A view may borrow application state; use it as the root of a
 /// [`ScopedScene`](crate::ScopedScene) when it needs Tuika-owned overlays.
 pub trait View {
-    /// Report the intrinsic content size wanted given `available`.
-    fn measure(&self, available: Size) -> Size;
+    /// Report the intrinsic content size wanted given `available` and `ctx`.
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size;
     /// Paint the view into the assigned `area` through `surface`.
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx);
 }
@@ -82,8 +83,8 @@ pub type ScopedElement<'view> = Box<dyn View + 'view>;
 pub type Element = ScopedElement<'static>;
 
 impl View for Box<dyn View + '_> {
-    fn measure(&self, available: Size) -> Size {
-        (**self).measure(available)
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        (**self).measure(available, ctx)
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
@@ -132,7 +133,7 @@ impl<F> View for DrawView<F>
 where
     F: Fn(Rect, &mut Surface<'_>, &RenderCtx<'_>),
 {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(
             self.intrinsic.width.min(available.width),
             self.intrinsic.height.min(available.height),
@@ -163,7 +164,11 @@ mod draw_view_tests {
         )
         .intrinsic_size(Size::new(20, 3));
 
-        assert_eq!(view.measure(Size::new(4, 1)), Size::new(4, 1));
+        let theme = Theme::default();
+        assert_eq!(
+            view.measure(Size::new(4, 1), &RenderCtx::new(&theme)),
+            Size::new(4, 1)
+        );
         assert_eq!(grid(&render(&view, 4, 1, &Theme::default())), "canv");
     }
 }

--- a/tests/measurement_context.rs
+++ b/tests/measurement_context.rs
@@ -1,0 +1,43 @@
+use tuika::prelude::*;
+use tuika::testing::render_with_sheet;
+
+struct HostView;
+
+impl View for HostView {
+    fn measure(&self, available: Size, ctx: &RenderCtx) -> Size {
+        let padding = ctx
+            .sheet
+            .panel
+            .padding
+            .expect("host stylesheet reaches third-party measurement");
+        Size::new(
+            1u16.saturating_add(padding.horizontal()),
+            1u16.saturating_add(padding.vertical()),
+        )
+        .clamp_to(available)
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        surface.set(area.x, area.y, 'x', ctx.sheet.heading.to_style());
+    }
+}
+
+#[test]
+fn third_party_measurement_receives_the_context_through_containers() {
+    let theme = Theme::default();
+    let sheet = StyleSheet {
+        panel: StyleBundle::new().padding(Padding::all(2)),
+        heading: StyleBundle::new().fg(Color::Cyan),
+        ..StyleSheet::from_theme(&theme)
+    };
+    let tree = Flex::column().auto(element(Boxed::new(element(HostView))));
+    let ctx = RenderCtx::new(&theme).with_sheet(sheet);
+
+    // HostView asks for 5x5 from the active padding; Boxed applies the same
+    // stylesheet padding plus its border, and Flex forwards that result.
+    assert_eq!(tree.measure(Size::new(20, 20), &ctx), Size::new(11, 11));
+
+    let buffer = render_with_sheet(&tree, 11, 11, &theme, sheet);
+    assert_eq!(buffer[(3, 3)].symbol(), "x");
+    assert_eq!(buffer[(3, 3)].fg, Color::Cyan);
+}

--- a/tests/scoped_scene.rs
+++ b/tests/scoped_scene.rs
@@ -11,7 +11,7 @@ struct Transcript<'data> {
 }
 
 impl View for Transcript<'_> {
-    fn measure(&self, available: Size) -> Size {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         Size::new(
             available.width,
             (self.messages.len() as u16).min(available.height),


### PR DESCRIPTION
## What changed

`View::measure` now receives the active `RenderCtx`, and every built-in composition path forwards the same theme, stylesheet, and focus state used for rendering. `Markdown` and `tuika-html::Html` measure under host styling; `Boxed` now treats stylesheet panel padding as real geometry with explicit instance padding taking precedence. `Flex::solve` and ItemScroll height helpers accept the context, and consumer tests gain `testing::render_with_sheet`.

## Why

Measurement previously synthesized the default theme and stylesheet in context-sensitive views. A tree could therefore request one geometry and render another, while the public `StyleBundle::padding` field was documented but ignored. A component library needs one layout contract through custom views, containers, companion crates, and host-side preflight helpers.

## Before / After

Before: `fn measure(&self, available: Size) -> Size` had no access to host styling; Markdown/HTML fell back to defaults, and panel stylesheet padding did not affect layout.

After: `fn measure(&self, available: Size, ctx: &RenderCtx) -> Size` uses the frame context end to end. Regression tests prove context-dependent Markdown output measures exactly what it paints, standalone HTML matches its styled render, nested third-party views receive context, panel padding measures/renders identically, and ItemScroll invalidates cached heights when styling changes. The default Boxed demo dump is unchanged and all 30 gallery scenes remain in sync.

## Risk

- Medium
- This is an intentional pre-1.0 source-breaking trait/API correction. Downstream `View` implementations and direct calls to `measure`, `Flex::solve`, or ItemScroll measurement helpers must pass `RenderCtx`; migration is called out in the changelog. Runtime risk is concentrated in container context propagation and context-sensitive height caching.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated rendering architecture, public API surface, consumer testing contract, and the knowledge log. Public README, component/styling guides, rustdoc, examples, and changelog include the new contract and migration.

## Security

Reviewed TM-CLIP, TM-STATE, TM-PARSE, TM-ESC, and TM-DEP. The change adds no I/O, parser, terminal-escape, unsafe, dependency, or credential path. Context affects only measurement/style resolution; oversized stylesheet padding saturates and clamps to the available geometry.

## Follow-ups

No follow-ups.