### PR TITLE
docs(brand): add tuika logo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ tuika's own suite covers more:
 
 ## Docs layout
 
+- `logo.svg` — the hand-authored vector source for tuika's mark, embedded in the
+  README and shipped so crates.io can resolve the relative path.
 - `docs/components.md` — the public component gallery (name, description, demo
   per component), covering **every** component, including those published in a
   companion crate. Keep it **presentational only**: no build or regeneration
@@ -167,9 +169,9 @@ tuika's own suite covers more:
 The root package's demo, showcase, example, theme, and styling assets are
 GitHub-only: `Cargo.toml`'s `exclude` keeps them (and the repository
 machinery — `knowledge/`, `.agents/`, `.github/`, `scripts/`) out of tuika's
-published `.crate`, and `tests/packaging.rs` guards that split. Only
-`docs/hero.gif`, `docs/demos/image.svg`, and `docs/demos/split-footer.svg`,
-which the crates.io README embeds by relative path, ship in tuika.
+published `.crate`, and `tests/packaging.rs` guards that split. Only `logo.svg`,
+`docs/hero.gif`, `docs/demos/image.svg`, and `docs/demos/split-footer.svg`, which
+the crates.io README embeds by relative path, ship in tuika.
 
 Every published member owns the same rule, and how its README embeds a recording
 decides the answer: `tuika-mermaid`'s small recording ships, because its README

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ categories = ["command-line-interface"]
 #    beside the `codex` example — total ~14 MiB and are consumed only from the
 #    repository by `docs/*.md` or absolute rustdoc URLs. rustdoc/docs.rs
 #    references none of them from its crate front page, so bundling them just
-#    bloats the tarball. Keep `hero.gif`, `demos/image.svg`, and
-#    `demos/split-footer.svg`: those are the only three the crates.io README
+#    bloats the tarball. Keep `logo.svg`, `hero.gif`, `demos/image.svg`, and
+#    `demos/split-footer.svg`: those are the four assets the crates.io README
 #    (`README.md`) embeds by relative path.
 # 2. Repository machinery. Since tuika is the root package, everything beside it
 #    in the repo would otherwise ship: internal knowledge, agent skills, CI

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# tuika
+<p align="center">
+  <img src="logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
+</p>
+
+<h1 align="center">tuika</h1>
 
 <div align="center">
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,13 @@
 
 ## 2026-07-31
 
+- **A composable visual identity**
+
+- Added tuika's first logo: two offset interface panels meet at a gold anchor,
+  pairing the toolkit's base-view/overlay model with Everruns' navy-and-gold
+  visual language. The authored SVG is the canonical source and ships with the
+  crate because the crates.io README embeds it by relative path.
+
 - **Semantic styling is open and complete**
 
 - Toasts, diffs, and keymap hints now join markdown and panels under one

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -134,8 +134,9 @@ owns clarity, task completeness, working examples, and accurate warnings.
 
 ## Generated visual assets
 
-Every visual in this repository is generated from code that is checked in, not
-staged by hand. The rule is that the *scene registry is the source of truth*:
+Every visual in this repository has checked-in source rather than an opaque
+staged artifact. The hand-authored `logo.svg` is its own editable vector source;
+generated demos follow the rule that the *scene registry is the source of truth*:
 
 - Component demos come from the `DEMOS` registry in `examples/demo.rs`; VHS
   tapes are generated per scene into a temp dir and are **not committed**.
@@ -266,18 +267,18 @@ consumed only by the GitHub-rendered README and `docs/*.md`. docs.rs renders the
 hand-written `//!` header, which references none of them, so bundling them only
 bloats the published `.crate`. Root `Cargo.toml`'s `exclude` keeps them — and the
 repository machinery (`knowledge/`, `.agents/`, `.github/`, `scripts/`) — out
-of that tarball; only `docs/hero.gif`, `docs/demos/image.svg`, and
-`docs/demos/split-footer.svg`, which its crates.io README embeds by relative
-path, ship.
+of that tarball; only `logo.svg`, `docs/hero.gif`, `docs/demos/image.svg`, and
+`docs/demos/split-footer.svg`, which its crates.io README embeds by relative path,
+ship.
 
 The split is per **published crate**, not per repository, and the deciding
 question is how that crate's own README reaches the asset — because that is what
 determines whether the packaged copy is ever read:
 
 - **Relative path** — crates.io renders the page from the tarball, so the asset
