### PR TITLE
docs(examples): expand interactive selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Each takes over the terminal — the alternate screen, or a pinned footer for
 | ---------- | ----------------------------------------- | -------------------------------------------------- |
 | [`gallery`](examples/gallery.rs)  | `cargo run --example gallery`    | motion components + native OSC 9;4 progress        |
 | [`markdown`](examples/markdown.rs) | `cargo run --example markdown`   | streaming `MarkdownState` + highlighted `CodeBlock`, following the stream until you scroll back |
-| [`select`](examples/select.rs)   | `cargo run --example select`     | `SelectState` + `SelectList` (stateful-widget idiom) |
+| [`select`](examples/select.rs)   | `cargo run --example select`     | interactive multi-select with aliases, numbers, and mouse hit-testing |
 | [`overlay`](examples/overlay.rs)  | `cargo run --example overlay`    | Target-following popover + input routing           |
 | [`primitives`](examples/primitives.rs) | `cargo run --example primitives` | owned dialog scene + form + arbitrary-child viewport |
 | [`ratatui_dashboard`](examples/ratatui_dashboard.rs) | `cargo run --example ratatui_dashboard` | mixed Ratatui widgets + responsive live data |

--- a/docs/components.md
+++ b/docs/components.md
@@ -477,7 +477,9 @@ overrides the theme selection style for one list. `handle_with` accepts a
 `SelectNavigation` policy; `SelectNavigation::common()` enables j/k, Ctrl+N/P,
 Tab/Shift+Tab, and numeric shortcuts. `handle_mouse` hit-tests explicit list
 bounds and a viewport offset. `MultiSelectState` adds Enter/Space/click toggling
-for pickers that retain several checked items.
+for pickers that retain several checked items. The runnable
+[`select` example](https://github.com/everruns/tuika/blob/main/examples/select.rs)
+combines every navigation mode in one picker.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.SelectList.html)
 
 <img src="demos/select.gif" width="880" alt="SelectList demo">

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -1,92 +1,161 @@
-//! Interactive select list. Run with `cargo run --example select`
-//! (↑/↓ move · enter choose · q or esc quit).
+//! Interactive picker demonstrating Tuika's configurable selection policies.
 //!
-//! Demonstrates the stateful-widget idiom: [`SelectState`] persists the
-//! highlighted index across frames while [`SelectList`] is rebuilt each frame,
-//! and [`translate_event`] feeds real terminal input to the widget.
+//! Run with:
+//!
+//! ```text
+//! cargo run --example select
+//! ```
+//!
+//! Navigate with arrows, j/k, Ctrl+N/P, or Tab/Shift+Tab. Number keys toggle
+//! items directly; Enter/Space toggles the cursor row; left-click toggles a row.
+//! Press `c` to clear checked items and `q`/Escape to quit.
 
 use std::io;
-use std::time::Duration;
-
-use crossterm::event::{self};
-use ratatui::backend::CrosstermBackend;
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
 
