### PR TITLE
fix(keymap): make character bindings layout-neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ block-HTML seam.
 
 ### Changed
 
+- **Breaking:** keymap character specs are now explicitly logical text. Write
+  the character produced by the active layout (`A`, `?`, `ctrl+R`) rather than
+  `shift+a` or `shift+/`; `Shift` remains valid for non-character chords such as
+  `shift+enter`. Ambiguous `shift+character` specs now return `KeyParseError`
+  (or panic through static `Layer::bind`) instead of silently discarding Shift.
 - **Breaking:** `AsyncRunner` update closures now return `UpdateResult` instead
   of `ControlFlow<()>`, matching synchronous `Runner`; clean ticks and events no
   longer rebuild or repaint the view.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,11 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Keymap** ([`keymap`](docs/keymap.md)) resolves declarative key bindings to
   named commands: chords (`ctrl+r`) and multi-stroke sequences (`g g`) grouped
   into prioritized, mode-gated `Layer`s, dispatched from a translated `Key` and
-  queryable for help/`KeyHints` surfaces. Host-agnostic, so it unit-tests
-  without a terminal. See the [keymap guide](docs/keymap.md).
+  queryable for help/`KeyHints` surfaces. Character chords are exact logical
+  text (`A`, `?`, `ж`), so the active keyboard layout is applied before
+  matching; Shift stays explicit for non-character keys such as `Shift+Enter`.
+  Host-agnostic, so it unit-tests without a terminal. See the
+  [keymap guide](docs/keymap.md).
 - **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
   `term::progress::TerminalProgress`) animates from a host-supplied frame counter and
   can drive the terminal's own OSC 9;4 progress indicator. `anim::Timeline` adds
@@ -634,9 +637,11 @@ took. Enhanced reporting preserves
 non-character modifiers, so `Shift+Enter` reaches `TextInputState` as a
 different chord from `Enter`; iTerm2 and tmux get their required protocol
 variants, while Windows uses the modifier state already carried by its native
-console events. It preserves raw mode and any keyboard-reporting stack entries
-the caller had already enabled. `AltScreen` remains available for hosts that
-intentionally own raw mode, keyboard modes, and cursor visibility themselves.
+console events. Character codes carry the logical text produced by the active
+keyboard layout, while modifiers remain separate for non-character chords. It
+preserves raw mode and any keyboard-reporting stack entries the caller had
+already enabled. `AltScreen` remains available for hosts that intentionally own
+raw mode, keyboard modes, and cursor visibility themselves.
 
 `Runner` is an optional synchronous event loop for dashboards and small tools.
 It owns `TerminalSession`, frame scheduling, Crossterm event translation, and

--- a/docs/keymap.md
+++ b/docs/keymap.md
@@ -18,7 +18,8 @@ unit-tests without a PTY.
 Four types, smallest to largest:
 
 - **`Chord`** — one key press plus its modifiers (`ctrl+r`, `alt+shift+tab`,
-  `?`, `space`, the literal `ctrl++`). Parse it from a string with
+  `?`, `A`, `space`, the literal `ctrl++`). Character tokens are exact logical
+  text, after the active keyboard layout. Parse a chord from a string with
   `Chord::parse`, or build it from a live event with `Chord::from_key`.
 - **`KeySequence`** — one *or more* chords typed in order, written
   space-separated (`g g`, `ctrl+x s`). A single chord is a one-element sequence,
@@ -87,15 +88,23 @@ A key that no active binding matches returns `Unmatched`, so the host stays in
 control of everything the keymap does not claim (typing into a text field,
 say).
 
-### Modifier normalization
+### Logical text and modifier normalization
 
 Matching is on a normalized chord, so a binding matches the event a terminal
-actually delivers. For a character key, Shift is folded into the character
-itself (`?` arrives as `Char('?')`, not `Shift`+`Char('/')`), so the `shift`
-flag is dropped for characters and kept meaningful only for non-character keys
-(`Shift`+`Enter`). `Shift`+`Tab` folds to the distinct `BackTab` key terminals
-report. Both the string parser and `Chord::from_key` apply the same rules, so a
-parsed binding and a live event agree.
+actually delivers. A character key is the exact logical Unicode character
+produced by the active keyboard layout: `?` arrives as `Char('?')`, not
+`Shift`+`Char('/')`. Bind `?`, `A`, or `ctrl+R` directly. This is portable to
+non-US layouts because the keymap never guesses which physical key plus Shift
+produces that text.
+
+Accordingly, `shift+character` specs are rejected instead of silently losing
+Shift; `Chord::parse` and `Layer::try_bind` return `KeyParseError`, while static
+`Layer::bind` fails fast as usual. Shift remains a distinct modifier for
+non-character keys (`Shift+Enter`). `Shift`+`Tab` folds to the distinct
+`BackTab` key terminals report. `Chord::from_key` drops any separately reported
+Shift flag from character events because its effect is already present in the
+character. Parsed bindings and live events therefore share one layout-neutral
+identity.
 
 ## Modes: layers gated on runtime data
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-08-01
 