-  must ship. tuika's README assets (`docs/hero.gif`, `docs/demos/image.svg`, and
-  `docs/demos/split-footer.svg`) and `tuika-mermaid`'s ~32 KiB recording beside
-  its example are here.
+  must ship. tuika's README assets (`logo.svg`, `docs/hero.gif`,
+  `docs/demos/image.svg`, and `docs/demos/split-footer.svg`) and
+  `tuika-mermaid`'s ~32 KiB recording beside its example are here.
 - **Absolute `raw.githubusercontent.com` URL** — the packaged copy is
   unreachable from inside the `.crate` and is pure weight, so it is excluded
   wherever it lives. `tuika-codeformatters`' `docs/languages.gif` was shipping

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1024"
+     height="1024"
+     viewBox="0 0 512 512"
+     role="img"
+     aria-labelledby="title desc">
+  <title id="title">tuika logo</title>
+  <desc id="desc">Two offset rounded interface panels intersect at a gold anchor point.</desc>
+
+  <defs>
+    <!-- The offset panels represent tuika's base view and anchored overlays;
+         their shared gold point carries the Everruns family signature. -->
+    <linearGradient id="front" x1="170" y1="158" x2="432" y2="420"
+                    gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#D4A43A"/>
+      <stop offset="0.24" stop-color="#D4A43A"/>
+      <stop offset="0.58" stop-color="#0A1636"/>
+      <stop offset="1" stop-color="#0B1233"/>
+    </linearGradient>
+  </defs>
+
+  <rect x="72" y="92" width="274" height="274" rx="58"
+        fill="none" stroke="#081C3F" stroke-width="30"/>
+  <rect x="166" y="146" width="274" height="274" rx="58"
+        fill="none" stroke="url(#front)" stroke-width="30"/>
+  <rect x="215" y="195" width="66" height="66" rx="20" fill="#D4A43A"/>
+</svg>

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -24,7 +24,7 @@
 //! README embeds it: an absolute `raw.githubusercontent.com` URL means the
 //! packaged copy is unreachable and must not ship (`tuika-codeformatters`), a
 //! relative path means crates.io renders from the packaged copy and it must
-//! (`tuika-mermaid`, `tuika-html`, and tuika's three README assets).
+//! (`tuika-mermaid`, `tuika-html`, and tuika's four README assets).
 
 use std::process::Command;
 
@@ -124,6 +124,7 @@ fn crates_io_readme_assets_and_source_are_kept() {
     let has = |p: &str| files.iter().any(|f| f == p);
 
     // The assets the crates.io README embeds by relative path.
+    assert!(has("logo.svg"), "README logo must ship");
     assert!(has("docs/hero.gif"), "README hero image must ship");
     assert!(
         has("docs/demos/image.svg"),


### PR DESCRIPTION
## What changed

Adds tuika's first project logo and presents it above the README title. The editable SVG shows two offset interface panels meeting at a gold anchor, combining tuika's base-view/overlay model with the Everruns navy-and-gold visual language.

The logo ships in the crate so the crates.io README can resolve its relative path, with packaging coverage guarding that contract.

## Why

tuika had no recognizable project mark. A lightweight source SVG gives the repository and crates.io page a distinct identity without adding generated binary assets or dependencies.

## Before / After

Before: the README opened with a text-only project heading.

After:

![tuika logo](https://raw.githubusercontent.com/everruns/tuika/e0dcbbf/logo.svg)

## Validation

- `xmllint --noout logo.svg`
- Rendered at 1024px and 32px
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo publish --dry-run --allow-dirty -p tuika`
- `python3 scripts/validate_okf.py knowledge --check-links`

Runtime smoke testing is not applicable: this changes only documentation, packaging coverage, and a static SVG asset.

## API

No public API change.

## Risk

- Low
- Risk is limited to README SVG rendering or accidentally omitting the relative asset from the published crate; local rendering and the packaging test cover both.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated the documentation asset contract and knowledge log to record the authored SVG source and packaged README asset.

## Security

No security-relevant code changes. TM-ESC, TM-STATE, TM-PARSE, TM-CLIP, and TM-DEP are unaffected; the SVG contains only fixed geometry and colors, with no scripts, external resources, user input, dependencies, or runtime execution.

## Follow-ups

No follow-ups.
