### PR TITLE
feat(dock): add responsive panel lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ block-HTML seam.
   select, and table now share those primitives. `SelectList::windowed` and
   `Table::windowed` accept only the visible records while preserving absolute
   selection and full-collection scrollbar geometry.
+- `DockState`, `DockSpec`, and `DockLayout` provide a host-owned responsive
+  lifecycle for one auxiliary panel: wide panels dock, narrow passive panels
+  hide, and focused narrow panels resolve as overlay drawers without introducing
+  a retained panel manager.
 - Target-relative overlays: `TargetPlacement` selects above/below/left/right,
   cross-axis alignment, gap, and optional edge-aware flipping;
   `OverlaySpec::resolve_target` resolves it directly and

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
   is cheap because `ratatui` diffs the resulting cell buffer, so there is no
   reconciler.
 - **State** that must survive across frames — scroll offset, selection index,
-  focus — lives in host-persisted `*State` structs (the `StatefulWidget`
-  idiom), not in the view tree.
+  focus, dock visibility — lives in host-persisted `*State` structs (the
+  `StatefulWidget` idiom), not in the view tree.
 - **Live data** (`Live` / `LiveView`) is shared application state read at render
   time. Updates request a redraw from the runner; Tuika does not spawn data
   sources or reconcile a retained widget tree.
@@ -551,6 +551,21 @@ frame's mutable buffer.
 `Responsive` chooses complete compact/wide view trees from the current width;
 this supports row-to-column reflow and intentionally omitted secondary
 content. `Constrained` supplies min/max intrinsic measurements to flex layout.
+
+`DockState` is the small host-owned lifecycle for an auxiliary panel. A visible
+panel docks beside the main view on wide frames; below its breakpoint it stays
+passive and hidden until focused, then resolves as an overlay drawer. It returns
+rectangles only—the host keeps the panel view, focus id, keymap, and state.
+
+```rust
+use tuika::prelude::*;
+
+let mut activity = DockState::new();
+activity.show_passive();
+let layout = activity.resolve(Rect::new(0, 0, 120, 30), DockSpec::right(90, 40));
+// Paint the main view into `layout.main` and, when present, the panel into
+// `layout.panel`.
+```
 
 `Live<T>` is shared application data with a narrow read/update API. `LiveView`
 derives a fresh view from its current value each frame. Connect it to

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -22,6 +22,14 @@
 
 ## 2026-07-31
 
+- **Responsive auxiliary panels stay host-owned**
+
+- A small dock state now resolves one panel to wide dock, narrow focused
+  drawer, or hidden passive geometry. It owns no view tree or application data,
+  so hosts can reuse the lifecycle without adopting a retained window manager.
+- Focused panels are always assigned a visible rectangle; passive panels may
+  remain logically open through narrow resizes and reappear when space returns.
+
 - **Overlay placement can follow laid-out targets**
 
 - Popovers, menus, and tooltips can resolve on any side of a probed root view,

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`Element`/`ScopedElement`/`RenderCtx`, owned or scoped scene composition, layout, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`Element`/`ScopedElement`/`RenderCtx`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -32,6 +32,11 @@ rather than beside it.
   For state types with a zero-argument constructor, `Default` and `new()` are
   identical; a meaningful alternate start is explicit (for example,
   `SelectState::unselected()`).