+- **Character key bindings use logical text**
+
+- Keymap character specs now name the exact Unicode result after keyboard
+  layout (`A`, `?`, `ctrl+R`) and reject layout-dependent
+  `shift+character` spellings; non-character Shift chords remain explicit.
+
 - **Monotonic time is injectable**
 
 - `Clock` gives gesture recognition and synchronous runner scheduling one

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -162,6 +162,12 @@ native console events already include modifier state. Everything above that
 boundary — the keymap engine, focus routing, component handlers — consumes only
 tuika types, which is what lets all of it be unit-tested without a PTY.
 
+Character key codes are logical Unicode text produced by the active keyboard
+layout, never physical key positions. Keymap character specs use that exact
+text (`A`, `?`, `ctrl+R`) and reject `shift+character`, whose result depends on
+layout; Shift remains independently matchable for non-character keys. This
+keeps input editing and command bindings on the same layout-neutral identity.
+
 Focus is a registry of scopes rather than a flag per component: a `FocusScope`
 claims input ownership for its subtree, so a modal or overlay can take input
 without every component learning about modality. At each frame boundary the

--- a/knowledge/specs/keymap.md
+++ b/knowledge/specs/keymap.md
@@ -25,9 +25,11 @@ A host-agnostic engine (`tuika::keymap`) that resolves declared key bindings to
 named command values:
 
 - **Chords and sequences.** A `Chord` is one key press plus modifiers, parsed
-  from a string (`ctrl+r`, `alt+shift+tab`, `?`, `space`, literal `ctrl++`). A
-  `KeySequence` is one or more chords typed in order, written space-separated
-  (`g g`, `ctrl+x s`), so multi-stroke bindings are first-class.
+  from a string (`ctrl+r`, `alt+shift+tab`, `?`, `A`, `space`, literal
+  `ctrl++`). Character tokens are exact logical text produced by the active
+  layout. A `KeySequence` is one or more chords typed in order, written
+  space-separated (`g g`, `ctrl+x s`), so multi-stroke bindings are
+  first-class.
 - **Layers.** Bindings are grouped into named, prioritized `Layer`s. A layer may
   be *gated* on runtime data (`when("mode", "panel")`) so it is active only in a
   given application mode; an ungated layer is always active. When two active
@@ -48,14 +50,19 @@ engine free of terminal I/O, so it is unit-testable without a PTY: the same
 boundary that lets the rest of the widget layer be tested against synthetic
 events.
 
-### Modifier normalization mirrors how terminals report input
+### Character bindings are logical text
 
 Matching is on a normalized `Chord`, so a binding matches the event a terminal
 actually delivers:
 
-- For a character key, Shift is folded into the character itself (`?` arrives as
-  `Char('?')`, not `Shift`+`Char('/')`), so the `shift` flag is dropped for
-  characters and kept meaningful only for non-character keys (`Shift`+`Enter`).
+- A character key is the exact Unicode character produced by the active
+  keyboard layout (`?` arrives as `Char('?')`, not `Shift`+`Char('/')`). A
+  binding spells that result directly (`?`, `A`, `ctrl+R`) rather than guessing
+  a physical Shift combination. This keeps bindings portable across layouts.
+- A `shift+character` spec is rejected because its result is layout policy;
+  Shift is kept meaningful for non-character keys (`Shift+Enter`). A translated
+  character event's Shift flag is dropped because its effect is already present
+  in the logical character.
 - `Shift`+`Tab` folds to the distinct `BackTab` key that terminals report.
 
 Both the string parser and `Chord::from_key` apply the same normalization, so a
@@ -73,12 +80,13 @@ is retried on its own so it can begin a fresh sequence. Changing runtime data
 clears the pending buffer, since the bindings that could complete it may no
 longer be active.
 
-### Bindings are static, so parse errors panic by construction
+### Static binding parse errors fail fast
 
