### PR TITLE
feat(runner): add async dirty updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@ block-HTML seam.
 
 ### Changed
 
+- **Breaking:** `AsyncRunner` update closures now return `UpdateResult` instead
+  of `ControlFlow<()>`, matching synchronous `Runner`; clean ticks and events no
+  longer rebuild or repaint the view.
+
 - **Breaking:** interactive component handlers now return one root/prelude
   `InputOutcome` (`Ignored`, `Consumed`, `Changed`, `Submitted`, or `Cancelled`).
   Read the submitted value back from its host-owned state. Replace

--- a/README.md
+++ b/README.md
@@ -672,8 +672,9 @@ model for applications that already have a Tokio runtime — anything doing
 network or disk I/O — and lets its update closure `.await`. It ties
 `TerminalSession`, `paint`, and `translate_event` to crossterm's async
 `EventStream` and a tick timer in one `tokio::select!`, so the host keeps a
-single event loop. Its update closure returns `ControlFlow<()>`; asynchronous
-updates currently repaint after every delivered signal.
+single event loop. Its update closure returns the same
+`UpdateResult::{Clean, Dirty, Exit}` as `Runner`, so awaited work only rebuilds
+and repaints when it actually changes visible state.
 
 Enabling `async` adds Tokio (timer + `select!`) and crossterm's `event-stream`
 feature; it stays off by default so sync-only hosts pull in no runtime. The

--- a/examples/async_dashboard.rs
+++ b/examples/async_dashboard.rs
@@ -11,7 +11,6 @@
 //! Run with: `cargo run --example async_dashboard --features async`.
 //! Press `q`/`esc` to quit, `r` to refresh now.
 
-use std::ops::ControlFlow;
 use std::time::Duration;
 
 use ratatui::layout::Constraint;
@@ -108,17 +107,17 @@ async fn main() -> std::io::Result<()> {
                 // Poll on the tick and on `r`; both simply await the fetch.
                 Signal::Tick => {
                     metrics.ingest(fetch_stats(metrics.requests).await);
-                    ControlFlow::Continue(())
+                    UpdateResult::Dirty
                 }
                 Signal::Event(Event::Key(key)) if key.plain() => match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => ControlFlow::Break(()),
+                    KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
                     KeyCode::Char('r') => {
                         metrics.ingest(fetch_stats(metrics.requests).await);
-                        ControlFlow::Continue(())
+                        UpdateResult::Dirty
                     }
-                    _ => ControlFlow::Continue(()),
+                    _ => UpdateResult::Clean,
                 },
-                _ => ControlFlow::Continue(()),
+                _ => UpdateResult::Clean,
             },
         )
         .await

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -22,6 +22,12 @@
 
 ## 2026-07-31
 
+- **Async runner uses explicit invalidation**
+  - Awaited updates return the same clean/dirty/exit result as synchronous
+    updates, so idle ticks and handled-but-invisible events do not rebuild or
+    repaint the view.
+  - State/view/update semantics are now symmetric across both runner variants.
+
 - **Responsive auxiliary panels stay host-owned**
 
 - A small dock state now resolves one panel to wide dock, narrow focused

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -69,10 +69,10 @@ rather than beside it.
 - **The host owns the terminal**: the screen mode (alternate screen or a split
   footer over live scrollback — see [screen-modes.md](./screen-modes.md)), raw
   mode, mouse capture, input translation, and frame compositing.
-- **The synchronous runner owns application state directly**: rendering receives
-  `&State`, updates receive `&mut State` plus a tick or input signal, and repaint
-  is an explicit dirty result or an external redraw request. Rendering stays
-  pure, and idle ticks do not churn the terminal.
+- **Runners own application state directly**: rendering receives `&State`,
+  updates receive `&mut State` plus a tick or input signal, and repaint is an
+  explicit dirty result (or, synchronously, an external redraw request).
+  Rendering stays pure, and idle ticks do not churn the terminal.
 
 `measure` and `render` are the two halves of every view, and both receive the
 same `RenderCtx`: `measure` reports a size in whole cells so the solver can

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -17,9 +17,7 @@
 //! `&mut state` at once.
 //!
 //! ```no_run
-//! use std::ops::ControlFlow;
 //! use std::time::Duration;
-//!
 //! use tuika::prelude::*;
 //!
 //! # async fn fetch_stats() -> std::io::Result<u64> { Ok(0) }
@@ -40,17 +38,17 @@
 //!                 // Poll on every tick and on `r`; both may await.
 //!                 Signal::Tick => {
 //!                     *requests = fetch_stats().await.unwrap_or(*requests);
-//!                     ControlFlow::Continue(())
+//!                     UpdateResult::Dirty
 //!                 }
 //!                 Signal::Event(Event::Key(k)) if k.plain() => match k.code {
-//!                     KeyCode::Char('q') | KeyCode::Esc => ControlFlow::Break(()),
+//!                     KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
 //!                     KeyCode::Char('r') => {
 //!                         *requests = fetch_stats().await.unwrap_or(*requests);