+- **Docking is state plus resolved geometry, not a retained panel manager.** A
+  host-owned dock state tracks only visibility and focus; the current frame
+  resolves it to a wide dock, a narrow focused drawer, or a hidden passive
+  panel. Views, focus ids, keymaps, scrolling, and domain state remain with the
+  host.
 - **Layout is a flexbox subset** over a direction-agnostic axis, so rows and
   columns share one solver: `Dimension` (`Auto`/`Fixed`/`Percent`/`Flex`) plus
   `Align`, `Justify`, and `Direction`.

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -1,0 +1,301 @@
+//! Responsive lifecycle and geometry for a single auxiliary panel.
+//!
+//! [`DockState`] keeps the host-owned visibility/focus state; [`DockSpec`]
+//! resolves that state to a wide dock, a narrow focused drawer, or a hidden
+//! passive panel. The panel's content, focus id, input routing, and chrome stay
+//! with the host.
+
+use ratatui_core::layout::Rect;
+
+/// Screen edge that owns a dock or drawer.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DockEdge {
+    /// Place the panel at the left edge.
+    Left,
+    /// Place the panel at the right edge.
+    #[default]
+    Right,
+}
+
+/// Responsive geometry policy for one dockable panel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DockSpec {
+    edge: DockEdge,
+    breakpoint: u16,
+    panel_width: u16,
+}
+
+impl DockSpec {
+    /// Put a panel on the right, docking at `breakpoint` columns and using at
+    /// most `panel_width` columns.
+    pub const fn right(breakpoint: u16, panel_width: u16) -> Self {
+        Self {
+            edge: DockEdge::Right,
+            breakpoint,
+            panel_width,
+        }
+    }
+
+    /// Put a panel on the left, docking at `breakpoint` columns and using at
+    /// most `panel_width` columns.
+    pub const fn left(breakpoint: u16, panel_width: u16) -> Self {
+        Self {
+            edge: DockEdge::Left,
+            breakpoint,
+            panel_width,
+        }
+    }
+
+    /// The screen edge that owns the panel.
+    pub const fn edge(self) -> DockEdge {
+        self.edge
+    }
+
+    /// Width at which a visible panel becomes docked instead of a drawer.
+    pub const fn breakpoint(self) -> u16 {
+        self.breakpoint
+    }
+
+    /// Preferred panel width. Resolution clamps it to at least one column and
+    /// at most the available frame width.
+    pub const fn panel_width(self) -> u16 {
+        self.panel_width
+    }
+}
+
+/// How the panel is placed in the current frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DockPlacement {
+    /// The panel is not painted. This includes a passive panel below its dock
+    /// breakpoint; its state remains visible so it can reappear after resize.
+    Hidden,
+    /// The panel consumes space beside the main content.
+    Docked,
+    /// The focused panel overlays the main content without shrinking it.
+    Drawer,
+}
+
+/// Resolved rectangles for a responsive dock frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DockLayout {
+    /// Area left for the host's main content.
+    pub main: Rect,
+    /// Panel area when docked or drawn; `None` when hidden.
+    pub panel: Option<Rect>,
+    /// Placement selected for this frame.
+    pub placement: DockPlacement,
+}
+
+/// Host-owned visibility and focus lifecycle for one dockable panel.
+///
+/// This is intentionally not a panel manager: it does not own views, focus
+/// identifiers, key bindings, or application state. A host can pair it with a
+/// [`FocusRegistry`](crate::focus::FocusRegistry) and any panel content.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DockState {
+    visible: bool,
+    focused: bool,
+}
+
+impl DockState {
+    /// A hidden, unfocused panel.
+    pub const fn new() -> Self {
+        Self {
+            visible: false,
+            focused: false,
+        }
+    }
+
+    /// Whether the panel is logically open. A passive panel may still resolve
+    /// to [`DockPlacement::Hidden`] below its breakpoint.
+    pub const fn is_visible(self) -> bool {
+        self.visible
+    }
+
+    /// Whether the panel should own input focus.
+    pub const fn is_focused(self) -> bool {
+        self.focused
+    }
+
+    /// Open the panel without taking focus from the main content.
+    pub fn show_passive(&mut self) {
+        self.visible = true;
+        self.focused = false;
+    }
+
+    /// Open and focus the panel.
+    pub fn focus(&mut self) {
+        self.visible = true;
+        self.focused = true;
+    }
+
+    /// Keep the panel open but return focus to the main content.
+    pub fn blur(&mut self) {
+        self.focused = false;
+    }
+
+    /// Close the panel and release its focus.
+    pub fn hide(&mut self) {
+        self.visible = false;
+        self.focused = false;
+    }
+
+    /// Focus a hidden or passive panel; close a focused panel.
+    ///
+    /// This supports the common single-shortcut lifecycle: background work can
+    /// open passively, the first shortcut focuses it, and the next closes it.
+    pub fn toggle(&mut self) {
+        if self.visible && self.focused {
+            self.hide();
+        } else {
+            self.focus();
+        }
+    }
+
+    /// Resolve the panel for `area` under `spec`.
+    ///
+    /// Wide visible panels dock regardless of focus. Below the breakpoint, a
+    /// passive panel stays logically open but is not painted; focusing it turns
+    /// it into an overlay drawer, so input can never be captured by an invisible
+    /// panel.
+    pub fn resolve(self, area: Rect, spec: DockSpec) -> DockLayout {
+        if !self.visible || area.width == 0 || area.height == 0 {
+            return hidden(area);
+        }
+        let panel_width = spec.panel_width.clamp(1, area.width);
+        if area.width >= spec.breakpoint {
+            let (main, panel) = split(area, panel_width, spec.edge);
+            return DockLayout {
+                main,
+                panel: Some(panel),
+                placement: DockPlacement::Docked,
+            };
+        }
+        if !self.focused {
+            return hidden(area);
+        }
+        let panel = match spec.edge {
+            DockEdge::Left => Rect {
+                width: panel_width,
+                ..area
+            },
+            DockEdge::Right => Rect {
+                x: area.right().saturating_sub(panel_width),
+                width: panel_width,
+                ..area
+            },
+        };
+        DockLayout {
+            main: area,
+            panel: Some(panel),
+            placement: DockPlacement::Drawer,
+        }
+    }
+}
+
+fn hidden(area: Rect) -> DockLayout {
+    DockLayout {
+        main: area,
+        panel: None,
+        placement: DockPlacement::Hidden,
+    }
+}
+
+fn split(area: Rect, panel_width: u16, edge: DockEdge) -> (Rect, Rect) {
+    let main_width = area.width.saturating_sub(panel_width);
+    match edge {
+        DockEdge::Left => (
+            Rect {
+                x: area.x.saturating_add(panel_width),
+                width: main_width,
+                ..area
+            },
+            Rect {
+                width: panel_width,
+                ..area
+            },
+        ),
+        DockEdge::Right => (
+            Rect {
+                width: main_width,
+                ..area
+            },
+            Rect {
+                x: area.x.saturating_add(main_width),
+                width: panel_width,
+                ..area
+            },
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui_core::layout::Rect;
+
+    #[test]
+    fn passive_dock_focuses_then_closes() {
+        let mut state = DockState::default();
+        state.show_passive();
+        assert!(state.is_visible());
+        assert!(!state.is_focused());
+
+        state.toggle();
+        assert!(state.is_visible());
+        assert!(state.is_focused());
+
+        state.toggle();
+        assert!(!state.is_visible());
+        assert!(!state.is_focused());
+    }
+
+    #[test]
+    fn wide_docks_narrow_passive_hides_and_narrow_focus_draws() {
+        let spec = DockSpec::right(90, 40);
+        let wide = Rect::new(0, 0, 120, 24);
+        let narrow = Rect::new(0, 0, 70, 24);
+        let mut state = DockState::default();
+        state.show_passive();
+
+        let docked = state.resolve(wide, spec);
+        assert_eq!(docked.placement, DockPlacement::Docked);
+        assert_eq!(docked.main, Rect::new(0, 0, 80, 24));
+        assert_eq!(docked.panel, Some(Rect::new(80, 0, 40, 24)));
+
+        let hidden = state.resolve(narrow, spec);
+        assert_eq!(hidden.placement, DockPlacement::Hidden);
+        assert_eq!(hidden.main, narrow);
+        assert_eq!(hidden.panel, None);
+
+        state.focus();
+        let drawer = state.resolve(narrow, spec);
+        assert_eq!(drawer.placement, DockPlacement::Drawer);
+        assert_eq!(drawer.main, narrow);
+        assert_eq!(drawer.panel, Some(Rect::new(30, 0, 40, 24)));
+    }
+
+    #[test]
+    fn left_drawer_clamps_to_tiny_viewports() {
+        let spec = DockSpec::left(90, 40);
+        let mut state = DockState::default();
+        state.focus();
+
+        let area = Rect::new(3, 5, 18, 8);
+        let layout = state.resolve(area, spec);
+        assert_eq!(layout.placement, DockPlacement::Drawer);
+        assert_eq!(layout.main, area);
+        assert_eq!(layout.panel, Some(area));
+    }
+
+    #[test]
+    fn focused_panel_with_zero_preferred_width_stays_visible() {
+        let mut state = DockState::default();
+        state.focus();
+
+        let area = Rect::new(0, 0, 20, 8);
+        let layout = state.resolve(area, DockSpec::right(90, 0));
+        assert_eq!(layout.placement, DockPlacement::Drawer);
+        assert_eq!(layout.panel, Some(Rect::new(19, 0, 1, 8)));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@
 
 pub mod anim;
 pub mod components;
+pub mod dock;
 pub mod event;
 #[macro_use]
 mod macros;
@@ -121,6 +122,7 @@ pub mod ui {
 // through its module (`themes::by_name`, `probe::RectProbe`, `term::clipboard`)
 // is deliberately not flattened: a shallow path is worth something only if the
 // name earns it.
+pub use dock::{DockEdge, DockLayout, DockPlacement, DockSpec, DockState};
 pub use event::{Event, EventFlow, InputOutcome, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use geometry::{Padding, Size};
 pub use host::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,12 +39,13 @@ pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.
 pub use crate::view;
 pub use crate::{
-    Align, Backdrop, Dimension, Direction, Element, Event, EventFlow, InputOutcome, Justify, Key,
-    KeyCode, LayoutStyle, Mouse, MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx,
-    Runner, RunnerConfig, Scene, SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback,
-    SemanticRole, Signal, Size, StyleSheet, Surface, TargetAlign, TargetPlacement, TargetSide,
-    TerminalSession, Theme, UpdateResult, View, element, paint, paint_scene, paint_with_context,
-    paint_with_sheet, translate_event,
+    Align, Backdrop, Dimension, Direction, DockEdge, DockLayout, DockPlacement, DockSpec,
+    DockState, Element, Event, EventFlow, InputOutcome, Justify, Key, KeyCode, LayoutStyle, Mouse,
+    MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx, Runner, RunnerConfig, Scene,
+    SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal, Size,
+    StyleSheet, Surface, TargetAlign, TargetPlacement, TargetSide, TerminalSession, Theme,
+    UpdateResult, View, element, paint, paint_scene, paint_with_context, paint_with_sheet,
+    translate_event,
 };
 
 #[cfg(feature = "async")]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -50,6 +50,21 @@ fn the_prelude_alone_can_build_and_render_a_screen() {
     );
 }
 
+#[test]
+fn responsive_dock_lifecycle_is_in_the_framework_prelude() {
+    let mut dock = DockState::new();
+    dock.show_passive();
+    let wide = dock.resolve(Rect::new(0, 0, 100, 20), DockSpec::right(80, 32));
+    assert_eq!(wide.placement, DockPlacement::Docked);
+    assert_eq!(wide.main.width, 68);
+
+    dock.focus();
+    let narrow = dock.resolve(Rect::new(0, 0, 60, 20), DockSpec::right(80, 32));
+    assert_eq!(narrow.placement, DockPlacement::Drawer);
+    assert_eq!(narrow.main.width, 60);
+    assert_eq!(narrow.panel.expect("focused drawer").x, 28);
+}
+
 /// `view!` expands to `$crate::components::…` paths. Only an out-of-crate
 /// expansion proves those paths resolve for a host.
 #[test]


### PR DESCRIPTION
## What changed

Tuika now exposes a small host-owned responsive dock lifecycle: DockState, DockSpec, DockLayout, DockPlacement, and DockEdge. A visible panel docks on wide frames, stays logically open but hidden when narrow and passive, and resolves as an overlay drawer when narrow and focused.

The API returns geometry only. Hosts continue to own panel views, focus identifiers, keymaps, scrolling, and domain state.

## Why

Applications need the docking and focus lifecycle without adopting a retained panel or window manager. This extracts the reusable seam demonstrated by the Yolop activity rail while preserving the ephemeral-view model in Tuika.

## Before / After

Before: each host had to reproduce the same breakpoint, hidden-passive, and focused-drawer state machine.

After: hosts can persist one DockState and resolve safe main/panel rectangles per frame, including tiny viewports and zero preferred widths.

## Risk

- Low
- This is additive public API. The primary risk is incorrect edge or degenerate geometry; unit and public API tests cover left/right placement, wide/narrow transitions, focus toggling, tiny frames, and zero preferred width.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered; the API is additive
- [x] Knowledge concepts updated

## Knowledge

Updated the API-surface and architecture concepts, knowledge log, public README, and changelog. The design explicitly rejects a retained panel manager in favor of host-owned state plus resolved geometry.

## Security

No security-relevant I/O or configuration changes. The new API is pure, constant-time rectangle/state computation with no filesystem, shell, network, prompt, secret, or dependency surface. Inputs are clamped to the available frame, including zero preferred width.

Validation:

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features: full workspace, integration, PTY, packaging, public API, and doctests green
- python3 scripts/validate_okf.py knowledge --check-links

## Follow-ups

- Yolop can adopt DockState after the next crates.io release; the visual correction remains local until a published version is available.