-const FRUITS: [&str; 8] = [
-    "Apple",
-    "Blueberry",
-    "Cherry",
-    "Date",
-    "Elderberry",
-    "Fig",
-    "Grape",
-    "Honeydew",
+const ITEMS: [&str; 7] = [
+    "Build release",
+    "Run test suite",
+    "Generate docs",
+    "Publish artifacts",
+    "Notify maintainers",
+    "Deploy canary",
+    "Promote production",
 ];
+const LIST_Y: u16 = 4;
 
-fn main() -> io::Result<()> {
-    let mut state = SelectState::new();
-    let mut chosen: Option<usize> = None;
+#[derive(Default)]
+struct PickerState {
+    selection: MultiSelectState,
+    message: String,
+}
 
-    let _session = TerminalSession::enter()?;
-    let mut terminal = Terminal::with_options(
-        CrosstermBackend::new(io::stdout()),
-        TerminalOptions {
-            viewport: Viewport::Fullscreen,
-        },
-    )?;
-    let theme = Theme::default();
+impl PickerState {
+    fn new() -> Self {
+        Self {
+            selection: MultiSelectState::new(),
+            message: "Choose any number of tasks".into(),
+        }
+    }
+}
 
-    loop {
-        terminal.draw(|f| {
-            let area = f.area();
-            let items: Vec<Line> = FRUITS.iter().map(|s| Line::from(*s)).collect();
-            let list = SelectList::new(items, &state);
-            let status = match chosen {
-                Some(i) => format!("chose: {}", FRUITS[i]),
-                None => "↑/↓ move · enter choose · q quit".to_string(),
-            };
-            let root = view! {
-                col(padding = Padding::all(1), gap = 1) {
-                    fixed(FRUITS.len() as u16 + 2) {
-                        boxed(title = Line::from(Span::styled(" fruit ", theme.accent_style()))) {
-                            node(list)
-                        }
-                    }
-                    fixed(1) {
-                        node(Text::new(vec![Line::from(Span::styled(
-                            status,
-                            theme.muted_style(),
-                        ))]))
-                    }
+fn scene(state: &PickerState, _theme: &Theme) -> Element {
+    let rows = ITEMS
+        .iter()
+        .enumerate()
+        .map(|(index, item)| {
+            Line::from(format!(
+                "{} {}  {item}",
+                index + 1,
+                if state.selection.contains(index) {
+                    "[x]"
+                } else {
+                    "[ ]"
                 }
-            };
-            paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
-        })?;
+            ))
+        })
+        .collect();
+    let checked = state.selection.selected().count();
 
-        if !event::poll(Duration::from_millis(150))? {
-            continue;
+    view! {
+        col {
+            fixed(1) { node(Text::raw("Interactive multi-select")) }
+            fixed(1) { node(Text::raw("↑↓/jk  Ctrl+N/P  Tab/Shift+Tab  1-7  click  Enter/Space")) }
+            fixed(1) { node(Text::raw(format!("{} · {checked} checked", state.message))) }
+            fixed(1) { node(Text::raw("")) }
+            fixed(7) { node(SelectList::new(rows, state.selection.cursor())) }
+            fixed(1) { node(Text::raw("c clear · q/esc quit")) }
         }
-        let Some(ev) = translate_event(event::read()?) else {
-            continue;
-        };
-        // `q` quits globally; the list itself only cares about arrows/enter/esc.
-        if let Event::Key(k) = &ev
-            && k.plain()
-            && matches!(k.code, KeyCode::Char('q'))
-        {
-            break;
-        }
-        match state.handle(&ev, FRUITS.len()) {
-            InputOutcome::Submitted => chosen = state.selected(),
-            InputOutcome::Cancelled => break,
+    }
+}
+
+fn update(state: &mut PickerState, event: &Event) -> UpdateResult {
+    if let Event::Key(key) = event
+        && key.plain()
+    {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => return UpdateResult::Exit,
+            KeyCode::Char('c') => {
+                state.selection.clear();
+                state.message = "Selection cleared".into();
+                return UpdateResult::Dirty;
+            }
             _ => {}
         }
     }
 
-    let _ = terminal.clear();
-    drop(terminal);
-    Ok(())
+    let outcome = match event {
+        Event::Mouse(_) => state.selection.handle_mouse(
+            event,
+            ITEMS.len(),
+            Rect::new(0, LIST_Y, u16::MAX, ITEMS.len() as u16),
+            0,
+        ),
+        _ => state
+            .selection
+            .handle(event, ITEMS.len(), SelectNavigation::common()),
+    };
+    match outcome {
+        InputOutcome::Ignored | InputOutcome::Consumed => UpdateResult::Clean,
+        InputOutcome::Changed => {
+            state.message = match state.selection.cursor().selected() {
+                Some(index) if state.selection.contains(index) => {
+                    format!("Checked {}", ITEMS[index])
+                }
+                Some(index) => format!("Cursor on {}", ITEMS[index]),
+                None => "No selection".into(),
+            };
+            UpdateResult::Dirty
+        }
+        InputOutcome::Submitted => UpdateResult::Dirty,
+        InputOutcome::Cancelled => UpdateResult::Exit,
+    }
+}
+
+fn main() -> io::Result<()> {
+    let theme = Theme::default();
+    let runner = Runner::new(RunnerConfig::default());
+    let mut state = PickerState::new();
+    runner.run(
+        &theme,
+        &mut state,
+        |state, _frame| scene(state, &theme),
+        |state, signal| match signal {
+            Signal::Event(event) => update(state, &event),
+            Signal::Tick => UpdateResult::Clean,
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tuika::event::{Mouse, MouseButton, MouseKind};
+
+    #[test]
+    fn aliases_numbers_mouse_and_clear_drive_the_example_state() {
+        let mut state = PickerState::new();
+        assert_eq!(
+            update(&mut state, &Event::Key(Key::new(KeyCode::Char('j')))),
+            UpdateResult::Dirty
+        );
+        assert_eq!(state.selection.cursor().selected(), Some(1));
+
+        assert_eq!(
+            update(&mut state, &Event::Key(Key::new(KeyCode::Char('3')))),
+            UpdateResult::Dirty
+        );
+        assert!(state.selection.contains(2));
+
+        let click = Event::Mouse(Mouse::at(MouseKind::Down(MouseButton::Left), 3, LIST_Y + 4));
+        assert_eq!(update(&mut state, &click), UpdateResult::Dirty);
+        assert!(state.selection.contains(4));
+
+        assert_eq!(
+            update(&mut state, &Event::Key(Key::new(KeyCode::Char('c')))),
+            UpdateResult::Dirty
+        );
+        assert_eq!(state.selection.selected().count(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- expand the runnable `select` example into a complete interactive multi-select picker
- demonstrate arrows, j/k, Ctrl+N/P, Tab/Shift+Tab, numeric shortcuts, Enter/Space toggling, explicit mouse hit-testing, and clearing
- test the example's keyboard, numeric, mouse, and clear paths directly

## Why

The richer selection state APIs were documented and unit-tested but lacked one discoverable runnable example showing how their policies, geometry, and multi-selection state fit together in a host event loop.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo test --example select`
- `cargo check --workspace --all-targets --all-features`
- `cargo run --example demo -- check`
- built and ran `select` under a 90x20 PTY, confirming the interactive picker frame rendered

## Before / After

**Before:** the example only showed arrow navigation and single-item Enter confirmation.

**After:** it is a working checklist-style picker demonstrating every configurable selection input surface and dirty-aware runner integration.

No component appearance changed and this is a whole interactive example rather than a gallery scene, so no component recording was regenerated.

## API changes

No API changes. This updates an existing example and public documentation only.

## Knowledge and docs

Updated the README examples table and Select component documentation. No knowledge update required: the selection policy and state model were already recorded when the API shipped; this adds executable teaching material without changing behavior or architecture.

## Security

No production security-relevant code changes. The example passes explicit list bounds to mouse hit-testing, checks indices through library APIs, and uses fixed local strings. No escape encoding, parser, dependency, or terminal lifecycle implementation changed.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