-//!                         ControlFlow::Continue(())
+//!                         UpdateResult::Dirty
 //!                     }
-//!                     _ => ControlFlow::Continue(()),
+//!                     _ => UpdateResult::Clean,
 //!                 },
-//!                 _ => ControlFlow::Continue(()),
+//!                 _ => UpdateResult::Clean,
 //!             },
 //!         )
 //!         .await
@@ -58,7 +56,6 @@
 //! ```
 
 use std::io;
-use std::ops::ControlFlow;
 use std::time::Duration;
 
 use crossterm::event::EventStream;
@@ -70,7 +67,9 @@ use tokio_stream::{Stream, StreamExt};
 
 use super::Signal;
 use crate::screen::{Scrollback, close_footer, pin_footer};
-use crate::{Element, Event, RunnerConfig, TerminalSession, Theme, paint, translate_event};
+use crate::{
+    Element, Event, RunnerConfig, TerminalSession, Theme, UpdateResult, paint, translate_event,
+};
 
 /// An asynchronous Crossterm event and rendering loop.
 ///
@@ -107,7 +106,7 @@ impl AsyncRunner {
         self.scrollback.clone()
     }
 
-    /// Run on the real terminal until `update` returns [`ControlFlow::Break`].
+    /// Run on the real terminal until `update` returns [`UpdateResult::Exit`].
     ///
     /// Enters a [`TerminalSession`] (restored on return, including on error or
     /// panic) and reads input from crossterm's async
@@ -121,7 +120,7 @@ impl AsyncRunner {
     ) -> io::Result<()>
     where
         V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, Signal) -> ControlFlow<()>,
+        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
         self.run_with_backend(
             theme,
@@ -148,7 +147,7 @@ impl AsyncRunner {
     where
         B: Backend<Error = io::Error>,
         V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, Signal) -> ControlFlow<()>,
+        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
         let mode = self.config.screen_mode;
         let _session = TerminalSession::enter_with(mode)?;
@@ -197,7 +196,7 @@ impl AsyncRunner {
     /// `events` yields already-translated tuika [`Event`]s. An `Err` item ends
     /// the run by propagating out; `None` (a finite stream running dry) stops
     /// event delivery but leaves the tick timer running, so the loop still exits
-    /// only when `update` returns [`ControlFlow::Break`].
+    /// only when `update` returns [`UpdateResult::Exit`].
     pub async fn run_with_events<S, B, V, U, E, Er>(
         &self,
         terminal: &mut Terminal<B>,
@@ -211,7 +210,7 @@ impl AsyncRunner {
         B: Backend<Error = Er>,
         E: Stream<Item = Result<Event, Er>> + Unpin,
         V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, Signal) -> ControlFlow<()>,
+        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
         let mut events_done = false;
         let mut frame = 0u64;
@@ -245,25 +244,27 @@ impl AsyncRunner {
                 },
             };
 
-            if update(state, signal).await.is_break() {
-                break;
-            }
+            let mut dirty = match update(state, signal).await {
+                UpdateResult::Clean => false,
+                UpdateResult::Dirty => true,
+                UpdateResult::Exit => break,
+            };
             if split {
-                // Publish first: committing a block scrolls the terminal and
-                // (on the portable path) clears the viewport, so the draw below
-                // is what puts the footer back. Resolve any resize before
-                // re-pinning, so the footer is measured against the new height.
-                self.scrollback.flush(terminal, theme)?;
-                terminal.autoresize()?;
-                pin_footer(terminal)?;
+                // Publishing scrolls the terminal and may clear the viewport,
+                // so a committed block always makes the footer dirty.
+                dirty |= self.scrollback.flush(terminal, theme)?;
+                if dirty {
+                    terminal.autoresize()?;
+                    pin_footer(terminal)?;
+                }
             } else {
                 // Nothing above the frame to publish into; drop queued blocks
                 // rather than let a producer grow the queue without bound.
                 self.scrollback.clear();
             }
-            // Redraws are a ratatui buffer diff, so repainting after every
-            // handled signal only flushes the cells that actually changed.
-            draw(terminal, theme, &mut view, state, &mut frame)?;
+            if dirty {
+                draw(terminal, theme, &mut view, state, &mut frame)?;
+            }
         }
 
         Ok(())
@@ -361,13 +362,13 @@ mod tests {
                 |count, _frame| element(Text::raw(format!("count={count}"))),
                 async |count, signal| match signal {
                     Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
-                        ControlFlow::Break(())
+                        UpdateResult::Exit
                     }
                     Signal::Event(Event::Key(_)) => {
                         *count += 1;
-                        ControlFlow::Continue(())
+                        UpdateResult::Dirty
                     }
-                    _ => ControlFlow::Continue(()),
+                    _ => UpdateResult::Clean,
                 },
             )
             .await;