-`Layer::bind` panics on a malformed key spec, because bindings are authored as
-static literals — a bad spec is a programmer error caught on first run, like a
-malformed regex literal. `Chord::parse` / `Layer::try_bind` return a `Result` for
-the rare dynamic case (config-sourced bindings).
+`Layer::bind` panics on a malformed or layout-dependent key spec, because
+bindings are authored as static literals — a bad spec is a programmer error
+caught on first run, like a malformed regex literal. `Chord::parse` /
+`Layer::try_bind` return a `Result` for the rare dynamic case (config-sourced
+bindings), including an explanation for rejected `shift+character` input.
 
 ### Precedence is the host's to choose
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -26,7 +26,7 @@ pub enum Event {
 /// A key press with its modifier state.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Key {
-    /// The key that was pressed.
+    /// The logical key value that was pressed.
     pub code: KeyCode,
     /// Ctrl held during the press.
     pub ctrl: bool,
@@ -54,10 +54,14 @@ impl Key {
     }
 }
 
-/// A physical/logical key, independent of modifier state.
+/// A logical key value, independent of the separately reported modifier state.
+///
+/// Character codes describe the text produced by the active keyboard layout,
+/// not a physical key position. This keeps text input and character bindings
+/// portable across layouts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum KeyCode {
-    /// A printable character.
+    /// The logical Unicode character produced by the key press.
     Char(char),
     /// Enter/Return.
     Enter,

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -14,6 +14,8 @@
 //! # Model
 //!
 //! - A [`Chord`] is one key press plus its modifiers (`ctrl+r`, `enter`, `?`).
+//!   Character tokens are exact logical text after keyboard-layout translation;
+//!   Shift is written separately only for non-character keys.
 //! - A [`KeySequence`] is one or more chords typed in order (`g g`, `ctrl+x s`).
 //! - A [`Binding`] maps a sequence to a command value `C` (usually an app enum).
 //! - A [`Layer`] groups bindings under a name and priority, optionally *gated*
@@ -55,10 +57,10 @@ use crate::event::{Key, KeyCode};
 
 /// One key press plus its modifier state, normalized for binding lookups.
 ///
-/// Modifier state is explicit, but with one normalization that mirrors how
-/// terminals report input: for a [`KeyCode::Char`] the Shift flag is *dropped*,
-/// because the shifted character is already folded into the `char` itself (`?`
-/// arrives as `Char('?')`, not `Shift`+`Char('/')`). Shift is kept meaningful
+/// Modifier state is explicit, but character codes are exact logical text from
+/// the active keyboard layout. For a [`KeyCode::Char`] the Shift flag is
+/// *dropped*, because its effect is already folded into the character (`?`
+/// arrives as `Char('?')`, not `Shift`+`Char('/')`). Shift remains meaningful
 /// for non-character keys, where it is a distinct chord (`Shift`+`Enter`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Chord {
