### PR TITLE
feat(input): unify component state outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,14 @@ block-HTML seam.
 
 ### Changed
 
+- **Breaking:** interactive component handlers now return one root/prelude
+  `InputOutcome` (`Ignored`, `Consumed`, `Changed`, `Submitted`, or `Cancelled`).
+  Read the submitted value back from its host-owned state. Replace
+  `SelectOutcome`, `MultiSelectOutcome`, `FormOutcome`, `TabSelectOutcome`,
+  `TextInputEvent`, and direct `EventFlow` matches with `InputOutcome`; call
+  `.flow()` when only propagation matters. `SelectState`, `MultiSelectState`,
+  and `ScrollState` now make `Default` identical to `new()`; use
+  `SelectState::unselected()` for an initially cursorless list.
 - **Breaking:** `StyleSheet` adds typed toast, diff, and key-hint fields. Toasts,
   diffs, `KeyHints`, and `KeymapHelp` now derive their defaults from those roles
   instead of renderer literals; explicit `Diff::style` colors still win for one

--- a/README.md
+++ b/README.md
@@ -330,9 +330,11 @@ container passes that context to the children it measures.
 
 `Form` lays out arbitrary control `Element`s beside responsive labels, stacking
 on narrow terminals. Help and validation rows are built in; `FormState` owns
-only focus traversal and submit/cancel outcomes, while values and cursor state
-stay in existing host-owned `TextInputState`, `SelectState`, or application
-models.
+only focus traversal, while values and cursor state stay in existing host-owned
+`TextInputState`, `SelectState`, or application models. Their `handle` methods
+share `InputOutcome`: ignored events bubble, recognized no-ops are consumed,
+state changes are distinct from submit/cancel intent, and submitted values are
+read from the state instead of duplicated in the outcome.
 
 ## Arbitrary-child viewports and drawing
 

--- a/benches/iai-baseline.json
+++ b/benches/iai-baseline.json
@@ -6,7 +6,7 @@
     "frame_windowed.large": 869465,
     "one_shot.large": 5832653,
     "one_shot.small": 246183,
-    "paging.large": 234776,
+    "paging.large": 252164,
     "reflow.mixed": 12142847,
     "render.large": 849948,
     "render.small": 849885,

--- a/benches/scroll.rs
+++ b/benches/scroll.rs
@@ -126,7 +126,7 @@ fn paging(c: &mut Criterion) {
                 state.jump_to_top();
                 // Page to the bottom; `handle` re-arms stick-to-bottom at the end.
                 while !state.is_stuck_to_bottom() {
-                    state.handle(black_box(&page_down), rows, HEIGHT as usize);
+                    let _ = state.handle(black_box(&page_down), rows, HEIGHT as usize);
                 }
                 black_box(state.offset())
             });

--- a/benches/scroll_iai.rs
+++ b/benches/scroll_iai.rs
@@ -132,7 +132,7 @@ fn paging(rows: usize) -> usize {
     let page_down = Event::Key(Key::new(KeyCode::PageDown));
     // Page from top to bottom; `handle` re-arms stick-to-bottom at the end.
     while !state.is_stuck_to_bottom() {
-        state.handle(black_box(&page_down), rows, HEIGHT as usize);
+        let _ = state.handle(black_box(&page_down), rows, HEIGHT as usize);
     }
     black_box(state.offset())
 }

--- a/crates/tuika-codeformatters/examples/languages.rs
+++ b/crates/tuika-codeformatters/examples/languages.rs
@@ -179,7 +179,7 @@ fn main() -> io::Result<()> {
         {
             break;
         }
-        tabs.handle(&ev, SNIPPETS.len());
+        let _ = tabs.handle(&ev, SNIPPETS.len());
     }
 
     let _ = terminal.clear();

--- a/docs/components.md
+++ b/docs/components.md
@@ -451,8 +451,9 @@ let chart = DrawView::new(
 ### `SelectList` + `SelectState`
 
 A selectable list; `SelectState` navigates with the arrow keys (wrapping),
-confirms on Enter, cancels on Esc. Selection is optional:
-`state.select(None)` draws neither caret nor highlight. `.selection_style(style)`
+confirms on Enter, cancels on Esc. `new()` and `default()` select the first row;
+`SelectState::unselected()` starts cursorless, and `state.select(None)` clears an
+existing selection so neither caret nor highlight is drawn. `.selection_style(style)`
 overrides the theme selection style for one list. `handle_with` accepts a
 `SelectNavigation` policy; `SelectNavigation::common()` enables j/k, Ctrl+N/P,
 Tab/Shift+Tab, and numeric shortcuts. `handle_mouse` hit-tests explicit list
@@ -465,9 +466,9 @@ for pickers that retain several checked items.
 ```rust
 use ratatui::style::{Color, Style};
 use tuika::prelude::*;
-let mut state = SelectState::new();
+let mut state = SelectState::unselected();
 let style = Style::default().fg(Color::Blue);
-state.select(None); // cursorless list; use Some(index) to select
+state.select(Some(0)); // select a row when the host is ready
 view! { node(SelectList::new(items, &state).selection_style(style)) }
 ```
 
@@ -518,8 +519,8 @@ view! { node(Tabs::new(labels, &state)) }
 
 A value-selecting segmented control (as opposed to `Tabs`, which is navigation
 chrome): moving the cursor changes the selected value immediately, and
-Enter/Space activates it. `handle` returns a `TabSelectOutcome` distinguishing a
-change from an activation.
+Enter/Space activates it. `handle` returns the shared `InputOutcome`,
+distinguishing a change from submission while the state owns the selected value.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.TabSelect.html)
 
 <img src="demos/tab_select.gif" width="880" alt="TabSelect demo">
@@ -563,6 +564,11 @@ For search fields and command bars, `SingleLineInputState` wraps the same editor
 but guarantees one line: setters and paste normalize CR/LF to spaces, Enter and
 Ctrl+J submit, and `text()` returns a borrowed `&str` without allocation. Render
 it with `TextInput::new(state.as_text_input())`.
+
+Like the other interactive state types, `handle` returns `InputOutcome`:
+`Changed` means persistent state moved, `Consumed` means a recognized action hit
+a bound, `Submitted`/`Cancelled` report lifecycle intent, and only `Ignored`
+should continue through input routing. The edited text remains in the state.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.TextInput.html)
 
 <img src="demos/textinput.gif" width="880" alt="TextInput demo">

--- a/examples/codex/app.rs
+++ b/examples/codex/app.rs
@@ -296,7 +296,7 @@ impl App {
         }
 
         match self.composer.handle(event) {
-            Some(TextInputEvent::Submit) => {
+            InputOutcome::Submitted => {
                 let text = self.composer.text().trim().to_string();
                 self.composer.clear();
                 self.popup = None;
@@ -305,7 +305,7 @@ impl App {
                     self.submit(&text);
                 }
             }
-            Some(TextInputEvent::Changed) | None => self.sync_popup(),
+            _ => self.sync_popup(),
         }
         Flow::Continue
     }
@@ -342,9 +342,9 @@ impl App {
             KeyCode::Char('2') if key.plain() => Some(1),
             KeyCode::Char('3') if key.plain() => Some(2),
             _ => match approval.state.handle(event, 3) {
-                SelectOutcome::Confirmed(i) => Some(i),
-                SelectOutcome::Cancelled => Some(2),
-                SelectOutcome::Moved(_) => None,
+                InputOutcome::Submitted => approval.state.selected(),
+                InputOutcome::Cancelled => Some(2),
+                _ => None,
             },
         };
         let Some(index) = picked else { return };
