### PR TITLE
feat(time): add injectable monotonic clocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ block-HTML seam.
 
 ### Added
 
+- `Clock` and `SystemClock` provide one monotonic time seam.
+  `SelectionState::handle_with_clock` makes double-click gestures deterministic,
+  and `Runner::with_clock` lets replayable synchronous hosts own tick time;
+  existing `handle` and `Runner::new` behavior remains system-clock backed.
 - `VirtualWindow` provides overflow-safe clamped and selection-centered ranges;
   `Scrollbar` renders the same window vertically or horizontally with semantic
   styling and local glyph/style overrides. Scroll, item scroll, viewport,

--- a/README.md
+++ b/README.md
@@ -667,6 +667,12 @@ runner.run(
 )?;
 ```
 
+`Runner::with_clock` replaces the default `SystemClock` when a replayable host
+or deterministic test owns monotonic time. The same `Clock` seam drives
+`SelectionState::handle_with_clock`, so double-click timing never has to depend
+on wall-clock sleeps. Frame animation, keymap timeouts, and toast expiry remain
+explicitly host-driven and therefore need no internal clock.
+
 `AsyncRunner` (behind `features = ["async"]`) uses the same state/view/signal
 model for applications that already have a Tokio runtime — anything doing
 network or disk I/O — and lets its update closure `.await`. It ties
@@ -744,7 +750,9 @@ you already rendered:
   clears the old selection). `selected_text(buffer, area, range)` reads the text
   back out of the rendered `ratatui::Buffer` — linear/stream selection like a
   terminal's own, wide glyphs intact — and `mouse::paint_selection(buffer, area, range,
-  style)` paints it in.
+  style)` paints it in. A same-cell double click selects a word;
+  `handle_with_clock` accepts a virtual monotonic `Clock`, while `handle` uses
+  `SystemClock`.
 - **Clicks and regions.** `HitMap<T>` maps screen rects to values (a button, a
   link, a row); the last-pushed match wins, so children/overlays registered
   after their parents take precedence. `ClickTracker` turns a same-cell

--- a/docs/features.md
+++ b/docs/features.md
@@ -247,7 +247,8 @@ event model (`MouseKind` carries `Down`/`Up`/`Drag`, `Moved`, and scroll, with
   pointer. Call `resolve(buffer, area)` after rendering to resolve pending word
   boundaries; `selected_text(buffer, area, range)` then reads the selected text
   back out of the rendered buffer (wide glyphs intact) and `mouse::paint_selection(buffer,
-  area, range, style)` paints it in.
+  area, range, style)` paints it in. `handle_with_clock` accepts a host `Clock`
+  for deterministic gesture timing; `handle` uses `SystemClock`.
 - `ctrl_click_url(event, buffer, area)` returns the URL under a Ctrl+left-button
   release: first an OSC 8 target embedded in the cell run (labeled markdown
   links after `apply_buffer_links`), then a visible bare `http(s)://` run. The

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-01
 
+- **Monotonic time is injectable**
+
+- `Clock` gives gesture recognition and synchronous runner scheduling one
+  replaceable monotonic source while preserving system-clock conveniences.
+- Animation, toast expiry, and keymap timeout policy remain host-driven; the
+  async runner retains Tokio's independently controllable time source.
+
 - **Virtualized collections share one range and scrollbar model**
 
 - `VirtualWindow` now supplies clamped, selection-centered absolute ranges,

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -72,7 +72,9 @@ rather than beside it.
 - **Runners own application state directly**: rendering receives `&State`,
   updates receive `&mut State` plus a tick or input signal, and repaint is an
   explicit dirty result (or, synchronously, an external redraw request).
-  Rendering stays pure, and idle ticks do not churn the terminal.
+  Rendering stays pure, and idle ticks do not churn the terminal. The
+  synchronous runner's monotonic clock defaults to the process clock and is
+  replaceable for deterministic hosts.
 
 `measure` and `render` are the two halves of every view, and both receive the
 same `RenderCtx`: `measure` reports a size in whole cells so the solver can
@@ -173,6 +175,12 @@ highlight spans. Editing nevertheless moves and deletes by grapheme boundary,
 and soft-wrap plus cursor placement use grapheme display width in terminal
 cells. Keeping one cell-width model across measurement, painting, and cursor
 math prevents CJK and multi-scalar emoji from drifting apart.