@@ -378,6 +379,42 @@ mod tests {
             buffer_text(&terminal).contains("count=2"),
             "final frame reflects state: {:?}",
             buffer_text(&terminal)
+        );
+    }
+
+    #[tokio::test]
+    async fn clean_updates_do_not_rebuild_or_repaint() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(16, 1);
+        let mut state = 0u8;
+        let views = std::cell::Cell::new(0usize);
+        let events = tokio_stream::iter([key(KeyCode::Char('a')), key(KeyCode::Esc)]);
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut state,
+                events,
+                |state, _frame| {
+                    views.set(views.get() + 1);
+                    element(Text::raw(format!("state={state}")))
+                },
+                async |_state, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    _ => UpdateResult::Clean,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            views.get(),
+            1,
+            "clean input leaves the initial frame intact"
         );
     }
 
@@ -397,7 +434,7 @@ mod tests {
                 &mut state,
                 events,
                 |state, _frame| element(Text::raw(*state)),
-                async |_state, _signal| ControlFlow::Break(()),
+                async |_state, _signal| UpdateResult::Exit,
             )
             .await
             .unwrap();
@@ -433,9 +470,9 @@ mod tests {
                         *ticks += 1;
                     }
                     if *ticks >= 3 {
-                        ControlFlow::Break(())
+                        UpdateResult::Exit
                     } else {
-                        ControlFlow::Continue(())
+                        UpdateResult::Dirty
                     }
                 },
             )
@@ -494,13 +531,13 @@ mod tests {
                 },
                 async |_state, signal| match signal {
                     Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
-                        ControlFlow::Break(())
+                        UpdateResult::Exit
                     }
                     Signal::Event(_) => {
                         scrollback.write(|_width| element(Text::raw("published")));
-                        ControlFlow::Continue(())
+                        UpdateResult::Dirty
                     }
-                    _ => ControlFlow::Continue(()),
+                    _ => UpdateResult::Clean,
                 },
             )
             .await
@@ -564,9 +601,9 @@ mod tests {
                     // Enough ticks for the spawned task to be polled and its
                     // blocks flushed.
                     if *ticks >= 8 {
-                        ControlFlow::Break(())
+                        UpdateResult::Exit
                     } else {
-                        ControlFlow::Continue(())
+                        UpdateResult::Clean
                     }
                 },
             )
@@ -609,10 +646,8 @@ mod tests {
                 events,
                 |_state, _frame| element(Text::raw("frame")),
                 async |_state, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
-                        ControlFlow::Break(())
-                    }
-                    _ => ControlFlow::Continue(()),
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    _ => UpdateResult::Clean,
                 },
             )
             .await
@@ -654,7 +689,7 @@ mod tests {
                 &mut state,
                 events,
                 |_state, _frame| element(Text::raw("x")),
-                async |_state, _signal| ControlFlow::Continue(()),
+                async |_state, _signal| UpdateResult::Dirty,
             )
             .await;
 


### PR DESCRIPTION
## Summary

- make `AsyncRunner` updates return the same `UpdateResult::{Clean, Dirty, Exit}` contract as synchronous `Runner`
- skip view reconstruction and terminal drawing for clean ticks and events
- preserve split-footer redraws when scrollback publication itself makes the viewport dirty

## Why

The synchronous runner now avoids idle repainting, but `AsyncRunner` still rebuilt the view after every tick and input signal. This change completes runner parity and lets awaited updates distinguish visible state changes from background work that leaves the frame unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test --doc --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --check-links`
- built and ran `async_dashboard` under a PTY, confirming it emitted frames without panic

A direct async runner test counts view constructions and proves a clean event leaves the initial frame intact.

## Before / After

**Before:** every async tick or input signal rebuilt the view and called terminal draw, even if update made no visible change.

**After:** `Clean` waits for the next signal without rebuilding; `Dirty` rebuilds and paints; `Exit` tears down normally. Split-footer publication still forces a repaint even when update itself is clean.

## API changes

**Breaking:** `AsyncRunner::{run, run_with_backend, run_with_events}` update closures now return `UpdateResult` instead of `ControlFlow<()>`.

Migration: replace `ControlFlow::Continue(())` with `UpdateResult::Dirty` when visible state changed or `UpdateResult::Clean` otherwise; replace `ControlFlow::Break(())` with `UpdateResult::Exit`.

No dependencies were added.

## Knowledge and docs

Updated README, changelog, architecture specification, knowledge log, module documentation, and the async dashboard example.

## Security

- **TM-STATE:** exit still flows through the existing footer/terminal cleanup path; no lifecycle enter/restore behavior changed.
- **TM-CLIP:** rendering remains the existing clipped paint path; clean updates perform fewer writes.
- **TM-PARSE / TM-ESC / TM-DEP:** no parsing, escape emission, untrusted-input, or dependency changes.
- Idle resource use is reduced; event/tick waits remain bounded by the configured interval and event stream.

## Follow-ups

- Add the separately requested interactive selection example after this runner API change lands.

Produced by [yolop](https://everruns.com/yolop)