@@ -103,6 +105,11 @@ impl Chord {
     /// `"?"`. Modifiers (`ctrl`/`control`, `alt`/`option`, `shift`) are joined to
     /// the key with `+`; the final segment is the key. A trailing `+` is the
     /// literal plus key (`"ctrl++"`).
+    ///
+    /// Character tokens are exact logical text. Spell a shifted character as
+    /// the character it produces (`"A"`, `"?"`, `"ctrl+R"`), not as
+    /// `"shift+a"` or `"shift+/"`: translating a physical key through Shift is
+    /// keyboard-layout policy and therefore cannot be parsed portably here.
     pub fn parse(spec: &str) -> Result<Self, KeyParseError> {
         let spec = spec.trim();
         if spec.is_empty() {
@@ -132,9 +139,8 @@ impl Chord {
 
         let key_token = key_token.ok_or_else(|| KeyParseError::new(spec))?;
         let mut code = parse_key_code(key_token).ok_or_else(|| KeyParseError::new(spec))?;
-        // A character key folds Shift into the char, matching `from_key`.
-        if matches!(code, KeyCode::Char(_)) {
-            shift = false;
+        if matches!(code, KeyCode::Char(_)) && shift {
+            return Err(KeyParseError::shifted_character(spec));
         }
         // Terminals report Shift+Tab as a distinct `BackTab` key (as does
         // `from_key`), so fold the spec to match what an event will carry.
@@ -163,6 +169,11 @@ impl Chord {
         if self.shift {
             out.push_str("Shift+");
         }
+        // Preserve the established keycap-style label for lowercase ASCII
+        // bindings while keeping an uppercase logical binding distinguishable.
+        if !self.shift && matches!(self.code, KeyCode::Char(c) if c.is_ascii_uppercase()) {
+            out.push_str("Shift+");
+        }
         out.push_str(&key_code_label(self.code));
         out
     }
@@ -188,6 +199,9 @@ fn parse_key_code(token: &str) -> Option<KeyCode> {
     // A single character (including a literal "+") is a `Char`, case-sensitive.
     let mut chars = token.chars();
     if let (Some(c), None) = (chars.next(), chars.next()) {
+        if c.is_control() {
+            return None;
+        }
         return Some(KeyCode::Char(c));
     }
     Some(match token.to_ascii_lowercase().as_str() {
@@ -233,23 +247,45 @@ fn key_code_label(code: KeyCode) -> String {
     }
 }
 
-/// A parse failure for a chord or sequence spec, carrying the offending text.
+/// A parse failure for a chord or sequence spec, carrying the offending text
+/// and, for layout-dependent character input, an explanatory reason.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyParseError {
     spec: String,
+    kind: KeyParseErrorKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KeyParseErrorKind {
+    Invalid,
+    ShiftedCharacter,
 }
 
 impl KeyParseError {
     fn new(spec: &str) -> Self {
         Self {
             spec: spec.to_string(),
+            kind: KeyParseErrorKind::Invalid,
+        }
+    }
+
+    fn shifted_character(spec: &str) -> Self {
+        Self {
+            spec: spec.to_string(),
+            kind: KeyParseErrorKind::ShiftedCharacter,
         }
     }
 }
 
 impl fmt::Display for KeyParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "invalid key spec: {:?}", self.spec)
+        write!(f, "invalid key spec: {:?}", self.spec)?;
+        if self.kind == KeyParseErrorKind::ShiftedCharacter {
+            f.write_str(
+                ": character keys are logical text; use the resulting character instead of Shift",
+            )?;
+        }
+        Ok(())
     }
 }
 
@@ -631,15 +667,25 @@ mod tests {
     }
 
     #[test]
-    fn char_chords_ignore_shift() {
-        // Shift is folded into the character, so a bare '?' never carries it.
-        assert!(!Chord::parse("shift+?").unwrap().shift);
+    fn character_chords_are_exact_logical_text() {
+        let error = Chord::parse("shift+/").unwrap_err();
+        assert!(error.to_string().contains("logical text"));
+        assert!(Chord::parse("shift+a").is_err());
+        assert!(Chord::parse("shift+space").is_err());
+
+        assert_eq!(Chord::parse("?").unwrap().code, KeyCode::Char('?'));
+        assert_eq!(Chord::parse("ж").unwrap().code, KeyCode::Char('ж'));
+        assert_ne!(Chord::parse("r").unwrap(), Chord::parse("R").unwrap());
+
+        // Translated events already contain the resulting character; an
+        // independently reported Shift flag is not part of a text chord.
         let from = Chord::from_key(Key {
-            code: KeyCode::Char('?'),
+            code: KeyCode::Char('R'),
             ctrl: false,
             alt: false,
             shift: true,
         });
+        assert_eq!(from.code, KeyCode::Char('R'));
         assert!(!from.shift);
     }
 
@@ -647,12 +693,15 @@ mod tests {
     fn rejects_garbage_specs() {
         assert!(Chord::parse("").is_err());
         assert!(Chord::parse("bogus+r").is_err());
+        assert!(Chord::parse("\u{1b}").is_err());
+        assert!(Chord::parse("\u{7}").is_err());
         assert!(KeySequence::parse("   ").is_err());
     }
 
     #[test]
     fn display_is_human_readable() {
         assert_eq!(Chord::parse("ctrl+r").unwrap().display(), "Ctrl+R");
+        assert_eq!(Chord::parse("ctrl+R").unwrap().display(), "Ctrl+Shift+R");
         assert_eq!(Chord::parse("space").unwrap().display(), "Space");
         assert_eq!(Chord::parse("enter").unwrap().display(), "Enter");
         assert_eq!(
@@ -674,6 +723,28 @@ mod tests {
         );
         assert_eq!(keymap.dispatch(ctrl('d')), Dispatch::Command(Action::Quit));
         assert_eq!(keymap.dispatch(ctrl('z')), Dispatch::Unmatched);
+    }
+
+    #[test]
+    fn dispatch_distinguishes_logical_character_case() {
+        let mut keymap = Keymap::new().layer(
+            Layer::new("global")
+                .bind("ctrl+r", Action::Search)
+                .bind("ctrl+R", Action::Close),
+        );
+        assert_eq!(
+            keymap.dispatch(Key {
+                code: KeyCode::Char('R'),
+                ctrl: true,
+                alt: false,
+                shift: true,
+            }),
+            Dispatch::Command(Action::Close)
+        );
+        assert_eq!(
+            keymap.dispatch(ctrl('r')),
+            Dispatch::Command(Action::Search)
+        );
     }
 
     #[test]

--- a/tests/logical_key_bindings.rs
+++ b/tests/logical_key_bindings.rs
@@ -1,0 +1,58 @@
+use tuika::event::{Key, KeyCode};
+use tuika::keymap::{Dispatch, Keymap, Layer};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Action {
+    Lower,
+    Upper,
+}
+
+#[test]
+fn public_keymap_matches_exact_layout_translated_characters() {
+    let mut keymap = Keymap::new().layer(
+        Layer::new("global")
+            .bind("ctrl+r", Action::Lower)
+            .bind("ctrl+R", Action::Upper),
+    );
+
+    let shifted = Key {
+        code: KeyCode::Char('R'),
+        ctrl: true,
+        alt: false,
+        // Some hosts retain this bit and some enhanced protocols fold it into
+        // the character. Both normalize to the same logical-text chord.
+        shift: true,
+    };
+    assert_eq!(keymap.dispatch(shifted), Dispatch::Command(Action::Upper));
+    assert_eq!(
+        keymap.dispatch(Key {
+            code: KeyCode::Char('r'),
+            ctrl: true,
+            alt: false,
+            shift: false,
+        }),
+        Dispatch::Command(Action::Lower)
+    );
+
+    let hints = keymap.hints();
+    assert_eq!(hints[0].keys, "Ctrl+R");
+    assert_eq!(hints[1].keys, "Ctrl+Shift+R");
+}
+
+#[test]
+fn physical_shift_character_specs_fail_fallibly() {
+    let error = Layer::new("global")
+        .try_bind("shift+/", Action::Upper)
+        .unwrap_err();
+    assert!(error.to_string().contains("logical text"));
+
+    // The logical result is portable and parses directly, including Unicode.
+    assert!(Layer::new("global").try_bind("?", Action::Upper).is_ok());
+    assert!(Layer::new("global").try_bind("ж", Action::Upper).is_ok());
+    // Shift remains a real modifier for non-character keys.
+    assert!(
+        Layer::new("global")
+            .try_bind("shift+enter", Action::Upper)
+            .is_ok()
+    );
+}


### PR DESCRIPTION
## What changed

Character key bindings now use one explicit, layout-neutral contract: the exact logical Unicode character delivered after keyboard-layout translation. Bind `A`, `?`, `ж`, or `ctrl+R` directly; Shift remains a modifier for non-character keys such as `shift+enter`.

Layout-dependent `shift+character` specs now return a descriptive `KeyParseError` through fallible APIs and fail fast through static `Layer::bind`. Lowercase and shifted logical character bindings dispatch separately, and help labels distinguish `Ctrl+R` from `Ctrl+Shift+R`. Control-character specs are rejected before they can enter help rendering.

## Why

The previous parser accepted `shift+a` and silently discarded Shift. The resulting chord was lowercase `a`, so it could not match the logical uppercase `A` delivered by enhanced terminal input. Guessing Shift mappings for punctuation would also hard-code a keyboard layout.

## Before / After

Before: `shift+a` parsed successfully as plain `a`, and `ctrl+r` and `ctrl+R` produced the same help label.

After: physical-style character specs fail with an actionable error; exact logical characters match predictably across layouts, Unicode is covered, and distinct case is visible in generated hints. The key-hint example rendered and restored in a real terminal.

## Risk

- Medium
- This deliberately breaks ambiguous `shift+character` configuration. Existing lowercase bindings and every non-character Shift binding are unchanged. The changelog and keymap guide provide the migration.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated the keymap and architecture specifications plus the durable knowledge log.

## Security

Reviewed parsing, terminal, rendering, denial-of-service, dependency, unsafe, and I/O surfaces. Parsing remains linear and bounded by the provided spec; error formatting escapes input; raw control-character specs are rejected before discoverable hints can render them. No dependency, unsafe code, terminal decoder, or external I/O was added.

## Follow-ups

No follow-ups.