@@ -380,18 +380,21 @@ impl App {
             return true;
         }
         match state.handle(event, items.len()) {
-            SelectOutcome::Confirmed(index) => {
-                let label = items.get(index).map(|(l, _)| l.clone());
+            InputOutcome::Submitted => {
+                let label = state
+                    .selected()
+                    .and_then(|index| items.get(index))
+                    .map(|(l, _)| l.clone());
                 if let (Some(label), Some(kind)) = (label, self.popup.take()) {
                     self.confirm_popup(kind, &label);
                 }
                 true
             }
-            SelectOutcome::Cancelled => {
+            InputOutcome::Cancelled => {
                 self.popup = None;
                 true
             }
-            SelectOutcome::Moved(flow) => flow == EventFlow::Consumed,
+            outcome => outcome.consumed(),
         }
     }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1138,7 +1138,7 @@ fn scene_scroll(frame: u64, theme: &Theme) -> Element {
     let steps = (reach * (content_h.saturating_sub(viewport_h) as f32 / 3.0 + 1.0)) as u32;
     let down = Event::Mouse(Mouse::at(MouseKind::ScrollDown, 0, 0));
     for _ in 0..steps {
-        state.handle(&down, content_h, viewport_h);
+        let _ = state.handle(&down, content_h, viewport_h);
     }
     view! {
         col {
@@ -1177,7 +1177,7 @@ fn scene_item_scroll(frame: u64, theme: &Theme) -> Element {
     let steps = (reach * (content_h.saturating_sub(viewport_h) as f32 / 3.0 + 1.0)) as u32;
     let down = Event::Mouse(Mouse::at(MouseKind::ScrollDown, 0, 0));
     for _ in 0..steps {
-        state.handle(&down, content_h, viewport_h);
+        let _ = state.handle(&down, content_h, viewport_h);
     }
     view! {
         col {
@@ -1240,7 +1240,7 @@ fn scene_select(frame: u64, theme: &Theme) -> Element {
     let target = (frame / 10) % items.len() as u64;
     let down = Event::Key(Key::new(KeyCode::Down));
     for _ in 0..target {
-        state.handle(&down, items.len());
+        let _ = state.handle(&down, items.len());
     }
     view! {
         col {
@@ -1258,7 +1258,7 @@ fn scene_tabs(frame: u64, theme: &Theme) -> Element {
     let target = (frame / 16) % labels.len() as u64;
     let right = Event::Key(Key::new(KeyCode::Right));
     for _ in 0..target {
-        state.handle(&right, labels.len());
+        let _ = state.handle(&right, labels.len());
     }
     view! {
         col(gap = 1) {
@@ -1563,7 +1563,7 @@ fn scene_tab_select(frame: u64, theme: &Theme) -> Element {
     let target = (frame / 18) % labels.len() as u64;
     let right = Event::Key(Key::new(KeyCode::Right));
     for _ in 0..target {
-        state.handle(&right, labels.len());
+        let _ = state.handle(&right, labels.len());
     }
     view! {
         col(gap = 1) {

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -273,7 +273,7 @@ fn main() -> io::Result<()> {
         }
         // PgUp/PgDn/Home/End and the wheel; scrolling up releases the stick,
         // reaching the bottom re-arms it.
-        scroll.handle(&event, content_h, viewport_h);
+        let _ = scroll.handle(&event, content_h, viewport_h);
     }
 
     let _ = terminal.clear();

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -193,7 +193,7 @@ fn tab_strip(frame: u64, theme: &Theme) -> Element {
     let target = (frame / 3) % labels.len() as u64;
     let right = Event::Key(Key::new(KeyCode::Right));
     for _ in 0..target {
-        state.handle(&right, labels.len());
+        let _ = state.handle(&right, labels.len());
     }
     element(Tabs::new(labels, &state))
 }
@@ -242,7 +242,7 @@ fn palette_panel(frame: u64, theme: &Theme) -> Element {
     let target = (frame / 2) % items.len() as u64;
     let down = Event::Key(Key::new(KeyCode::Down));
     for _ in 0..target {
-        state.handle(&down, items.len());
+        let _ = state.handle(&down, items.len());
     }
     view! {
         boxed(title = Line::from(Span::styled(" command palette ", theme.accent_style())),

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -80,9 +80,9 @@ fn main() -> io::Result<()> {
             break;
         }
         match state.handle(&ev, FRUITS.len()) {
-            SelectOutcome::Confirmed(i) => chosen = Some(i),
-            SelectOutcome::Cancelled => break,
-            SelectOutcome::Moved(_) => {}
+            InputOutcome::Submitted => chosen = state.selected(),
+            InputOutcome::Cancelled => break,
+            _ => {}
         }
     }
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,17 @@
 # Knowledge Log
 
+## 2026-08-01
+
+- **Interactive components share one state contract**
+
+- Selection, multi-selection, tabs, segmented selection, sliders, scrolling,
+  forms, and text input now report one `InputOutcome` vocabulary. Hosts can
+  route every component consistently while reading values from the state they
+  already own.
+- `Default` and zero-argument `new()` no longer disagree about initial
+  selection or bottom-follow behavior. Alternate starts are named explicitly,
+  and handled boundary keys are distinguishable from events a host may reuse.
+
 ## 2026-07-31
 
 - **Overlay placement can follow laid-out targets**

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -25,6 +25,13 @@ rather than beside it.
   focus registry, text-input cursor, and toast expiry are `*State` structs the
   host owns and passes back in each frame — the `StatefulWidget` idiom. A view
   never hides mutable state a host cannot inspect or persist.
+- **Interactive state has one lifecycle vocabulary.** Component handlers return
+  `InputOutcome`: ignored events may continue routing; recognized no-ops stop;
+  persistent mutations, submission, and cancellation remain distinct. Values
+  are read from the host-owned state rather than duplicated in outcome enums.
+  For state types with a zero-argument constructor, `Default` and `new()` are
+  identical; a meaningful alternate start is explicit (for example,
+  `SelectState::unselected()`).
 - **Layout is a flexbox subset** over a direction-agnostic axis, so rows and
   columns share one solver: `Dimension` (`Auto`/`Fixed`/`Percent`/`Flex`) plus
   `Align`, `Justify`, and `Direction`.

--- a/src/components/form.rs
+++ b/src/components/form.rs
@@ -2,22 +2,11 @@
 
 use ratatui_core::layout::Rect;
 
-use crate::event::{Event, EventFlow, KeyCode};
+use crate::event::{Event, InputOutcome, KeyCode};
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{Element, RenderCtx, ScopedElement, View};
 use crate::width::str_cols;
-
-/// Result of routing a form-level navigation event.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum FormOutcome {
-    /// Focus moved, with the event's consumed status.
-    FocusChanged(EventFlow),
-    /// The host should submit the form.
-    Submitted,
-    /// The host should cancel the form.
-    Cancelled,
-}
 
 /// Host-owned focus state for a form.
 #[derive(Clone, Copy, Debug, Default)]
@@ -54,22 +43,40 @@ impl FormState {
     ///
     /// Give the focused control first refusal when Enter or Esc has
     /// control-specific meaning, then pass ignored events here.
-    pub fn handle(&mut self, event: &Event, field_count: usize) -> FormOutcome {
+    pub fn handle(&mut self, event: &Event, field_count: usize) -> InputOutcome {
         let Event::Key(key) = event else {
-            return FormOutcome::FocusChanged(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         };
         match key.code {
             KeyCode::Tab if key.plain() && field_count > 0 => {
-                self.focused = (self.focused + 1) % field_count;
-                FormOutcome::FocusChanged(EventFlow::Consumed)
+                let before = self.focused;
+                self.focused = if self.focused >= field_count - 1 {
+                    0
+                } else {
+                    self.focused + 1
+                };
+                if self.focused == before {
+                    InputOutcome::Consumed
+                } else {
+                    InputOutcome::Changed
+                }
             }
             KeyCode::BackTab if field_count > 0 => {
-                self.focused = (self.focused + field_count - 1) % field_count;
-                FormOutcome::FocusChanged(EventFlow::Consumed)
+                let before = self.focused;
+                self.focused = if self.focused == 0 || self.focused >= field_count {
+                    field_count - 1
+                } else {
+                    self.focused - 1
+                };
+                if self.focused == before {
+                    InputOutcome::Consumed
+                } else {
+                    InputOutcome::Changed
+                }
             }
-            KeyCode::Enter if key.plain() => FormOutcome::Submitted,
-            KeyCode::Esc if key.plain() => FormOutcome::Cancelled,
-            _ => FormOutcome::FocusChanged(EventFlow::Ignored),
+            KeyCode::Enter if key.plain() => InputOutcome::Submitted,
+            KeyCode::Esc if key.plain() => InputOutcome::Cancelled,
+            _ => InputOutcome::Ignored,
         }
     }
 }
@@ -294,16 +301,16 @@ mod tests {
         let mut state = FormState::new();
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Tab)), 2),
-            FormOutcome::FocusChanged(EventFlow::Consumed)
+            InputOutcome::Changed
         );
         assert_eq!(state.focused(), 1);
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Enter)), 2),
-            FormOutcome::Submitted
+            InputOutcome::Submitted
         );
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Esc)), 2),
-            FormOutcome::Cancelled
+            InputOutcome::Cancelled
         );
     }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -60,7 +60,7 @@ pub use dialog::Dialog;
 pub use diff::{Diff, DiffMode, DiffRow, DiffStyle, DiffTag};
 pub use flex::Flex;
 pub use focus_scope::FocusScope;
-pub use form::{Form, FormField, FormOutcome, FormState};
+pub use form::{Form, FormField, FormState};
 pub use image::Image;
 pub use item_scroll::ItemScroll;
 pub use key_hints::{KeyHint, KeyHints, KeymapHelp};
@@ -74,20 +74,18 @@ pub use qr::{QrCode, QrEcc};
 pub use responsive::Responsive;
 pub use rule::Rule;
 pub use scroll::{Scroll, ScrollState};
-pub use select::{
-    MultiSelectOutcome, MultiSelectState, SelectList, SelectNavigation, SelectOutcome, SelectState,
-};
+pub use select::{MultiSelectState, SelectList, SelectNavigation, SelectState};
 pub use slider::{Slider, SliderState};
 pub use spacer::Spacer;
 pub use spinner::{Spinner, SpinnerStyle};
 pub use status_bar::StatusBar;
-pub use tab_select::{TabSelect, TabSelectOutcome, TabSelectState};
+pub use tab_select::{TabSelect, TabSelectState};
 pub use table::{Column, Table};
 pub use tabs::{Tabs, TabsState};
 pub use text::{Paragraph, Text, Wrap};
 pub use textinput::{
-    SingleLineInputState, TextInput, TextInputEvent, TextInputMode, TextInputState, TextSpan,
-    Token, Trigger, TriggerAnchor,
+    SingleLineInputState, TextInput, TextInputMode, TextInputState, TextSpan, Token, Trigger,
+    TriggerAnchor,
 };
 pub use toast::{ToastLevel, ToastList, Toasts};
 pub use viewport::Viewport;

--- a/src/components/scroll.rs
+++ b/src/components/scroll.rs
@@ -27,7 +27,7 @@ use ratatui_core::layout::Rect;
 use ratatui_core::style::Style;
 use ratatui_core::text::Line;
 
-use crate::event::{Event, EventFlow, KeyCode, MouseKind};
+use crate::event::{Event, InputOutcome, KeyCode, MouseKind};
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
@@ -40,7 +40,7 @@ use super::text::wrap_lines;
 /// `u16::MAX` rows in a long session. Measuring the offset and content height in
 /// `u16` let a 65,536-row transcript wrap to ~0, which collapsed
 /// stick-to-bottom's `max_offset` to 0 and silently snapped the view to the top.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct ScrollState {
     /// Top visible content row.
     offset: usize,
@@ -50,6 +50,12 @@ pub struct ScrollState {
     /// When true, `clamp` snaps to the bottom on content growth so new
     /// transcript output stays visible.
     stick_to_bottom: bool,
+}
+
+impl Default for ScrollState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ScrollState {
@@ -136,16 +142,28 @@ impl ScrollState {
         self.x_offset = self.x_offset.min(Self::max_x_offset(content_w, viewport_w));
     }
 
-    fn scroll_up(&mut self, lines: usize) {
+    fn scroll_up(&mut self, lines: usize) -> InputOutcome {
+        let changed = self.offset != 0 || self.stick_to_bottom;
         self.offset = self.offset.saturating_sub(lines);
         self.stick_to_bottom = false;
+        if changed {
+            InputOutcome::Changed
+        } else {
+            InputOutcome::Consumed
+        }
     }
 
-    fn scroll_down(&mut self, lines: usize, content_h: usize, viewport_h: usize) {
+    fn scroll_down(&mut self, lines: usize, content_h: usize, viewport_h: usize) -> InputOutcome {
         let max = Self::max_offset(content_h, viewport_h);
+        let changed = self.offset != max || !self.stick_to_bottom;
         self.offset = self.offset.saturating_add(lines).min(max);
         // Re-arm bottom-stick once the user scrolls back to the end.
         self.stick_to_bottom = self.offset >= max;
+        if changed {
+            InputOutcome::Changed
+        } else {
+            InputOutcome::Consumed
+        }
     }
 
     /// Jump to the newest content and re-enable bottom-stick.
@@ -161,40 +179,39 @@ impl ScrollState {
     }
 
     /// Handle a scroll/paging event against the given dimensions.
-    pub fn handle(&mut self, event: &Event, content_h: usize, viewport_h: usize) -> EventFlow {
+    pub fn handle(&mut self, event: &Event, content_h: usize, viewport_h: usize) -> InputOutcome {
         let page = viewport_h.saturating_sub(1).max(1);
         match event {
             Event::Mouse(m) => match m.kind {
-                MouseKind::ScrollUp => {
-                    self.scroll_up(3);
-                    EventFlow::Consumed
-                }
-                MouseKind::ScrollDown => {
-                    self.scroll_down(3, content_h, viewport_h);
-                    EventFlow::Consumed
-                }
-                _ => EventFlow::Ignored,
+                MouseKind::ScrollUp => self.scroll_up(3),
+                MouseKind::ScrollDown => self.scroll_down(3, content_h, viewport_h),
+                _ => InputOutcome::Ignored,
             },
             Event::Key(k) if k.plain() => match k.code {
-                KeyCode::PageUp => {
-                    self.scroll_up(page);
-                    EventFlow::Consumed
-                }
-                KeyCode::PageDown => {
-                    self.scroll_down(page, content_h, viewport_h);
-                    EventFlow::Consumed
-                }
+                KeyCode::PageUp => self.scroll_up(page),
+                KeyCode::PageDown => self.scroll_down(page, content_h, viewport_h),
                 KeyCode::Home => {
+                    let changed = self.offset != 0 || self.stick_to_bottom;
                     self.jump_to_top();
-                    EventFlow::Consumed
+                    if changed {
+                        InputOutcome::Changed
+                    } else {
+                        InputOutcome::Consumed
+                    }
                 }
                 KeyCode::End => {
+                    let max = Self::max_offset(content_h, viewport_h);
+                    let changed = self.offset != max || !self.stick_to_bottom;
                     self.jump_to_bottom(content_h, viewport_h);
-                    EventFlow::Consumed
+                    if changed {
+                        InputOutcome::Changed
+                    } else {
+                        InputOutcome::Consumed
+                    }
                 }
-                _ => EventFlow::Ignored,
+                _ => InputOutcome::Ignored,
             },
-            _ => EventFlow::Ignored,
+            _ => InputOutcome::Ignored,
         }
     }
 }
@@ -432,7 +449,7 @@ pub(crate) fn draw_scrollbar(
 mod tests {
     use super::*;
     use crate::Surface;
-    use crate::event::{Event, EventFlow, Key, KeyCode, Mouse, MouseKind};
+    use crate::event::{Event, InputOutcome, Key, KeyCode, Mouse, MouseKind};
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
@@ -449,7 +466,7 @@ mod tests {
 
         // Wheel up unsticks and moves up by 3.
         let up = Event::Mouse(Mouse::at(MouseKind::ScrollUp, 0, 0));
-        assert_eq!(s.handle(&up, 100, 10), EventFlow::Consumed);
+        assert_eq!(s.handle(&up, 100, 10), InputOutcome::Changed);
         assert!(!s.is_stuck_to_bottom());
         assert_eq!(s.offset(), 87);
 
@@ -472,7 +489,7 @@ mod tests {
         // Paging up from the bottom detaches and moves by a page, still far from
         // the top rather than snapping there.
         let up = Event::Key(Key::new(KeyCode::PageUp));
-        assert_eq!(s.handle(&up, content_h, viewport_h), EventFlow::Consumed);
+        assert_eq!(s.handle(&up, content_h, viewport_h), InputOutcome::Changed);
         assert!(!s.is_stuck_to_bottom());
         assert_eq!(s.offset(), content_h - viewport_h - (viewport_h - 1));
     }
@@ -596,8 +613,8 @@ mod tests {
 
         // Read back a couple of screens.
         let up = Event::Mouse(Mouse::at(MouseKind::ScrollUp, 0, 0));
-        s.handle(&up, 100, 10);
-        s.handle(&up, 100, 10);
+        let _ = s.handle(&up, 100, 10);
+        let _ = s.handle(&up, 100, 10);
         assert_eq!(s.offset(), 84);
         assert!(!s.is_stuck_to_bottom());
 
@@ -612,7 +629,7 @@ mod tests {
             if s.is_stuck_to_bottom() {
                 break;
             }
-            s.handle(&down, 130, 10);
+            let _ = s.handle(&down, 130, 10);
         }
         assert!(
             s.is_stuck_to_bottom(),
@@ -633,7 +650,7 @@ mod tests {
         assert_eq!(s.offset(), 0);
         assert!(!s.is_stuck_to_bottom());
         let end = Event::Key(Key::new(KeyCode::End));
-        assert_eq!(s.handle(&end, 100, 10), EventFlow::Consumed);
+        assert_eq!(s.handle(&end, 100, 10), InputOutcome::Changed);
         assert_eq!(s.offset(), 90);
         assert!(s.is_stuck_to_bottom());
     }
@@ -676,7 +693,7 @@ mod tests {
         state.clamp(content.len(), height as usize);
         state.jump_to_top();
         let end = Event::Key(Key::new(KeyCode::PageDown));
-        state.handle(&end, content.len(), height as usize); // one page down
+        let _ = state.handle(&end, content.len(), height as usize); // one page down
         let offset = state.offset();
         assert!(offset > 0 && offset < content.len() - height as usize);
 

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -3,14 +3,14 @@
 //! [`SelectState`] persists an optional highlighted index and handles
 //! up/down/wrap navigation; [`SelectList`] renders the options, marking the
 //! current one with a theme-default or instance selection style and a caret.
-//! Enter is surfaced to the host via [`SelectOutcome`] so the caller decides
-//! what "confirm" means.
+//! Enter is surfaced as [`InputOutcome::Submitted`] so the caller decides what
+//! "confirm" means.
 
 use ratatui_core::layout::Rect;
 use ratatui_core::style::Style;
 use ratatui_core::text::Line;
 
-use crate::event::{Event, EventFlow, KeyCode, MouseButton, MouseKind};
+use crate::event::{Event, InputOutcome, KeyCode, MouseButton, MouseKind};
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
@@ -44,27 +44,27 @@ impl SelectNavigation {
     }
 }
 
-/// Result of feeding an event to a [`SelectState`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SelectOutcome {
-    /// Highlight moved or nothing happened; event consumed status in `.1`.
-    Moved(EventFlow),
-    /// Enter pressed on the given index.
-    Confirmed(usize),
-    /// Esc pressed.
-    Cancelled,
-}
-
 /// Persisted optional selection index for one list.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug)]
 pub struct SelectState {
     selected: Option<usize>,
+}
+
+impl Default for SelectState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SelectState {
     /// A fresh state with the first row highlighted.
     pub fn new() -> Self {
         Self { selected: Some(0) }
+    }
+
+    /// A fresh state with no highlighted row.
+    pub fn unselected() -> Self {
+        Self { selected: None }
     }
 
     /// The currently highlighted index, or `None` when no row is selected.
@@ -107,7 +107,7 @@ impl SelectState {
     }
 
     /// Navigate with arrow keys (wrapping), confirm with Enter, cancel on Esc.
-    pub fn handle(&mut self, event: &Event, len: usize) -> SelectOutcome {
+    pub fn handle(&mut self, event: &Event, len: usize) -> InputOutcome {
         self.handle_with(event, len, SelectNavigation::default())
     }
 
@@ -117,23 +117,23 @@ impl SelectState {
         event: &Event,
         len: usize,
         navigation: SelectNavigation,
-    ) -> SelectOutcome {
+    ) -> InputOutcome {
         if len == 0 {
-            return SelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         }
         let Event::Key(k) = event else {
-            return SelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         };
 
         if navigation.ctrl_n_p && k.ctrl && !k.alt && !k.shift {
             return match k.code {
                 KeyCode::Char('n') => self.step_down(len),
                 KeyCode::Char('p') => self.step_up(len),
-                _ => SelectOutcome::Moved(EventFlow::Ignored),
+                _ => InputOutcome::Ignored,
             };
         }
         if !k.plain() {
-            return SelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         }
         match k.code {
             KeyCode::Up => self.step_up(len),
@@ -146,17 +146,14 @@ impl SelectState {
                 let index = digit as usize - '1' as usize;
                 if index < len {
                     self.selected = Some(index);
-                    SelectOutcome::Confirmed(index)
+                    InputOutcome::Submitted
                 } else {
-                    SelectOutcome::Moved(EventFlow::Ignored)
+                    InputOutcome::Ignored
                 }
             }
-            KeyCode::Enter => self.selected.map_or(
-                SelectOutcome::Moved(EventFlow::Ignored),
-                SelectOutcome::Confirmed,
-            ),
-            KeyCode::Esc => SelectOutcome::Cancelled,
-            _ => SelectOutcome::Moved(EventFlow::Ignored),
+            KeyCode::Enter if self.selected.is_some() => InputOutcome::Submitted,
+            KeyCode::Esc => InputOutcome::Cancelled,
+            _ => InputOutcome::Ignored,
         }
     }
 
@@ -171,9 +168,9 @@ impl SelectState {
         len: usize,
         bounds: Rect,
         first_visible: usize,
-    ) -> SelectOutcome {
+    ) -> InputOutcome {
         let Event::Mouse(mouse) = event else {
-            return SelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         };
         if !mouse.plain()
             || mouse.kind != MouseKind::Down(MouseButton::Left)
@@ -182,39 +179,41 @@ impl SelectState {
             || mouse.row < bounds.y
             || mouse.row >= bounds.bottom()
         {
-            return SelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         }
         let index = first_visible.saturating_add(usize::from(mouse.row - bounds.y));
         if index >= len {
-            return SelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         }
         self.selected = Some(index);
-        SelectOutcome::Confirmed(index)
+        InputOutcome::Submitted
     }
 
-    fn step_up(&mut self, len: usize) -> SelectOutcome {
+    fn step_up(&mut self, len: usize) -> InputOutcome {
+        let before = self.selected;
         self.selected = Some(match self.selected {
-            Some(0) | None => len - 1,
-            Some(selected) => selected - 1,
+            Some(selected) if selected > 0 && selected < len => selected - 1,
+            _ => len - 1,
         });
-        SelectOutcome::Moved(EventFlow::Consumed)
+        if self.selected == before {
+            InputOutcome::Consumed
+        } else {
+            InputOutcome::Changed
+        }
     }
 
-    fn step_down(&mut self, len: usize) -> SelectOutcome {
-        self.selected = Some(self.selected.map_or(0, |selected| (selected + 1) % len));
-        SelectOutcome::Moved(EventFlow::Consumed)
+    fn step_down(&mut self, len: usize) -> InputOutcome {
+        let before = self.selected;
+        self.selected = Some(match self.selected {
+            Some(selected) if selected < len - 1 => selected + 1,
+            _ => 0,
+        });
+        if self.selected == before {
+            InputOutcome::Consumed
+        } else {
+            InputOutcome::Changed
+        }
     }
-}
-
-/// Outcome from [`MultiSelectState`] input handling.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum MultiSelectOutcome {
-    /// The cursor moved; event consumed status in `.0`.
-    Moved(EventFlow),
-    /// The given item changed checked state.
-    Toggled(usize),
-    /// Escape cancelled the interaction.
-    Cancelled,
 }
 
 /// Cursor and checked-item state for a multiple-selection list.
@@ -264,7 +263,7 @@ impl MultiSelectState {
         event: &Event,
         len: usize,
         navigation: SelectNavigation,
-    ) -> MultiSelectOutcome {
+    ) -> InputOutcome {
         if let Event::Key(key) = event
             && key.plain()
             && key.code == KeyCode::Char(' ')
@@ -272,12 +271,14 @@ impl MultiSelectState {
             return self.toggle_cursor(len);
         }
         match self.cursor.handle_with(event, len, navigation) {
-            SelectOutcome::Moved(flow) => MultiSelectOutcome::Moved(flow),
-            SelectOutcome::Confirmed(index) => {
+            InputOutcome::Submitted => {
+                let Some(index) = self.cursor.selected() else {
+                    return InputOutcome::Ignored;
+                };
                 self.toggle(index);
-                MultiSelectOutcome::Toggled(index)
+                InputOutcome::Changed
             }
-            SelectOutcome::Cancelled => MultiSelectOutcome::Cancelled,
+            outcome => outcome,
         }
     }
 
@@ -288,24 +289,26 @@ impl MultiSelectState {
         len: usize,
         bounds: Rect,
         first_visible: usize,
-    ) -> MultiSelectOutcome {
+    ) -> InputOutcome {
         match self.cursor.handle_mouse(event, len, bounds, first_visible) {
-            SelectOutcome::Confirmed(index) => {
+            InputOutcome::Submitted => {
+                let Some(index) = self.cursor.selected() else {
+                    return InputOutcome::Ignored;
+                };
                 self.toggle(index);
-                MultiSelectOutcome::Toggled(index)
+                InputOutcome::Changed
             }
-            SelectOutcome::Moved(flow) => MultiSelectOutcome::Moved(flow),
-            SelectOutcome::Cancelled => MultiSelectOutcome::Cancelled,
+            outcome => outcome,
         }
     }
 
-    fn toggle_cursor(&mut self, len: usize) -> MultiSelectOutcome {
+    fn toggle_cursor(&mut self, len: usize) -> InputOutcome {
         self.cursor.clamp(len);
         let Some(index) = self.cursor.selected() else {
-            return MultiSelectOutcome::Moved(EventFlow::Ignored);
+            return InputOutcome::Ignored;
         };
         self.toggle(index);
-        MultiSelectOutcome::Toggled(index)
+        InputOutcome::Changed
     }
 
     fn toggle(&mut self, index: usize) {
@@ -503,7 +506,7 @@ impl SelectList {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{Event, EventFlow, Key, KeyCode};
+    use crate::event::{Event, InputOutcome, Key, KeyCode};
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
@@ -515,17 +518,14 @@ mod tests {
         let mut s = SelectState::new();
         let down = Event::Key(Key::new(KeyCode::Down));
         let up = Event::Key(Key::new(KeyCode::Up));
-        assert_eq!(s.handle(&up, 3), SelectOutcome::Moved(EventFlow::Consumed));
+        assert_eq!(s.handle(&up, 3), InputOutcome::Changed);
         assert_eq!(s.selected(), Some(2)); // wrapped from 0 to last
-        assert_eq!(
-            s.handle(&down, 3),
-            SelectOutcome::Moved(EventFlow::Consumed)
-        );
+        assert_eq!(s.handle(&down, 3), InputOutcome::Changed);
         assert_eq!(s.selected(), Some(0)); // wrapped back
         let enter = Event::Key(Key::new(KeyCode::Enter));
-        assert_eq!(s.handle(&enter, 3), SelectOutcome::Confirmed(0));
+        assert_eq!(s.handle(&enter, 3), InputOutcome::Submitted);
         let esc = Event::Key(Key::new(KeyCode::Esc));
-        assert_eq!(s.handle(&esc, 3), SelectOutcome::Cancelled);
+        assert_eq!(s.handle(&esc, 3), InputOutcome::Cancelled);
     }
 
     #[test]
@@ -534,7 +534,7 @@ mod tests {
         let mut state = SelectState::new();
         assert_eq!(
             state.handle_with(&Event::Key(Key::new(KeyCode::Char('j'))), 4, policy),
-            SelectOutcome::Moved(EventFlow::Consumed)
+            InputOutcome::Changed
         );
         assert_eq!(state.selected(), Some(1));
         assert_eq!(
@@ -548,17 +548,17 @@ mod tests {
                 4,
                 policy
             ),
-            SelectOutcome::Moved(EventFlow::Consumed)
+            InputOutcome::Changed
         );
         assert_eq!(state.selected(), Some(0));
         assert_eq!(
             state.handle_with(&Event::Key(Key::new(KeyCode::BackTab)), 4, policy),
-            SelectOutcome::Moved(EventFlow::Consumed)
+            InputOutcome::Changed
         );
         assert_eq!(state.selected(), Some(3));
         assert_eq!(
             state.handle_with(&Event::Key(Key::new(KeyCode::Char('2'))), 4, policy),
-            SelectOutcome::Confirmed(1)
+            InputOutcome::Submitted
         );
         assert_eq!(state.selected(), Some(1));
     }
@@ -569,7 +569,7 @@ mod tests {
         for code in [KeyCode::Char('j'), KeyCode::Tab, KeyCode::Char('1')] {
             assert_eq!(
                 state.handle_with(&Event::Key(Key::new(code)), 3, SelectNavigation::default()),
-                SelectOutcome::Moved(EventFlow::Ignored)
+                InputOutcome::Ignored
             );
         }
         assert_eq!(state.selected(), Some(0));
@@ -586,7 +586,7 @@ mod tests {
         ));
         assert_eq!(
             state.handle_mouse(&click, 10, bounds, 4),
-            SelectOutcome::Confirmed(5)
+            InputOutcome::Submitted
         );
         assert_eq!(state.selected(), Some(5));
 
@@ -597,7 +597,7 @@ mod tests {
         ));
         assert_eq!(
             state.handle_mouse(&outside, 10, bounds, 4),
-            SelectOutcome::Moved(EventFlow::Ignored)
+            InputOutcome::Ignored
         );
     }
 
@@ -607,21 +607,21 @@ mod tests {
         let policy = SelectNavigation::common();
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Char(' '))), 3, policy),
-            MultiSelectOutcome::Toggled(0)
+            InputOutcome::Changed
         );
         assert!(state.contains(0));
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Char('j'))), 3, policy),
-            MultiSelectOutcome::Moved(EventFlow::Consumed)
+            InputOutcome::Changed
         );
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Enter)), 3, policy),
-            MultiSelectOutcome::Toggled(1)
+            InputOutcome::Changed
         );
         assert_eq!(state.selected().collect::<Vec<_>>(), vec![0, 1]);
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Char('1'))), 3, policy),
-            MultiSelectOutcome::Toggled(0)
+            InputOutcome::Changed
         );
         assert_eq!(state.selected().collect::<Vec<_>>(), vec![1]);
     }
@@ -657,13 +657,12 @@ mod tests {
 
     #[test]
     fn select_state_and_list_support_no_selection() {
-        assert_eq!(SelectState::default().selected(), None);
-        let mut state = SelectState::new();
-        state.select(None);
+        assert_eq!(SelectState::default().selected(), Some(0));
+        let mut state = SelectState::unselected();
         assert_eq!(state.selected(), None);
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Enter)), 2),
-            SelectOutcome::Moved(EventFlow::Ignored)
+            InputOutcome::Ignored
         );
 
         let list = SelectList::new(vec![Line::from("a"), Line::from("b")], &state);
@@ -691,7 +690,7 @@ mod tests {
     fn select_highlights_current_row() {
         let items = vec![Line::from("alpha"), Line::from("beta")];
         let mut state = SelectState::new();
-        state.handle(&Event::Key(Key::new(KeyCode::Down)), 2); // select beta
+        let _ = state.handle(&Event::Key(Key::new(KeyCode::Down)), 2); // select beta
         let list = SelectList::new(items, &state);
         let mut buf = buffer(10, 2);
         let theme = Theme::default();
@@ -754,7 +753,7 @@ mod tests {
     fn select_list_selection_uses_theme_slots() {
         let t = rainbow_theme();
         let mut state = SelectState::new();
-        state.handle(&Event::Key(Key::new(KeyCode::Down)), 2); // select row 1
+        let _ = state.handle(&Event::Key(Key::new(KeyCode::Down)), 2); // select row 1
         let list = SelectList::new(vec![Line::from("a"), Line::from("b")], &state);
         let mut buf = buffer(10, 2);
         let area = buf.area;

--- a/src/components/slider.rs
+++ b/src/components/slider.rs
@@ -9,7 +9,7 @@
 use ratatui_core::layout::Rect;
 use ratatui_core::style::{Modifier, Style};
 
-use crate::event::{Event, EventFlow, KeyCode};
+use crate::event::{Event, InputOutcome, KeyCode};
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
@@ -103,15 +103,18 @@ impl SliderState {
     }
 
     /// Apply a key: Right/Up step up, Left/Down step down, PageUp/PageDown jump
-    /// ten steps, Home/End snap to the bounds. Returns whether the key was
-    /// consumed. Modified keys and everything else are ignored so they can bubble.
-    pub fn handle(&mut self, event: &Event) -> EventFlow {
+    /// ten steps, Home/End snap to the bounds. Reports
+    /// [`InputOutcome::Changed`] when the value moves and
+    /// [`InputOutcome::Consumed`] at a bound. Modified keys and everything else
+    /// are ignored so they can bubble.
+    pub fn handle(&mut self, event: &Event) -> InputOutcome {
         let Event::Key(key) = event else {
-            return EventFlow::Ignored;
+            return InputOutcome::Ignored;
         };
         if !key.plain() {
-            return EventFlow::Ignored;
+            return InputOutcome::Ignored;
         }
+        let before = self.value;
         match key.code {
             KeyCode::Right | KeyCode::Up => self.increment(),
             KeyCode::Left | KeyCode::Down => self.decrement(),
@@ -119,9 +122,13 @@ impl SliderState {
             KeyCode::PageDown => self.set_value(self.value - self.step * 10.0),
             KeyCode::Home => self.value = self.min,
             KeyCode::End => self.value = self.max,
-            _ => return EventFlow::Ignored,
+            _ => return InputOutcome::Ignored,
         }
-        EventFlow::Consumed
+        if self.value == before {
+            InputOutcome::Consumed
+        } else {
+            InputOutcome::Changed
+        }
     }
 }
 
@@ -268,19 +275,19 @@ mod tests {
     #[test]
     fn keys_step_page_and_snap() {
         let mut s = SliderState::new(0.0, 100.0, 50.0).step(1.0);
-        assert_eq!(s.handle(&key(KeyCode::Right)), EventFlow::Consumed);
+        assert_eq!(s.handle(&key(KeyCode::Right)), InputOutcome::Changed);
         assert_eq!(s.value(), 51.0);
-        s.handle(&key(KeyCode::Left));
-        s.handle(&key(KeyCode::Left));
+        let _ = s.handle(&key(KeyCode::Left));
+        let _ = s.handle(&key(KeyCode::Left));
         assert_eq!(s.value(), 49.0);
-        s.handle(&key(KeyCode::PageUp));
+        let _ = s.handle(&key(KeyCode::PageUp));
         assert_eq!(s.value(), 59.0); // ten steps
-        s.handle(&key(KeyCode::Home));
+        let _ = s.handle(&key(KeyCode::Home));
         assert_eq!(s.value(), 0.0);
-        s.handle(&key(KeyCode::End));
+        let _ = s.handle(&key(KeyCode::End));
         assert_eq!(s.value(), 100.0);
         // Unrelated keys bubble.
-        assert_eq!(s.handle(&key(KeyCode::Char('x'))), EventFlow::Ignored);
+        assert_eq!(s.handle(&key(KeyCode::Char('x'))), InputOutcome::Ignored);
     }
 
     #[test]

--- a/src/components/tab_select.rs
+++ b/src/components/tab_select.rs
@@ -3,30 +3,19 @@
 //! Where [`Tabs`](crate::Tabs) is navigation chrome (a strip you move a focus
 //! ring across, the host deciding what a switch means), `TabSelect` is an input:
 //! moving the cursor changes the selected value immediately, and Enter/Space
-//! activates it. Its [`handle`](TabSelectState::handle) returns a
-//! [`TabSelectOutcome`] so the host can react to a change versus an activation —
-//! the value-select analog of OpenTUI's `TabSelect`.
+//! activates it. Its [`handle`](TabSelectState::handle) returns the shared
+//! [`InputOutcome`] contract so the host can react to a change versus an
+//! activation — the value-select analog of OpenTUI's `TabSelect`.
 
 use ratatui_core::layout::Rect;
 use ratatui_core::style::{Modifier, Style};
 use ratatui_core::text::Line;
 
 use crate::components::text::line_width;
-use crate::event::{Event, KeyCode};
+use crate::event::{Event, InputOutcome, KeyCode};
 use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
-
-/// The result of feeding a key to a [`TabSelectState`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TabSelectOutcome {
-    /// Navigation moved the selection to this index (its value changed).
-    Changed(usize),
-    /// The current index was activated (Enter/Space) without moving.
-    Activated(usize),
-    /// The key was not handled; let it bubble.
-    Ignored,
-}
 
 /// Host-owned selected-option state for a [`TabSelect`].
 #[derive(Clone, Copy, Debug, Default)]
@@ -35,6 +24,11 @@ pub struct TabSelectState {
 }
 
 impl TabSelectState {
+    /// A state with the first option selected.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// A state with `index` selected.
     pub fn with_selected(index: usize) -> Self {
         Self { selected: index }
@@ -52,32 +46,38 @@ impl TabSelectState {
 
     /// Apply a key over `len` options: Left/BackTab and Right/Tab move the
     /// selection (wrapping), Enter/Space activates the current option. Wrapping
-    /// navigation reports [`TabSelectOutcome::Changed`]; activation reports
-    /// [`TabSelectOutcome::Activated`]; anything else is
-    /// [`TabSelectOutcome::Ignored`].
-    pub fn handle(&mut self, event: &Event, len: usize) -> TabSelectOutcome {
+    /// navigation reports [`InputOutcome::Changed`]; activation reports
+    /// [`InputOutcome::Submitted`]; anything else is [`InputOutcome::Ignored`].
+    pub fn handle(&mut self, event: &Event, len: usize) -> InputOutcome {
         if len == 0 {
-            return TabSelectOutcome::Ignored;
+            return InputOutcome::Ignored;
         }
         let Event::Key(key) = event else {
-            return TabSelectOutcome::Ignored;
+            return InputOutcome::Ignored;
         };
         if !key.plain() {
-            return TabSelectOutcome::Ignored;
+            return InputOutcome::Ignored;
         }
-        // Keep the selection in range even if `len` shrank since it was set.
-        self.selected = self.selected.min(len - 1);
+        let before = self.selected;
         match key.code {
             KeyCode::Left | KeyCode::BackTab => {
+                self.selected = self.selected.min(len - 1);
                 self.selected = self.selected.checked_sub(1).unwrap_or(len - 1);
-                TabSelectOutcome::Changed(self.selected)
             }
             KeyCode::Right | KeyCode::Tab => {
+                self.selected = self.selected.min(len - 1);
                 self.selected = (self.selected + 1) % len;
-                TabSelectOutcome::Changed(self.selected)
             }
-            KeyCode::Enter | KeyCode::Char(' ') => TabSelectOutcome::Activated(self.selected),
-            _ => TabSelectOutcome::Ignored,
+            KeyCode::Enter | KeyCode::Char(' ') => {
+                self.selected = self.selected.min(len - 1);
+                return InputOutcome::Submitted;
+            }
+            _ => return InputOutcome::Ignored,
+        }
+        if self.selected == before {
+            InputOutcome::Consumed
+        } else {
+            InputOutcome::Changed
         }
     }
 }
@@ -89,9 +89,9 @@ impl TabSelectState {
 /// use tuika::prelude::*;
 /// let mut state = TabSelectState::default();
 /// let right = Event::Key(Key::new(KeyCode::Right));
-/// assert_eq!(state.handle(&right, 3), TabSelectOutcome::Changed(1));
+/// assert_eq!(state.handle(&right, 3), InputOutcome::Changed);
 /// let enter = Event::Key(Key::new(KeyCode::Enter));
-/// assert_eq!(state.handle(&enter, 3), TabSelectOutcome::Activated(1));
+/// assert_eq!(state.handle(&enter, 3), InputOutcome::Submitted);
 /// ```
 pub struct TabSelect {
     labels: Vec<Line<'static>>,
@@ -172,44 +172,30 @@ mod tests {
     #[test]
     fn navigation_changes_value_and_wraps() {
         let mut s = TabSelectState::default();
-        assert_eq!(
-            s.handle(&key(KeyCode::Right), 3),
-            TabSelectOutcome::Changed(1)
-        );
-        assert_eq!(
-            s.handle(&key(KeyCode::Right), 3),
-            TabSelectOutcome::Changed(2)
-        );
+        assert_eq!(s.handle(&key(KeyCode::Right), 3), InputOutcome::Changed);
+        assert_eq!(s.selected(), 1);
+        assert_eq!(s.handle(&key(KeyCode::Right), 3), InputOutcome::Changed);
+        assert_eq!(s.selected(), 2);
         // Wraps forward past the end...
-        assert_eq!(
-            s.handle(&key(KeyCode::Right), 3),
-            TabSelectOutcome::Changed(0)
-        );
+        assert_eq!(s.handle(&key(KeyCode::Right), 3), InputOutcome::Changed);
+        assert_eq!(s.selected(), 0);
         // ...and backward past the start.
-        assert_eq!(
-            s.handle(&key(KeyCode::Left), 3),
-            TabSelectOutcome::Changed(2)
-        );
+        assert_eq!(s.handle(&key(KeyCode::Left), 3), InputOutcome::Changed);
+        assert_eq!(s.selected(), 2);
     }
 
     #[test]
     fn enter_and_space_activate_without_moving() {
         let mut s = TabSelectState::with_selected(1);
-        assert_eq!(
-            s.handle(&key(KeyCode::Enter), 3),
-            TabSelectOutcome::Activated(1)
-        );
+        assert_eq!(s.handle(&key(KeyCode::Enter), 3), InputOutcome::Submitted);
         assert_eq!(
             s.handle(&key(KeyCode::Char(' ')), 3),
-            TabSelectOutcome::Activated(1)
+            InputOutcome::Submitted
         );
         assert_eq!(s.selected(), 1);
         // Unhandled keys bubble.
-        assert_eq!(
-            s.handle(&key(KeyCode::Char('x')), 3),
-            TabSelectOutcome::Ignored
-        );
-        assert_eq!(s.handle(&key(KeyCode::Up), 0), TabSelectOutcome::Ignored);
+        assert_eq!(s.handle(&key(KeyCode::Char('x')), 3), InputOutcome::Ignored);
+        assert_eq!(s.handle(&key(KeyCode::Up), 0), InputOutcome::Ignored);
     }
 
     #[test]

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -548,7 +548,7 @@ mod tests {
         // The table shares SelectState with SelectList — arrow keys move the row.
         let (_, rows) = sample();
         let mut state = SelectState::new();
-        state.handle(&Event::Key(Key::new(KeyCode::Down)), rows.len());
+        let _ = state.handle(&Event::Key(Key::new(KeyCode::Down)), rows.len());
         assert_eq!(state.selected(), Some(1));
     }
 

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -4,7 +4,7 @@ use ratatui_core::layout::Rect;
 use ratatui_core::style::{Modifier, Style};
 use ratatui_core::text::Line;
 
-use crate::{Event, EventFlow, KeyCode, RenderCtx, Size, Surface, View};
+use crate::{Event, InputOutcome, KeyCode, RenderCtx, Size, Surface, View};
 
 use super::text::line_width;
 
@@ -15,6 +15,16 @@ pub struct TabsState {
 }
 
 impl TabsState {
+    /// A state with the first tab selected.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A state with `index` selected.
+    pub fn with_selected(index: usize) -> Self {
+        Self { selected: index }
+    }
+
     /// Current selected tab index.
     pub fn selected(&self) -> usize {
         self.selected
@@ -26,26 +36,32 @@ impl TabsState {
     }
 
     /// Handle left/right and forward/backward tab navigation.
-    pub fn handle(&mut self, event: &Event, len: usize) -> EventFlow {
+    pub fn handle(&mut self, event: &Event, len: usize) -> InputOutcome {
         if len == 0 {
-            return EventFlow::Ignored;
+            return InputOutcome::Ignored;
         }
         let Event::Key(key) = event else {
-            return EventFlow::Ignored;
+            return InputOutcome::Ignored;
         };
         if !key.plain() {
-            return EventFlow::Ignored;
+            return InputOutcome::Ignored;
         }
+        let before = self.selected;
         match key.code {
             KeyCode::Left | KeyCode::BackTab => {
+                self.selected = self.selected.min(len - 1);
                 self.selected = self.selected.checked_sub(1).unwrap_or(len - 1);
-                EventFlow::Consumed
             }
             KeyCode::Right | KeyCode::Tab => {
+                self.selected = self.selected.min(len - 1);
                 self.selected = (self.selected + 1) % len;
-                EventFlow::Consumed
             }
-            _ => EventFlow::Ignored,
+            _ => return InputOutcome::Ignored,
+        }
+        if self.selected == before {
+            InputOutcome::Consumed
+        } else {
+            InputOutcome::Changed
         }
     }
 }
@@ -114,7 +130,7 @@ impl View for Tabs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::{Event, EventFlow, Key, KeyCode};
+    use crate::event::{Event, InputOutcome, Key, KeyCode};
     use crate::style::Theme;
     use crate::tests::support::row;
     use ratatui_core::text::Line;
@@ -124,7 +140,7 @@ mod tests {
         let mut state = TabsState::default();
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Left)), 3),
-            EventFlow::Consumed
+            InputOutcome::Changed
         );
         assert_eq!(state.selected(), 2);
 

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -35,6 +35,8 @@ pub struct TextInputState {
     /// Cursor column (char index within `lines[row]`).
     col: usize,
     mode: TextInputMode,
+    /// Monotonic marker for text mutations, used to classify handled no-ops.
+    revision: u64,
 }
 
 /// Controls which Enter chord submits a text input.
@@ -219,9 +221,9 @@ impl TextSpan {
     }
 }
 
-/// Result of applying an Enter chord to a text input.
+/// Internal result of applying an Enter chord to a text input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TextInputEvent {
+enum TextInputEvent {
     /// The chord inserted a newline; text changed.
     Changed,
     /// The chord requested submission.
@@ -242,6 +244,7 @@ impl TextInputState {
             row: 0,
             col: 0,
             mode: TextInputMode::default(),
+            revision: 0,
         }
     }
 
@@ -256,7 +259,14 @@ impl TextInputState {
     }
 
     /// Apply an Enter chord according to the configured mode.
-    pub fn handle_enter(&mut self, shift: bool) -> TextInputEvent {
+    pub fn handle_enter(&mut self, shift: bool) -> crate::InputOutcome {
+        match self.enter_event(shift) {
+            TextInputEvent::Changed => crate::InputOutcome::Changed,
+            TextInputEvent::Submit => crate::InputOutcome::Submitted,
+        }
+    }
+
+    fn enter_event(&mut self, shift: bool) -> TextInputEvent {
         let submit = match self.mode {
             TextInputMode::SubmitOnEnter => !shift,
             TextInputMode::SubmitOnShiftEnter => shift,
@@ -298,19 +308,27 @@ impl TextInputState {
 
     /// Replace all text; cursor moves to the end.
     pub fn set_text(&mut self, text: &str) {
-        self.lines = text.split('\n').map(str::to_string).collect();
-        if self.lines.is_empty() {
-            self.lines.push(String::new());
+        let mut lines: Vec<String> = text.split('\n').map(str::to_string).collect();
+        if lines.is_empty() {
+            lines.push(String::new());
         }
+        if self.lines != lines {
+            self.revision = self.revision.wrapping_add(1);
+        }
+        self.lines = lines;
         self.row = self.lines.len() - 1;
         self.col = self.lines[self.row].chars().count();
     }
 
     /// Clear to a single empty line. Preserves [`TextInputMode`].
     pub fn clear(&mut self) {
-        let mode = self.mode;
-        *self = Self::new();
-        self.mode = mode;
+        if !self.is_empty() {
+            self.revision = self.revision.wrapping_add(1);
+        }
+        self.lines.clear();
+        self.lines.push(String::new());
+        self.row = 0;
+        self.col = 0;
     }
 
     /// Move the cursor to `(row, col)`, clamped into the buffer and to the
@@ -326,7 +344,11 @@ impl TextInputState {
     }
 
     fn set_row(&mut self, row: usize, chars: Vec<char>) {
-        self.lines[row] = chars.into_iter().collect();
+        let line: String = chars.into_iter().collect();
+        if self.lines[row] != line {
+            self.lines[row] = line;
+            self.revision = self.revision.wrapping_add(1);
+        }
     }
 
     /// Insert one char at the cursor.
@@ -357,6 +379,7 @@ impl TextInputState {
         let head: String = chars[..at].iter().collect();
         self.lines[self.row] = head;
         self.lines.insert(self.row + 1, tail);
+        self.revision = self.revision.wrapping_add(1);
         self.row += 1;
         self.col = 0;
     }
@@ -374,6 +397,7 @@ impl TextInputState {
             self.row -= 1;
             self.col = self.lines[self.row].chars().count();
             self.lines[self.row].push_str(&cur);
+            self.revision = self.revision.wrapping_add(1);
         }
     }
 
@@ -387,6 +411,7 @@ impl TextInputState {
         } else if self.row + 1 < self.lines.len() {
             let next = self.lines.remove(self.row + 1);
             self.lines[self.row].push_str(&next);
+            self.revision = self.revision.wrapping_add(1);
         }
     }
 
@@ -542,9 +567,12 @@ impl TextInputState {
 
     /// Apply an input event according to the configured [`TextInputMode`].
     ///
-    /// Returns [`None`] when the event is ignored; [`Some`] with
-    /// [`TextInputEvent::Changed`] when the buffer or cursor changed, or
-    /// [`TextInputEvent::Submit`] when the Enter chord requested submission
+    /// Returns [`InputOutcome::Ignored`](crate::InputOutcome::Ignored) when the
+    /// event is ignored, [`InputOutcome::Consumed`](crate::InputOutcome::Consumed)
+    /// when a recognized edit or navigation is already at its bound,
+    /// [`InputOutcome::Changed`](crate::InputOutcome::Changed) when text or the
+    /// cursor changes, or
+    /// [`InputOutcome::Submitted`](crate::InputOutcome::Submitted) when the Enter chord requested submission
     /// (the buffer is left unchanged so the host can read [`Self::text`] and
     /// clear).
     ///
@@ -559,7 +587,19 @@ impl TextInputState {
     /// `C-f`/`C-b` char move, `C-p`/`C-n` line move, `C-h`/`C-d` delete,
     /// `C-j` newline, `C-k`/`C-u` kill to line end/start, `C-w`/`M-Backspace`
     /// delete word back, `M-f`/`M-b` word move, `M-d` delete word forward.
-    pub fn handle(&mut self, event: &Event) -> Option<TextInputEvent> {
+    pub fn handle(&mut self, event: &Event) -> crate::InputOutcome {
+        let before = (self.row, self.col, self.revision);
+        match self.handle_event(event) {
+            Some(TextInputEvent::Changed) if (self.row, self.col, self.revision) == before => {
+                crate::InputOutcome::Consumed
+            }
+            Some(TextInputEvent::Changed) => crate::InputOutcome::Changed,
+            Some(TextInputEvent::Submit) => crate::InputOutcome::Submitted,
+            None => crate::InputOutcome::Ignored,
+        }
+    }
+
+    fn handle_event(&mut self, event: &Event) -> Option<TextInputEvent> {
         match event {
             Event::Key(k) if k.ctrl && !k.alt => match k.code {
                 KeyCode::Char('a') => {
@@ -638,7 +678,7 @@ impl TextInputState {
                     self.insert_char(c);
                     Some(TextInputEvent::Changed)
                 }
-                KeyCode::Enter => Some(self.handle_enter(k.shift)),
+                KeyCode::Enter => Some(self.enter_event(k.shift)),
                 KeyCode::Backspace => {
                     self.backspace();
                     Some(TextInputEvent::Changed)
@@ -1030,22 +1070,27 @@ impl SingleLineInputState {
     }
 
     /// Handle editing input. Enter and Ctrl+J always submit.
-    pub fn handle(&mut self, event: &Event) -> Option<TextInputEvent> {
+    pub fn handle(&mut self, event: &Event) -> crate::InputOutcome {
         match event {
             Event::Paste(text) => {
+                let before = (self.inner.row, self.inner.col, self.inner.revision);
                 self.insert_str(text);
-                Some(TextInputEvent::Changed)
+                if (self.inner.row, self.inner.col, self.inner.revision) == before {
+                    crate::InputOutcome::Consumed
+                } else {
+                    crate::InputOutcome::Changed
+                }
             }
             Event::Key(key)
                 if key.plain()
                     && matches!(key.code, KeyCode::Enter | KeyCode::Char('\n' | '\r')) =>
             {
-                Some(TextInputEvent::Submit)
+                crate::InputOutcome::Submitted
             }
             Event::Key(key)
                 if key.ctrl && !key.alt && !key.shift && key.code == KeyCode::Char('j') =>
             {
-                Some(TextInputEvent::Submit)
+                crate::InputOutcome::Submitted
             }
             _ => self.inner.handle(event),
         }
@@ -1219,7 +1264,7 @@ mod tests {
         assert_eq!(state.text(), "alpha beta gamma delta");
         assert_eq!(
             state.handle(&Event::Paste(" one\r\ntwo\nthree".into())),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         );
         assert_eq!(state.text(), "alpha beta gamma delta one two three");
     }
@@ -1246,7 +1291,7 @@ mod tests {
                 shift: false,
             }),
         ] {
-            assert_eq!(state.handle(&event), Some(TextInputEvent::Submit));
+            assert_eq!(state.handle(&event), crate::InputOutcome::Submitted);
             assert_eq!(state.text(), "query");
         }
     }
@@ -1254,7 +1299,7 @@ mod tests {
     fn press(state: &mut TextInputState, code: KeyCode) -> bool {
         matches!(
             state.handle(&Event::Key(Key::new(code))),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         )
     }
 
@@ -1266,7 +1311,7 @@ mod tests {
                 alt: false,
                 shift: true,
             })),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         )
     }
 
@@ -1278,7 +1323,7 @@ mod tests {
                 alt: false,
                 shift: false,
             })),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         )
     }
 
@@ -1290,7 +1335,7 @@ mod tests {
                 alt: true,
                 shift: false,
             })),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         )
     }
 
@@ -1376,7 +1421,7 @@ mod tests {
         let mut state = TextInputState::new();
         assert_eq!(
             state.handle(&Event::Paste("one\ntwo".to_string())),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         );
         assert_eq!(state.text(), "one\ntwo");
         assert_eq!(state.line_count(), 2);
@@ -1647,8 +1692,8 @@ mod tests {
     fn submit_on_enter_mode_uses_shift_enter_for_newline() {
         let mut state = TextInputState::new();
         assert_eq!(state.mode(), TextInputMode::SubmitOnEnter);
-        assert_eq!(state.handle_enter(false), TextInputEvent::Submit);
-        assert_eq!(state.handle_enter(true), TextInputEvent::Changed);
+        assert_eq!(state.handle_enter(false), crate::InputOutcome::Submitted);
+        assert_eq!(state.handle_enter(true), crate::InputOutcome::Changed);
         assert_eq!(state.text(), "\n");
     }
 
@@ -1656,8 +1701,8 @@ mod tests {
     fn submit_on_shift_enter_mode_reverses_enter_chords() {
         let mut state = TextInputState::new();
         state.set_mode(TextInputMode::SubmitOnShiftEnter);
-        assert_eq!(state.handle_enter(false), TextInputEvent::Changed);
-        assert_eq!(state.handle_enter(true), TextInputEvent::Submit);
+        assert_eq!(state.handle_enter(false), crate::InputOutcome::Changed);
+        assert_eq!(state.handle_enter(true), crate::InputOutcome::Submitted);
         assert_eq!(state.text(), "\n");
     }
 
@@ -1678,14 +1723,14 @@ mod tests {
         });
         assert_eq!(
             state.handle(&shift_enter),
-            Some(TextInputEvent::Changed),
+            crate::InputOutcome::Changed,
             "Shift+Enter must insert a newline under SubmitOnEnter"
         );
         assert_eq!(state.text(), "one\n");
         type_str(&mut state, "two");
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Enter))),
-            Some(TextInputEvent::Submit),
+            crate::InputOutcome::Submitted,
             "plain Enter must submit under SubmitOnEnter, not insert another newline"
         );
         assert_eq!(
@@ -1702,7 +1747,7 @@ mod tests {
         type_str(&mut state, "one");
         assert_eq!(
             state.handle(&Event::Key(Key::new(KeyCode::Enter))),
-            Some(TextInputEvent::Changed)
+            crate::InputOutcome::Changed
         );
         assert_eq!(state.text(), "one\n");
         type_str(&mut state, "two");
@@ -1712,7 +1757,7 @@ mod tests {
             alt: false,
             shift: true,
         });
-        assert_eq!(state.handle(&shift_enter), Some(TextInputEvent::Submit));
+        assert_eq!(state.handle(&shift_enter), crate::InputOutcome::Submitted);
         assert_eq!(state.text(), "one\ntwo");
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -173,6 +173,49 @@ pub enum EventFlow {
     Ignored,
 }
 
+/// Result of routing an input event through host-owned component state.
+///
+/// The outcome describes both propagation and lifecycle without duplicating
+/// values already available from the state (`selected()`, `value()`, `text()`,
+/// and so on). Every variant except [`Ignored`](Self::Ignored) consumes the
+/// event.
+#[must_use = "input outcomes determine whether an event keeps propagating"]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum InputOutcome {
+    /// The state did not recognize the event; keep routing it.
+    #[default]
+    Ignored,
+    /// The event was recognized, but persistent state was already at its bound.
+    Consumed,
+    /// Persistent component state changed.
+    Changed,
+    /// The current value was activated or requested for submission.
+    Submitted,
+    /// The interaction requested cancellation or dismissal.
+    Cancelled,
+}
+
+impl InputOutcome {
+    /// Convert this richer result to the propagation-only [`EventFlow`].
+    pub fn flow(self) -> EventFlow {
+        if self == Self::Ignored {
+            EventFlow::Ignored
+        } else {
+            EventFlow::Consumed
+        }
+    }
+
+    /// Whether the event was recognized and should stop propagating.
+    pub fn consumed(self) -> bool {
+        self.flow().consumed()
+    }
+
+    /// Whether persistent component state changed.
+    pub fn changed(self) -> bool {
+        self == Self::Changed
+    }
+}
+
 impl EventFlow {
     /// True for [`EventFlow::Consumed`].
     pub fn consumed(self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub mod ui {
 // through its module (`themes::by_name`, `probe::RectProbe`, `term::clipboard`)
 // is deliberately not flattened: a shallow path is worth something only if the
 // name earns it.
-pub use event::{Event, EventFlow, Key, KeyCode, Mouse, MouseButton, MouseKind};
+pub use event::{Event, EventFlow, InputOutcome, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use geometry::{Padding, Size};
 pub use host::{
     TerminalSession, paint, paint_scene, paint_with_context, paint_with_sheet, translate_event,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,9 +39,9 @@ pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.
 pub use crate::view;
 pub use crate::{
-    Align, Backdrop, Dimension, Direction, Element, Event, EventFlow, Justify, Key, KeyCode,
-    LayoutStyle, Mouse, MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx, Runner,
-    RunnerConfig, Scene, SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback,
+    Align, Backdrop, Dimension, Direction, Element, Event, EventFlow, InputOutcome, Justify, Key,
+    KeyCode, LayoutStyle, Mouse, MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx,
+    Runner, RunnerConfig, Scene, SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback,
     SemanticRole, Signal, Size, StyleSheet, Surface, TargetAlign, TargetPlacement, TargetSide,
     TerminalSession, Theme, UpdateResult, View, element, paint, paint_scene, paint_with_context,
     paint_with_sheet, translate_event,

--- a/src/tests/snapshots.rs
+++ b/src/tests/snapshots.rs
@@ -121,7 +121,7 @@ fn snapshot_spinner_and_progress_row() {
 fn snapshot_select_list() {
     let mut state = SelectState::new();
     // Move to the middle entry deterministically.
-    state.handle(
+    let _ = state.handle(
         &crate::event::Event::Key(crate::event::Key::new(crate::event::KeyCode::Down)),
         3,
     );

--- a/tests/input_outcome.rs
+++ b/tests/input_outcome.rs
@@ -1,0 +1,123 @@
+//! One interaction contract across host-owned component states.
+
+use tuika::prelude::*;
+
+fn key(code: KeyCode) -> Event {
+    Event::Key(Key::new(code))
+}
+
+#[test]
+fn constructors_and_defaults_start_from_the_same_state() {
+    assert_eq!(
+        SelectState::default().selected(),
+        SelectState::new().selected()
+    );
+    assert_eq!(SelectState::default().selected(), Some(0));
+    assert_eq!(SelectState::unselected().selected(), None);
+
+    assert_eq!(
+        ScrollState::default().is_stuck_to_bottom(),
+        ScrollState::new().is_stuck_to_bottom()
+    );
+    assert!(ScrollState::default().is_stuck_to_bottom());
+
+    assert_eq!(
+        MultiSelectState::default().cursor().selected(),
+        MultiSelectState::new().cursor().selected()
+    );
+
+    assert_eq!(
+        TabSelectState::default().selected(),
+        TabSelectState::new().selected()
+    );
+}
+
+#[test]
+fn interactive_components_share_one_outcome_vocabulary() {
+    let mut select = SelectState::default();
+    assert_eq!(select.handle(&key(KeyCode::Down), 3), InputOutcome::Changed);
+    assert_eq!(
+        select.handle(&key(KeyCode::Enter), 3),
+        InputOutcome::Submitted
+    );
+    assert_eq!(select.selected(), Some(1));
+
+    let mut tabs = TabsState::default();
+    assert_eq!(tabs.handle(&key(KeyCode::Right), 3), InputOutcome::Changed);
+    let mut single_tab = TabsState::default();
+    assert_eq!(
+        single_tab.handle(&key(KeyCode::Right), 1),
+        InputOutcome::Consumed
+    );
+
+    let mut tab_select = TabSelectState::default();
+    assert_eq!(
+        tab_select.handle(&key(KeyCode::Enter), 3),
+        InputOutcome::Submitted
+    );
+
+    let mut slider = SliderState::default();
+    assert_eq!(slider.handle(&key(KeyCode::Right)), InputOutcome::Changed);
+    slider.set_value(slider.max());
+    assert_eq!(slider.handle(&key(KeyCode::Right)), InputOutcome::Consumed);
+
+    let mut form = FormState::default();
+    assert_eq!(form.handle(&key(KeyCode::Tab), 2), InputOutcome::Changed);
+    assert_eq!(
+        form.handle(&key(KeyCode::Enter), 2),
+        InputOutcome::Submitted
+    );
+    form.focus(usize::MAX);
+    assert_eq!(form.handle(&key(KeyCode::Tab), 2), InputOutcome::Changed);
+    assert_eq!(form.focused(), 0);
+
+    select.select(Some(usize::MAX));
+    assert_eq!(select.handle(&key(KeyCode::Down), 3), InputOutcome::Changed);
+    assert_eq!(select.selected(), Some(0));
+
+    let mut scroll = ScrollState::default();
+    scroll.clamp(100, 10);
+    assert_eq!(
+        scroll.handle(&key(KeyCode::PageUp), 100, 10),
+        InputOutcome::Changed
+    );
+
+    let mut input = TextInputState::default();
+    assert_eq!(
+        input.handle(&key(KeyCode::Char('a'))),
+        InputOutcome::Changed
+    );
+    assert_eq!(input.handle(&key(KeyCode::Enter)), InputOutcome::Submitted);
+    let mut empty_input = TextInputState::default();
+    assert_eq!(
+        empty_input.handle(&key(KeyCode::Left)),
+        InputOutcome::Consumed
+    );
+    assert_eq!(
+        empty_input.handle(&Event::Paste(String::new())),
+        InputOutcome::Consumed
+    );
+    assert_eq!(
+        empty_input.handle(&Event::Resize {
+            width: 80,
+            height: 24,
+        }),
+        InputOutcome::Ignored
+    );
+}
+
+#[test]
+fn outcomes_map_uniformly_to_event_propagation() {
+    let root_path: tuika::InputOutcome = InputOutcome::Changed;
+    assert_eq!(root_path, InputOutcome::Changed);
+    assert_eq!(InputOutcome::Ignored.flow(), EventFlow::Ignored);
+    for outcome in [
+        InputOutcome::Consumed,
+        InputOutcome::Changed,
+        InputOutcome::Submitted,
+        InputOutcome::Cancelled,
+    ] {
+        assert_eq!(outcome.flow(), EventFlow::Consumed);
+        assert!(outcome.consumed());
+    }
+}


### PR DESCRIPTION
## What changed

Interactive component states now share one root/prelude `InputOutcome`: ignored, consumed-at-bound, changed, submitted, or cancelled. Submitted values remain in host-owned state instead of being duplicated in component-specific result enums.

`SelectState`, `MultiSelectState`, and `ScrollState` now make `Default` identical to `new()`. `SelectState::unselected()` is the explicit cursorless start. Text input distinguishes actual edits/cursor moves from recognized boundary no-ops.

## Why

The library exposed incompatible handler contracts across selection, forms, tabs, sliders, scrolling, and text input, while several derived defaults silently disagreed with their constructors. Generic host routing therefore required component-specific adapters and could start in different states depending on construction style.

## Before / After

Before: handlers returned `EventFlow`, `Option<TextInputEvent>`, or one of four component-specific outcome enums; `default()` could disagree with `new()`.

After: every interactive component handler uses `InputOutcome`, `.flow()` provides propagation-only compatibility, and zero-argument constructors agree with `Default`. The `select` example was exercised in a real terminal: Down changed the highlighted row, Enter submitted Blueberry from state, and exit restored terminal state.

## Risk

- Medium
- This intentionally breaks handler return types and removes the old public outcome enums. The changelog includes direct migration guidance. Default selection and scroll-follow behavior also change where callers previously relied on the derived defaults.
- Classifying scroll boundary no-ops adds four instructions per page action in the CI instruction-count benchmark: 234,776 to 252,164 instructions for paging 100,000 rows (+7.406%). The path remains O(1), render/window costs are unchanged, and the exact intentional constant is recorded in the baseline without loosening its 2% tolerance.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo +1.88 check -p tuika --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --strict --check-links`
- `cargo run --example demo -- check`
- Interactive `cargo run --example select` smoke

## Knowledge

Updated the rendering architecture state contract and knowledge log. README, component guide, rustdoc, examples, and changelog carry the public behavior and migration.

## Security

Reviewed TM-ESC, TM-STATE, TM-PARSE, TM-CLIP, and TM-DEP. The change adds no escape emission, terminal lifecycle path, parser, dependency, filesystem/network/process access, or rendering write. Input handling performs bounded state transitions only; externally supplied selection/focus indices are normalized without unchecked overflow. Full degenerate rendering and PTY suites remain green.

## Follow-ups

No follow-ups.