+
+Time-sensitive component state never owns an unreplaceable wall clock. Mouse
+double-click detection and the synchronous runner consume the root `Clock`
+seam, defaulting to `SystemClock`; animation frames, toast expiry, and keymap
+timeouts remain values or ticks explicitly advanced by the host. The async
+runner uses Tokio time, whose paused-time facility is its deterministic clock.
 
 Inline composer tokens follow the same host-agnostic rule. A `Trigger` declares
 only *where* an opening character counts (`Anywhere`/`WordStart`/`LineStart`/

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,23 @@
+//! Monotonic time source for host loops and time-sensitive input gestures.
+
+use std::time::Instant;
+
+/// A monotonic clock that can be replaced in deterministic hosts and tests.
+///
+/// Returned instants must share one monotonic epoch and must not move backward.
+/// Components use elapsed durations only; wall-clock dates and time zones are
+/// intentionally outside this seam.
+pub trait Clock {
+    /// Read the current monotonic instant.
+    fn now(&self) -> Instant;
+}
+
+/// The process monotonic clock backed by [`Instant::now`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod anim;
+mod clock;
 pub mod components;
 pub mod dock;
 pub mod event;
@@ -122,6 +123,7 @@ pub mod ui {
 // through its module (`themes::by_name`, `probe::RectProbe`, `term::clipboard`)
 // is deliberately not flattened: a shallow path is worth something only if the
 // name earns it.
+pub use clock::{Clock, SystemClock};
 pub use dock::{DockEdge, DockLayout, DockPlacement, DockSpec, DockState};
 pub use event::{Event, EventFlow, InputOutcome, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use geometry::{Padding, Size};

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -29,6 +29,7 @@ use ratatui_core::style::Style;
 use std::time::{Duration, Instant};
 
 use crate::event::{Mouse, MouseButton, MouseKind};
+use crate::{Clock, SystemClock};
 
 /// A normalized text selection in reading order: `start` is at or before `end`
 /// ordered by `(row, column)`. Both endpoints are inclusive cells.
@@ -104,6 +105,15 @@ impl SelectionState {
     /// Feed a mouse event; returns `true` when the selection changed and a
     /// redraw is warranted.
     pub fn handle(&mut self, m: &Mouse) -> bool {
+        self.handle_with_clock(m, &SystemClock)
+    }
+
+    /// Feed a mouse event using an explicit monotonic `clock`.
+    ///
+    /// This is behaviorally identical to [`handle`](Self::handle), but makes
+    /// double-click timing deterministic in tests, replay systems, and hosts
+    /// with a virtual clock.
+    pub fn handle_with_clock(&mut self, m: &Mouse, clock: &dyn Clock) -> bool {
         match m.kind {
             MouseKind::Down(MouseButton::Left) => {
                 self.anchor = (m.column, m.row);
@@ -129,9 +139,10 @@ impl SelectionState {
                     self.last_click = None;
                 } else {
                     let position = self.cursor;
-                    let now = Instant::now();
+                    let now = clock.now();
                     let is_double = self.last_click.is_some_and(|(previous, at)| {
-                        previous == position && now.duration_since(at) <= DOUBLE_CLICK_INTERVAL
+                        previous == position
+                            && now.saturating_duration_since(at) <= DOUBLE_CLICK_INTERVAL
                     });
                     self.last_click = Some((position, now));
                     self.pending_word = is_double.then_some(position);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,12 +39,12 @@ pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.
 pub use crate::view;
 pub use crate::{
-    Align, Backdrop, Dimension, Direction, DockEdge, DockLayout, DockPlacement, DockSpec,
+    Align, Backdrop, Clock, Dimension, Direction, DockEdge, DockLayout, DockPlacement, DockSpec,
     DockState, Element, Event, EventFlow, InputOutcome, Justify, Key, KeyCode, LayoutStyle, Mouse,
     MouseButton, MouseKind, Overlay, OverlaySpec, Padding, RenderCtx, Runner, RunnerConfig, Scene,
     SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal, Size,
-    StyleSheet, Surface, TargetAlign, TargetPlacement, TargetSide, TerminalSession, Theme,
-    UpdateResult, View, element, paint, paint_scene, paint_with_context, paint_with_sheet,
+    StyleSheet, Surface, SystemClock, TargetAlign, TargetPlacement, TargetSide, TerminalSession,
+    Theme, UpdateResult, View, element, paint, paint_scene, paint_with_context, paint_with_sheet,
     translate_event,
 };
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -23,7 +23,8 @@ mod asynchronous;
 pub use asynchronous::AsyncRunner;
 
 use std::io;
-use std::time::{Duration, Instant};
+use std::sync::Arc;
+use std::time::Duration;
 
 use crossterm::event;
 use ratatui_core::backend::Backend;
@@ -32,7 +33,7 @@ use ratatui_crossterm::CrosstermBackend;
 
 use crate::live::RedrawHandle;
 use crate::screen::{ScreenMode, Scrollback, close_footer, pin_footer};
-use crate::{Element, Event, TerminalSession, Theme, paint, translate_event};
+use crate::{Clock, Element, Event, SystemClock, TerminalSession, Theme, paint, translate_event};
 
 #[derive(Clone, Copy, Debug)]
 /// Options for [`Runner`] and [`AsyncRunner`].
@@ -77,19 +78,30 @@ pub enum UpdateResult {
 /// A synchronous Crossterm event and rendering loop.
 pub struct Runner {
     config: RunnerConfig,
+    clock: Arc<dyn Clock + Send + Sync>,
     redraw: RedrawHandle,
     scrollback: Scrollback,
 }
 
 impl Runner {
     /// Create a runner without touching the terminal.
-    pub fn new(mut config: RunnerConfig) -> Self {
+    pub fn new(config: RunnerConfig) -> Self {
+        Self::with_clock(config, SystemClock)
+    }
+
+    /// Create a runner driven by an explicit monotonic clock.
+    ///
+    /// The system clock remains the default. Supplying a virtual clock makes
+    /// tick scheduling deterministic for replayable hosts and tests; advance a
+    /// shared clock while the runner is waiting so time can progress.
+    pub fn with_clock(mut config: RunnerConfig, clock: impl Clock + Send + Sync + 'static) -> Self {
         // A zero interval would busy-spin even when the application has no
         // events or updates. Keep the public config ergonomic while enforcing
         // a safe scheduling floor at the boundary.
         config.tick_rate = config.tick_rate.max(Duration::from_millis(1));
         Self {
             config,
+            clock: Arc::new(clock),
             redraw: RedrawHandle::default(),
             scrollback: Scrollback::new(),
         }
@@ -152,7 +164,7 @@ impl Runner {
             },
         )?;
         let mut frame = 0u64;
-        let mut last_tick = Instant::now();
+        let mut last_tick = self.clock.now();
 
         if split {
             pin_footer(&mut terminal)?;
@@ -169,8 +181,9 @@ impl Runner {
                 self.scrollback.clear();
             }
 
-            if last_tick.elapsed() >= self.config.tick_rate {
-                last_tick = Instant::now();
+            let now = self.clock.now();
+            if now.saturating_duration_since(last_tick) >= self.config.tick_rate {
+                last_tick = now;
                 if apply_update(update(state, Signal::Tick), &mut dirty) {
                     break;
                 }
@@ -184,7 +197,8 @@ impl Runner {
                 draw(&mut terminal, theme, &mut view, state, &mut frame)?;
             }
 
-            let timeout = self.config.tick_rate.saturating_sub(last_tick.elapsed());
+            let elapsed = self.clock.now().saturating_duration_since(last_tick);
+            let timeout = self.config.tick_rate.saturating_sub(elapsed);
             if event::poll(timeout)?
                 && let Some(event) = translate_event(event::read()?)
             {
@@ -245,7 +259,18 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
     use super::*;
+
+    #[derive(Clone, Copy)]
+    struct FixedClock(Instant);
+
+    impl Clock for FixedClock {
+        fn now(&self) -> Instant {
+            self.0
+        }
+    }
 
     #[test]
     fn clean_updates_do_not_request_a_repaint() {
@@ -275,6 +300,13 @@ mod tests {
             ..RunnerConfig::default()
         });
         assert_eq!(runner.config.tick_rate, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn explicit_clock_drives_the_runner() {
+        let now = Instant::now();
+        let runner = Runner::with_clock(RunnerConfig::default(), FixedClock(now));
+        assert_eq!(runner.clock.now(), now);
     }
 
     #[test]

--- a/tests/injectable_clock.rs
+++ b/tests/injectable_clock.rs
@@ -1,0 +1,64 @@
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tuika::mouse::SelectionState;
+use tuika::prelude::{
+    Clock, Mouse, MouseButton, MouseKind, Runner, RunnerConfig, SystemClock, Text,
+};
+use tuika::testing::render;
+use tuika::ui::Rect;
+
+#[derive(Clone)]
+struct ManualClock(Arc<Mutex<Instant>>);
+
+impl ManualClock {
+    fn new(now: Instant) -> Self {
+        Self(Arc::new(Mutex::new(now)))
+    }
+
+    fn advance(&self, duration: Duration) {
+        let mut now = self.0.lock().expect("manual clock lock");
+        *now += duration;
+    }
+}
+
+impl Clock for ManualClock {
+    fn now(&self) -> Instant {
+        *self.0.lock().expect("manual clock lock")
+    }
+}
+
+fn click(state: &mut SelectionState, clock: &dyn Clock, column: u16) {
+    let down = Mouse::at(MouseKind::Down(MouseButton::Left), column, 0);
+    let up = Mouse::at(MouseKind::Up(MouseButton::Left), column, 0);
+    state.handle_with_clock(&down, clock);
+    state.handle_with_clock(&up, clock);
+}
+
+#[test]
+fn selection_double_click_uses_the_injected_monotonic_clock() {
+    let clock = ManualClock::new(Instant::now());
+    let mut state = SelectionState::new();
+    click(&mut state, &clock, 1);
+    clock.advance(Duration::from_millis(100));
+    click(&mut state, &clock, 1);
+
+    let theme = tuika::Theme::default();
+    let buffer = render(&Text::raw("hello world"), 11, 1, &theme);
+    assert!(state.resolve(&buffer, Rect::new(0, 0, 11, 1)));
+    assert_eq!(state.range().expect("word selection").end, (4, 0));
+
+    state.clear();
+    click(&mut state, &clock, 7);
+    clock.advance(Duration::from_millis(501));
+    click(&mut state, &clock, 7);
+    assert!(!state.resolve(&buffer, Rect::new(0, 0, 11, 1)));
+}
+
+#[test]
+fn system_and_manual_clocks_are_accepted_by_the_runner() {
+    let _system = Runner::with_clock(RunnerConfig::default(), SystemClock);
+    let clock = ManualClock::new(Instant::now());
+    let _manual = Runner::with_clock(RunnerConfig::default(), clock.clone());
+    clock.advance(Duration::from_secs(1));
+}


### PR DESCRIPTION
## What changed

Added one public monotonic `Clock` seam with a default `SystemClock`. Synchronous runners can now use `Runner::with_clock`, and mouse selection can use `SelectionState::handle_with_clock`, while existing constructors preserve system-clock behavior.

## Why

Library-owned time reads made deterministic replay and gesture tests depend on real elapsed time. Hosts should be able to own time without reimplementing runner scheduling or text selection.

## Before / After

Before: synchronous runner ticks and double-click recognition read the process clock internally.

After: both accept a shared virtual clock. Automated coverage advances a manual clock without sleeping and verifies double-click boundaries; the existing system-backed paths remain unchanged. The synchronous runner also completed a real-terminal render and clean restoration smoke check.

## Risk

- Medium
- Tick scheduling and double-click timing could regress. Saturating elapsed-time math, the existing minimum tick interval, workspace tests, MSRV checks, and terminal smoke coverage constrain that risk.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated the architecture timing contract and durable knowledge log.

## Security

Reviewed timing, denial-of-service, terminal, parser, dependency, unsafe, and I/O surfaces. No new dependency, unsafe code, parser, terminal escape, or external I/O was added. Tick intervals remain clamped away from zero, and elapsed calculations saturate.

## Follow-ups

No follow-ups.