### PR TITLE
test(pty): avoid late palette reply

### DIFF
--- a/tests/pty_palette.rs
+++ b/tests/pty_palette.rs
@@ -169,7 +169,11 @@ fn run_inherit(args: &[&str], answer: Option<Vec<u8>>) -> Run {
 
 #[test]
 fn the_probe_asks_for_the_palette_and_fences_with_device_attributes() {
-    let run = run_inherit(&["--probe"], Some(replies()));
+    // This test only observes the emitted query bytes. Do not race an unused
+    // reply against the short probe timeout: on macOS, writing after the child
+    // closes the pty slave reports EIO. Reply parsing and fence preservation
+    // are exercised by the dedicated tests below.
+    let run = run_inherit(&["--probe"], None);
     let bytes = &run.output;
     let has = |needle: &[u8]| bytes.windows(needle.len()).any(|w| w == needle);
 


### PR DESCRIPTION
## Summary

- stop sending an unused palette reply in the query-emission-only PTY test
- retain all OSC 10/11/4 and device-attributes fence assertions
- leave reply parsing and fence preservation covered by their dedicated tests

## Why

The post-merge macOS CI run for #61 exposed a test-harness race: the short probe can close the PTY slave after emitting its final query but before the harness writes a reply that this test never consumes. macOS reports that late master write as `EIO`, while Linux commonly accepts it.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- built the `inherit` example, then ran the affected test 25 consecutive times
- `cargo test --test pty_palette`

## API changes

No API changes. Test-harness-only repair.

## Knowledge and docs

No knowledge update required: terminal palette behavior is unchanged; this removes an unnecessary response from a query-observation test.

## Security

No production security-relevant code changes. Protocol assertions remain intact, and the reply parsing tests are unchanged.

## Follow-ups

No follow-ups.

Produced by [yolop](https://everruns.com/yolop)
