### PR TITLE
feat(markdown): unify structured block renderers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ repository, so keep it short, factual, and project-specific.
 
 This is a small Cargo **workspace**: the root package is the `tuika` library;
 `crates/tuika-codeformatters/` is the tree-sitter `Highlighter`,
-`crates/tuika-mermaid/` is the mmdflux `FencedBlockRenderer`, and
-`crates/tuika-html/` is the html5ever `HtmlBlockRenderer` (plus its own `Html`
+`crates/tuika-mermaid/` is the mmdflux `MarkdownBlockRenderer`, and
+`crates/tuika-html/` is the html5ever `MarkdownBlockRenderer` (plus its own `Html`
 view). All three are published separately so tuika core stays grammar-,
 diagram-engine-, and HTML-parser-free.
 Cargo defaults to the root package only, so pass `--workspace` to cover the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,20 +55,17 @@ block-HTML seam.
   parser: this is a fixed tag whitelist, so anything outside it — block-level
   HTML, `<script>`, unlisted attributes — is dropped as before, and never echoed
   as literal markup.
-- **`HtmlBlockRenderer`, the block-HTML seam.** Raw block-level HTML
-  (`<details>`, `<table>`, `<div>`) is handed to a host-supplied renderer with
-  the source, the available width, the theme, and the active `StyleSheet`;
-  returning `None` drops the block, which is the previous behavior. The parser
-  stays out of tuika — [`tuika-html`](https://crates.io/crates/tuika-html) is
-  the ready-made implementation. Reachable as `Markdown::html_renderer`,
-  `MarkdownState::with_html_renderer`, and `markdown::Renderers`.
+- **One structured markdown block seam.** `MarkdownBlockRenderer` receives a
+  non-exhaustive `MarkdownBlock` descriptor (`Fenced` or `Html`) and a shared
+  `MarkdownBlockContext` containing width, theme, and the active stylesheet.
+  `Markdown::block_renderer` and `MarkdownState::with_block_renderer` append to
+  an ordered renderer chain, so Mermaid, HTML, and host-defined block parsers
+  compose without adding another trait or field for every syntax.
 - `tuika-html` bounds nesting on the source before parsing, so a fragment deep
   enough to overflow html5ever's recursive tree building is refused rather than
   crashing the host.
-- **`markdown::Renderers`** bundles the fenced-block and HTML-block seams into
-  one value, with `markdown::to_lines_with` / `to_linked_lines_with` taking it.
-  The existing `to_lines_with_renderer` / `to_linked_lines_with_renderer` are
-  unchanged.
+- **`markdown::Renderers`** builds the same ordered block-renderer chain for
+  `markdown::to_lines_with` / `to_linked_lines_with`.
 - `ProgressBar::label` draws a centered, clipped caption over determinate and
   indeterminate bars.
 - `Scroll::wrap(true)` reflows owned styled lines at render width before
@@ -90,6 +87,12 @@ block-HTML seam.
 
 ### Changed
 
+- **Breaking:** `FencedBlockRenderer` and `HtmlBlockRenderer` are replaced by
+  `MarkdownBlockRenderer`. Match on `MarkdownBlock`, read width/theme/sheet from
+  `MarkdownBlockContext`, register every implementation through
+  `block_renderer`, and build free-function chains with
+  `Renderers::new().renderer(&first).renderer(&second)`. HTML fences now receive
+  the host's active stylesheet instead of synthesizing theme defaults.
 - **Breaking:** keymap character specs are now explicitly logical text. Write
   the character produced by the active layout (`A`, `?`, `ctrl+R`) rather than
   `shift+a` or `shift+/`; `Shift` remains valid for non-character chords such as

--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ crates. The companion crate
 [`tuika-codeformatters`](https://crates.io/crates/tuika-codeformatters) ships a
 ready-made tree-sitter `Highlighter`.
 
-Fenced blocks can replace their source with a different, width-aware
-presentation through `FencedBlockRenderer`. The
+Structured blocks can replace their source with a different, width-aware
+presentation through `MarkdownBlockRenderer`. The
 [`tuika-mermaid`](crates/tuika-mermaid/) companion uses that seam with mmdflux:
 a `mermaid` fence becomes a Unicode cell diagram inside the surrounding
 Markdown, with no browser, SVG, or image protocol. Unsupported or invalid input
@@ -417,8 +417,10 @@ Markdown in the wild carries HTML. The presentational inline tags — `<b>`,
 `<em>`, `<code>`, `<kbd>`, `<mark>`, `<a>`, `<br>`, `<sub>`/`<sup>` — render in
 tuika itself, each through the same `StyleSheet` role as the markdown it
 mirrors. Block-level HTML is a seam, for the same reason highlighting is: an
-HTML parser is a dependency tuika will not carry. Attach an `HtmlBlockRenderer`
-and `<details>`, `<table>`, and `<div>` lay out too.
+HTML parser is a dependency tuika will not carry. Attach a
+`MarkdownBlockRenderer` and `<details>`, `<table>`, and `<div>` lay out too. The
+same ordered renderer chain handles fenced diagrams and block HTML with one
+context, including the active stylesheet.
 [`tuika-html`](crates/tuika-html/) is the ready-made one, and it also supplies
 the [`Html`](docs/components.md#html) component for markup that is not inside
 markdown at all. See the markdown guide for
@@ -860,8 +862,8 @@ The separately published companion crates live in this repository:
 - [`tuika-mermaid`](crates/tuika-mermaid/) renders Mermaid fences as Unicode
   terminal diagrams through mmdflux.
 - [`tuika-html`](crates/tuika-html/) lays out block-level HTML with html5ever —
-  inside Markdown through the `HtmlBlockRenderer` seam, or standalone through
-  its own [`Html`](docs/components.md#html) component.
+  inside Markdown through the `MarkdownBlockRenderer` seam, or standalone
+  through its own [`Html`](docs/components.md#html) component.
 
 All three keep their heavier parsers and grammars out of tuika core.
 

--- a/crates/tuika-html/Cargo.toml
+++ b/crates/tuika-html/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["command-line-interface", "text-processing"]
 [dependencies]
 # This requirement tracks the *published* tuika, so it stays at the in-tree
 # version and is bumped by the release that carries the seam this crate
-# implements — `HtmlBlockRenderer` does not exist in 0.6.0, so tuika-html cannot
+# implements — `MarkdownBlockRenderer` does not exist in 0.6.0, so tuika-html cannot
 # be published until then. `publish_order.py` already publishes tuika first, and
 # the release process owns the bump; see `knowledge/processes/release.md`.
 tuika = { version = "0.6.0", path = "../.." }

--- a/crates/tuika-html/README.md
+++ b/crates/tuika-html/README.md
@@ -9,9 +9,9 @@ crate exists separately.
 
 ## In Markdown
 
-`HtmlRenderer` implements both of tuika's markdown seams: `HtmlBlockRenderer`
-for raw `<details>` / `<table>` / `<div>` blocks, and `FencedBlockRenderer` for
-` ```html ` fences.
+`HtmlRenderer` implements tuika's `MarkdownBlockRenderer` seam. One value
+handles raw `<details>` / `<table>` / `<div>` blocks and ` ```html ` fences,
+using the same active stylesheet for both.
 
 ```rust
 use tuika::components::Markdown;
@@ -19,7 +19,6 @@ use tuika_html::HtmlRenderer;
 
 let html = HtmlRenderer::new();
 let document = Markdown::new("<details><summary>Notes</summary>Body</details>")
-    .html_renderer(&html)
     .block_renderer(&html);
 # let _ = document;
 ```

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -41,7 +41,7 @@ impl View for Padded {
             height: area.height.saturating_sub(2),
         };
         Markdown::new(DOCUMENT)
-            .html_renderer(&html)
+            .block_renderer(&html)
             .render(inner, surface, ctx);
     }
 }

--- a/crates/tuika-html/src/lib.rs
+++ b/crates/tuika-html/src/lib.rs
@@ -2,11 +2,9 @@
 //!
 //! Two ways in, one engine behind both:
 //!
-//! - [`HtmlRenderer`] plugs into markdown. It implements tuika's
-//!   [`HtmlBlockRenderer`] seam, so raw `<details>`, `<table>`, and `<div>`
-//!   blocks inside a markdown document lay out instead of being dropped — and
-//!   [`FencedBlockRenderer`], so a ` ```html ` fence renders rather than showing
-//!   its source.
+//! - [`HtmlRenderer`] plugs into markdown through tuika's
+//!   [`MarkdownBlockRenderer`] seam. One implementation handles raw `<details>`,
+//!   `<table>`, and `<div>` blocks as well as ` ```html ` fences.
 //! - [`Html`] is a `View`, the standalone viewer: hand it a fragment, place it
 //!   in a layout, and it paints like [`Markdown`](tuika::components::Markdown)
 //!   does.
@@ -18,7 +16,7 @@
 //! // In markdown:
 //! let renderer = HtmlRenderer::new();
 //! let doc = Markdown::new("<details><summary>Notes</summary>Body</details>")
-//!     .html_renderer(&renderer);
+//!     .block_renderer(&renderer);
 //!
 //! // Standalone:
 //! let view = Html::new("<h1>Title</h1><p>Prose with <b>bold</b>.</p>");
@@ -56,13 +54,12 @@
 //! markup overflows the stack inside the size bound. No network is touched:
 //! `<img>` becomes its alt text, never a fetch.
 //!
-//! [`FencedBlockRenderer`]: tuika::components::FencedBlockRenderer
-//! [`HtmlBlockRenderer`]: tuika::components::HtmlBlockRenderer
+//! [`MarkdownBlockRenderer`]: tuika::components::MarkdownBlockRenderer
 //! [`StyleSheet`]: tuika::style::StyleSheet
 
 use ratatui_core::text::Line;
 use tuika::Theme;
-use tuika::components::{FencedBlockRenderer, HtmlBlockRenderer};
+use tuika::components::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
 use tuika::style::StyleSheet;
 
 mod block;
@@ -102,13 +99,10 @@ impl Default for Limits {
     }
 }
 
-/// Renders HTML for tuika's markdown seams.
+/// Renders HTML for tuika's structured markdown block seam.
 ///
-/// One value serves both: attach it with
-/// [`Markdown::html_renderer`](tuika::components::Markdown::html_renderer) for raw
-/// block HTML, and with
-/// [`Markdown::block_renderer`](tuika::components::Markdown::block_renderer) for
-/// ` ```html ` fences.
+/// One value serves both raw block HTML and ` ```html ` fences. Attach it with
+/// [`Markdown::block_renderer`](tuika::components::Markdown::block_renderer).
 ///
 /// ```
 /// use tuika::prelude::*;
@@ -116,7 +110,6 @@ impl Default for Limits {
 ///
 /// let renderer = HtmlRenderer::new();
 /// let doc = Markdown::new("<ul><li>one</li><li>two</li></ul>")
-///     .html_renderer(&renderer)
 ///     .block_renderer(&renderer);
 /// # let _ = doc;
 /// ```
@@ -146,40 +139,32 @@ impl HtmlRenderer {
     }
 }
 
-impl HtmlBlockRenderer for HtmlRenderer {
+impl MarkdownBlockRenderer for HtmlRenderer {
     fn render(
         &self,
-        source: &str,
-        width: u16,
-        theme: &Theme,
-        sheet: &StyleSheet,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
     ) -> Option<Vec<Line<'static>>> {
-        let lines = to_lines_with_limits(source, width, theme, sheet, self.limits)?;
-        // An empty result would silently swallow the block; let markdown's own
-        // "no renderer" path own that case instead.
-        (!lines.is_empty()).then_some(lines)
-    }
-}
-
-impl FencedBlockRenderer for HtmlRenderer {
-    fn render(
-        &self,
-        language: &str,
-        source: &str,
-        width: u16,
-        theme: &Theme,
-    ) -> Option<Vec<Line<'static>>> {
-        if !matches!(
-            language.to_ascii_lowercase().as_str(),
-            "html" | "htm" | "xhtml"
-        ) {
-            return None;
-        }
-        // A fence carries no stylesheet through the seam, so the theme's own
-        // default mapping stands in — the same styles a host that never
-        // customized its sheet would see.
-        let sheet = StyleSheet::from_theme(theme);
-        let lines = to_lines_with_limits(source, width, theme, &sheet, self.limits)?;
+        let source = match block {
+            MarkdownBlock::Html { source } => source,
+            MarkdownBlock::Fenced { language, source }
+                if matches!(
+                    language.to_ascii_lowercase().as_str(),
+                    "html" | "htm" | "xhtml"
+                ) =>
+            {
+                source
+            }
+            _ => return None,
+        };
+        let lines = to_lines_with_limits(
+            source,
+            context.width,
+            context.theme,
+            context.sheet,
+            self.limits,
+        )?;
+        // An empty result would silently swallow a fence's visible fallback.
         (!lines.is_empty()).then_some(lines)
     }
 }
@@ -453,22 +438,49 @@ mod tests {
     }
 
     #[test]
-    fn the_renderer_serves_both_markdown_seams() {
+    fn one_renderer_serves_both_markdown_block_kinds() {
         let theme = Theme::default();
         let sheet = StyleSheet::from_theme(&theme);
         let renderer = HtmlRenderer::new();
+        let context = MarkdownBlockContext::new(20, &theme, &sheet);
 
-        let block = HtmlBlockRenderer::render(&renderer, "<p>hi</p>", 20, &theme, &sheet);
+        let block = renderer.render(
+            MarkdownBlock::Html {
+                source: "<p>hi</p>",
+            },
+            context,
+        );
         assert!(block.is_some());
-        let fence = FencedBlockRenderer::render(&renderer, "html", "<p>hi</p>", 20, &theme);
+        let fence = renderer.render(
+            MarkdownBlock::Fenced {
+                language: "html",
+                source: "<p>hi</p>",
+            },
+            context,
+        );
         assert!(fence.is_some());
         // Other languages stay with markdown's code-block presentation.
         assert!(
-            FencedBlockRenderer::render(&renderer, "rust", "fn main() {}", 20, &theme).is_none()
+            renderer
+                .render(
+                    MarkdownBlock::Fenced {
+                        language: "rust",
+                        source: "fn main() {}",
+                    },
+                    context,
+                )
+                .is_none()
         );
         // Nothing to show is `None`, so markdown's own drop path handles it.
         assert!(
-            HtmlBlockRenderer::render(&renderer, "<!-- note -->", 20, &theme, &sheet).is_none()
+            renderer
+                .render(
+                    MarkdownBlock::Html {
+                        source: "<!-- note -->",
+                    },
+                    context,
+                )
+                .is_none()
         );
     }
 }

--- a/crates/tuika-mermaid/README.md
+++ b/crates/tuika-mermaid/README.md
@@ -2,9 +2,9 @@
 
 Terminal-native Mermaid diagrams inside
 [`tuika`](https://crates.io/crates/tuika) Markdown. The crate adapts
-[`mmdflux`](https://crates.io/crates/mmdflux) to tuika's generic fenced-block
-renderer seam; diagrams are Unicode cells, not images, and require no browser or
-JavaScript runtime.
+[`mmdflux`](https://crates.io/crates/mmdflux) to tuika's generic
+`MarkdownBlockRenderer` seam; diagrams are Unicode cells, not images, and
+require no browser or JavaScript runtime.
 
 ```rust
 use tuika::components::Markdown;

--- a/crates/tuika-mermaid/src/lib.rs
+++ b/crates/tuika-mermaid/src/lib.rs
@@ -2,7 +2,7 @@
 //! [`tuika::components::Markdown`].
 //!
 //! [`MermaidRenderer`] adapts mmdflux's Unicode text output to tuika's generic
-//! [`FencedBlockRenderer`] seam. It
+//! [`MarkdownBlockRenderer`] seam. It
 //! handles `mermaid` fences and returns `None` for every other language or for
 //! Mermaid input mmdflux cannot render, preserving tuika's ordinary code-block
 //! fallback.
@@ -11,7 +11,7 @@ use mmdflux::{OutputFormat, RenderConfig, TextColorMode, render_diagram};
 use ratatui_core::style::Style;
 use ratatui_core::text::{Line, Span};
 use tuika::Theme;
-use tuika::components::FencedBlockRenderer;
+use tuika::components::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
 
 /// Upper bound for one Mermaid fence handed to mmdflux.
 const MAX_SOURCE_BYTES: usize = 64 * 1024;
@@ -32,14 +32,15 @@ impl MermaidRenderer {
     }
 }
 
-impl FencedBlockRenderer for MermaidRenderer {
+impl MarkdownBlockRenderer for MermaidRenderer {
     fn render(
         &self,
-        language: &str,
-        source: &str,
-        _width: u16,
-        theme: &Theme,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
     ) -> Option<Vec<Line<'static>>> {
+        let MarkdownBlock::Fenced { language, source } = block else {
+            return None;
+        };
         if !language.eq_ignore_ascii_case("mermaid") {
             return None;
         }
@@ -58,7 +59,7 @@ impl FencedBlockRenderer for MermaidRenderer {
         Some(
             rendered
                 .lines()
-                .map(|line| styled_line(line, theme))
+                .map(|line| styled_line(line, context.theme))
                 .collect(),
         )
     }
@@ -109,6 +110,7 @@ fn diagram_glyph(ch: char) -> bool {
 mod tests {
     use super::*;
     use tuika::components::Markdown;
+    use tuika::style::StyleSheet;
     use tuika::testing::{grid, render};
 
     fn text(line: &Line) -> String {
@@ -116,6 +118,16 @@ mod tests {
             .iter()
             .map(|span| span.content.as_ref())
             .collect()
+    }
+
+    fn render_block(block: MarkdownBlock<'_>) -> Option<Vec<Line<'static>>> {
+        let theme = Theme::default();
+        let sheet = StyleSheet::from_theme(&theme);
+        MarkdownBlockRenderer::render(
+            &MermaidRenderer::new(),
+            block,
+            MarkdownBlockContext::new(80, &theme, &sheet),
+        )
     }
 
     #[test]
@@ -138,18 +150,22 @@ mod tests {
     #[test]
     fn ignores_other_fence_languages() {
         assert!(
-            MermaidRenderer::new()
-                .render("rust", "fn main() {}", 80, &Theme::default())
-                .is_none()
+            render_block(MarkdownBlock::Fenced {
+                language: "rust",
+                source: "fn main() {}",
+            })
+            .is_none()
         );
     }
 
     #[test]
     fn invalid_mermaid_uses_markdown_fallback() {
         assert!(
-            MermaidRenderer::new()
-                .render("mermaid", "this is not Mermaid", 80, &Theme::default())
-                .is_none()
+            render_block(MarkdownBlock::Fenced {
+                language: "mermaid",
+                source: "this is not Mermaid",
+            })
+            .is_none()
         );
     }
 
@@ -157,9 +173,11 @@ mod tests {
     fn oversized_source_uses_markdown_fallback() {
         let oversized = "x".repeat(MAX_SOURCE_BYTES + 1);
         assert!(
-            MermaidRenderer::new()
-                .render("mermaid", &oversized, 80, &Theme::default())
-                .is_none()
+            render_block(MarkdownBlock::Fenced {
+                language: "mermaid",
+                source: &oversized,
+            })
+            .is_none()
         );
     }
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -155,7 +155,7 @@ definition lists, block quotes, `<pre>`, `<hr>`, `<table>`,
 resolves a `StyleSheet` role, so HTML inherits the app's theme like everything
 else. No CSS — this renders content, not pages. Ships in the companion crate
 [`tuika-html`](../crates/tuika-html/), which also supplies the
-`HtmlBlockRenderer` that lays out HTML blocks inside
+`MarkdownBlockRenderer` that lays out HTML blocks inside
 [Markdown](markdown.md#block-html).
 [API](https://docs.rs/tuika-html/latest/tuika_html/struct.Html.html)
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -122,19 +122,19 @@ use tuika_html::HtmlRenderer;
 
 let html = HtmlRenderer::new();
 let doc = Markdown::new("<details><summary>Notes</summary>Body</details>")
-    .html_renderer(&html)
     .block_renderer(&html);
 # let _ = doc;
 ```
 
-A streaming host attaches it once, with
-`MarkdownState::with_html_renderer(Box::new(HtmlRenderer::new()))`; a settled
+A streaming host attaches it once with
+`MarkdownState::with_block_renderer(Box::new(HtmlRenderer::new()))`; a settled
 block is then laid out once per width, like a fenced block.
 
-Implementing the seam yourself means `HtmlBlockRenderer`: it receives the raw
-run, the available width, the theme, and the active `StyleSheet` — so headings,
-links, and code resolve the same roles the surrounding markdown does. Returning
-`None` drops the block.
+Implementing the seam yourself means `MarkdownBlockRenderer`: it receives a
+structured `MarkdownBlock` (`Fenced` or `Html`) and one `MarkdownBlockContext`
+with the available width, theme, and active `StyleSheet`. Returning `None`
+passes the block to the next registered renderer; if none handle it, a fence
+keeps its normal code fallback and raw HTML is dropped.
 
 One framing detail is worth knowing, because it looks like a bug: pulldown-cmark
 ends an HTML block at a blank line, so an element whose content is separated by
@@ -221,9 +221,9 @@ lexer implements the two-method trait instead.
 
 ## Mermaid diagrams
 
-`FencedBlockRenderer` can replace a language fence with terminal-native,
-width-aware lines. A renderer returns `None` for languages or inputs it does not
-handle, preserving the normal themed code block. The companion
+`MarkdownBlockRenderer` can replace a language fence with terminal-native,
+width-aware lines. A renderer returns `None` for block kinds, languages, or
+inputs it does not handle, preserving the normal themed code block. The companion
 [`tuika-mermaid`](https://crates.io/crates/tuika-mermaid) crate supplies an
 mmdflux-backed renderer for `mermaid` fences:
 

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -43,7 +43,7 @@ the reason for a decision is cheapest to write down while it is still at hand.
 
 ## Capabilities
 
-- [Markdown](specs/markdown.md) — CommonMark rendering, streaming, and the highlighter seam.
+- [Markdown](specs/markdown.md) — CommonMark rendering, streaming, highlighting, and structured block parsing.
 - [Images](specs/images.md) — terminal graphics protocols over reserved cells.
 - [Keymap](specs/keymap.md) — declarative key-binding dispatch.
 - [Styling](specs/styling.md) — themes as tokens, stylesheets as rules.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,14 @@
 
 ## 2026-08-01
 
+- **Markdown block parsing has one open contract**
+
+- Fenced diagrams and raw HTML now arrive as `MarkdownBlock` variants through
+  one `MarkdownBlockRenderer` trait and one width/theme/stylesheet context.
+- Renderer registration is an ordered chain in one-shot and streaming paths;
+  adding another parser-backed block no longer grows parallel component fields
+  and methods. HTML fences now inherit the active host stylesheet.
+
 - **Character key bindings use logical text**
 
 - Keymap character specs now name the exact Unicode result after keyboard

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -62,16 +62,15 @@ a trait the host implements:
 | Concern | tuika owns | Host owns |
 | --- | --- | --- |
 | Syntax highlighting | framing, background, gutter, wrapping (`CodeBlock`) | token spans, via `Highlighter` |
-| Rich fenced blocks | width-aware placement and code fallback (`Markdown`) | parsing and terminal-native rendering, via `FencedBlockRenderer` |
-| Block-level HTML | placement, indentation, and the drop fallback (`Markdown`) | parsing and layout, via `HtmlBlockRenderer` |
+| Structured markdown blocks | width-aware placement, indentation, renderer ordering, and kind-specific fallbacks (`Markdown`) | parsing and terminal-native rendering, via `MarkdownBlockRenderer` |
 | Images | protocol encoding, cell reservation, alt fallback | decoding bytes to RGBA, via `ImageResolver` |
 | Live data | reading shared state at render time | producing it, and requesting redraws |
 | Input | translation to tuika events, keymap dispatch | the event source and the command semantics |
 
 The companion crates exist because of this rule: `tuika-codeformatters`
 supplies tree-sitter grammars behind `Highlighter`, `tuika-mermaid` supplies
-mmdflux parsing and layout behind `FencedBlockRenderer`, and `tuika-html`
-supplies html5ever behind `HtmlBlockRenderer`. They are separately published
+mmdflux parsing and layout behind `MarkdownBlockRenderer`, and `tuika-html`
+supplies html5ever behind the same structured-block seam. They are separately published
 rather than optional tuika features so the core dependency tree cannot grow by
 accident.
 

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -86,23 +86,32 @@ means a host that renders no code pays nothing, and a host that renders code can
 choose its own highlighter. `tuika-codeformatters` is the batteries-included
 answer, published separately for exactly that reason.
 
-### Rich fenced blocks are a second seam
+### Structured blocks share one parsing seam
 
 Syntax highlighting must reconstruct the original source line-for-line, so it
 cannot express a fence whose presentation has a different shape than its source.
-`FencedBlockRenderer` handles that case: given the language, source, current
-width, and theme, it may replace the fence with styled lines. Returning `None`
-keeps the ordinary code-block fallback, so unsupported or malformed content
-never disappears.
+`MarkdownBlockRenderer` handles that case: it receives a structured
+`MarkdownBlock` descriptor plus one `MarkdownBlockContext` carrying width,
+theme, and the active stylesheet. Today the descriptor distinguishes fenced
+blocks from raw block HTML; it is non-exhaustive so another parser-backed block
+form does not require another parallel trait. Returning `None` tries the next
+renderer in registration order. If none handle a fence, the ordinary code-block
+fallback remains, so unsupported or malformed content never disappears.
 
 Parsed fenced blocks retain both their source and their already-highlighted
 fallback. Rendering happens during width-dependent flattening: settled blocks
 are rendered once per width, while an in-flight fence may be attempted on each
 streaming frame. Implementations therefore stay deterministic and avoid I/O.
-`tuika-mermaid` is the first companion implementation, keeping mmdflux and its
+`tuika-mermaid` is a companion implementation, keeping mmdflux and its
 diagram grammars outside tuika core. The adapter bounds source and output size,
 disables ANSI output, and strips control bytes before creating cells; a diagram
 fence is untrusted markdown, not permission to emit terminal commands.
+
+The chain is deliberately open rather than one field per syntax. A host can
+register Mermaid, HTML, and its own query-plan renderer in one ordered list;
+each implementation sees every structured block and declines the kinds it does
+not own. `Markdown` and `MarkdownState` both append renderers when their
+`block_renderer` builders are called repeatedly.
 
 ### Inline HTML is a whitelist, not a parser
 
@@ -133,20 +142,22 @@ text matched*.
 (`4ᵗh`) depends on which characters a word happens to use, which is a worse
 result than leaving the text alone.
 
-### Block HTML is a seam for the same reason highlighting is
+### Block HTML reuses the structured-block seam
 
 The presentational inline tags need no parser. Block HTML does — a tree builder
 that recovers implied end tags, inserts the `<tbody>` nobody wrote, and survives
-malformed input is exactly the dependency [goal.md](./goal.md) keeps out. So
-`HtmlBlockRenderer` takes the raw run, the available width, the theme, *and the
-stylesheet*: an implementation resolves the same roles the surrounding markdown
-does, or HTML in one document would look like it came from another. With no
-renderer attached the block is dropped, which is what markdown did with all HTML
-before the seam existed, so attaching one is purely additive.
+malformed input is exactly the dependency [goal.md](./goal.md) keeps out. Raw
+HTML is therefore the second `MarkdownBlock` variant, not a second trait. Its
+renderer receives the raw run through the same context as a fence, including
+the active stylesheet: headings and links resolve the same roles as the
+surrounding markdown. With no renderer attached the block is dropped, which is
+what markdown did with all HTML before the seam existed, so attaching one is
+purely additive.
 
 `tuika-html` is that implementation, and it is also where the line inside this
-capability shows: the same crate serves the fenced-`html` seam, and adds a
-standalone `Html` view for fragments that are not inside markdown at all.
+capability shows: the same renderer serves raw HTML and fenced `html` blocks
+without synthesizing a default stylesheet, and the crate adds a standalone
+`Html` view for fragments that are not inside markdown at all.
 
 One consequence of pulldown-cmark's framing is worth stating, because it looks
 like a bug: an HTML block ends at a blank line, so an element whose content is
@@ -181,8 +192,8 @@ host that restyles headings restyles them in markdown too. See
 
 - No HTML *document* rendering: no DOM, no CSS, no block-level HTML layout.
   Block HTML (`<div>`, `<details>`, `<table>`) is dropped in core; a host that
-  wants it supplies the parser behind a seam, the way `FencedBlockRenderer`
-  already lets a ` ```html ` fence be rendered by a companion crate.
+  wants it supplies the parser behind `MarkdownBlockRenderer`, the same seam a
+  ` ```html ` fence uses.
 - No raw-HTML passthrough: unrecognized markup is never echoed as literal text.
 - No markdown *authoring* or round-tripping — rendering only.
 - No document-level layout beyond a linear block sequence (no columns, no

--- a/src/components/markdown/flatten.rs
+++ b/src/components/markdown/flatten.rs
@@ -13,10 +13,10 @@ use crate::style::{StyleSheet, Theme};
 use crate::term::hyperlink::BufferLink;
 use crate::width::grapheme_cols;
 
-use super::Renderers;
 use super::image::{MarkdownImage, image_cell_size};
 use super::item::{MdItem, RichSpan};
 use super::table::render_table_linked;
+use super::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
 
 /// Trim surrounding whitespace from a cell's span run: the leading edge of the
 /// first span and the trailing edge of the last, dropping any span left empty.
@@ -41,12 +41,12 @@ pub(super) fn spans_cols(spans: &[RichSpan]) -> usize {
 
 /// Flatten parsed items into lines plus [`BufferLink`]s for every hyperlink run
 /// that survived wrapping — labeled markdown links included.
-pub(super) fn flatten_linked(
+pub(super) fn flatten_linked<R: MarkdownBlockRenderer + ?Sized>(
     items: &[MdItem],
     width: u16,
     theme: &Theme,
     sheet: &StyleSheet,
-    renderers: Renderers<'_>,
+    renderers: &R,
 ) -> (Vec<Line<'static>>, Vec<BufferLink>) {
     let mut images = Vec::new();
     flatten_linked_into(items, width, theme, sheet, renderers, &mut images)
@@ -55,23 +55,23 @@ pub(super) fn flatten_linked(
 /// Flatten into lines and collect the block images reserved, with the row each
 /// landed on, so the [`Markdown`](super::Markdown) view can overlay an [`Image`](crate::components::Image) at the matching
 /// screen rect. A block image reserves `rows` blank lines here.
-pub(super) fn flatten_into(
+pub(super) fn flatten_into<R: MarkdownBlockRenderer + ?Sized>(
     items: &[MdItem],
     width: u16,
     theme: &Theme,
     sheet: &StyleSheet,
-    renderers: Renderers<'_>,
+    renderers: &R,
     images: &mut Vec<MarkdownImage>,
 ) -> Vec<Line<'static>> {
     flatten_linked_into(items, width, theme, sheet, renderers, images).0
 }
 
-pub(super) fn flatten_linked_into(
+pub(super) fn flatten_linked_into<R: MarkdownBlockRenderer + ?Sized>(
     items: &[MdItem],
     width: u16,
     theme: &Theme,
     sheet: &StyleSheet,
-    renderers: Renderers<'_>,
+    renderers: &R,
     images: &mut Vec<MarkdownImage>,
 ) -> (Vec<Line<'static>>, Vec<BufferLink>) {
     let mut out = Vec::new();
@@ -107,9 +107,10 @@ pub(super) fn flatten_linked_into(
                 indent,
             } => {
                 let avail = width.saturating_sub(*indent).max(1);
-                let rendered = renderers
-                    .fenced
-                    .and_then(|renderer| renderer.render(language, source, avail, theme));
+                let rendered = renderers.render(
+                    MarkdownBlock::Fenced { language, source },
+                    MarkdownBlockContext::new(avail, theme, sheet),
+                );
                 for line in rendered.as_ref().unwrap_or(fallback) {
                     out.push(prefix_rendered_line(*indent, line));
                 }
@@ -132,10 +133,10 @@ pub(super) fn flatten_linked_into(
             // all HTML before the seam existed.
             MdItem::Html { source, indent } => {
                 let avail = width.saturating_sub(*indent).max(1);
-                if let Some(rendered) = renderers
-                    .html
-                    .and_then(|renderer| renderer.render(source, avail, theme, sheet))
-                {
+                if let Some(rendered) = renderers.render(
+                    MarkdownBlock::Html { source },
+                    MarkdownBlockContext::new(avail, theme, sheet),
+                ) {
                     for line in &rendered {
                         out.push(prefix_rendered_line(*indent, line));
                     }

--- a/src/components/markdown/item.rs
+++ b/src/components/markdown/item.rs
@@ -19,7 +19,7 @@ pub(super) enum MdItem {
     /// Word-wrappable prose (a paragraph line, heading, list item, quote line).
     Prose { spans: Vec<RichSpan>, indent: u16 },
     /// A fenced or indented code block. The source stays width-independent so a
-    /// [`FencedBlockRenderer`](super::FencedBlockRenderer) can lay it out for
+    /// [`MarkdownBlockRenderer`](super::MarkdownBlockRenderer) can lay it out for
     /// the current viewport; the ordinary themed presentation is the fallback.
     CodeBlock {
         language: String,
@@ -30,7 +30,7 @@ pub(super) enum MdItem {
     /// A GFM table, laid out to the available width when flattened.
     Table { table: TableData, indent: u16 },
     /// A raw block-level HTML run, kept verbatim for an
-    /// [`HtmlBlockRenderer`](super::HtmlBlockRenderer) to lay out at flatten
+    /// [`MarkdownBlockRenderer`](super::MarkdownBlockRenderer) to lay out at flatten
     /// time. With no renderer attached it renders as nothing, which is what
     /// markdown did with all HTML before the seam existed.
     Html { source: String, indent: u16 },

--- a/src/components/markdown/mod.rs
+++ b/src/components/markdown/mod.rs
@@ -66,140 +66,151 @@ pub use view::Markdown;
 use flatten::flatten_linked;
 use parse::parse;
 
-/// Replaces a fenced code block with width-aware rendered lines.
+/// A parsed block whose presentation may be supplied outside tuika.
 ///
-/// This is the extension seam for languages whose presentation is more than
-/// syntax coloring: diagrams, mathematical notation, query plans, and similar
-/// block content. Implementations inspect `language` and return `None` when they
-/// do not handle it (or when rendering fails); markdown then falls back to the
-/// ordinary themed [`CodeBlock`](crate::components::CodeBlock).
+/// The descriptor is width-independent: parsing identifies the block and keeps
+/// its source; layout happens later through [`MarkdownBlockRenderer`]. This is
+/// what lets [`MarkdownState`] cache settled parsing across resizes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MarkdownBlock<'a> {
+    /// A fenced code block, including its first info-string word as `language`.
+    Fenced {
+        /// The first word of the fence info string, or empty.
+        language: &'a str,
+        /// The verbatim fence body.
+        source: &'a str,
+    },
+    /// One raw block-level HTML run as framed by pulldown-cmark.
+    Html {
+        /// The raw HTML run.
+        source: &'a str,
+    },
+}
+
+impl<'a> MarkdownBlock<'a> {
+    /// The verbatim source carried by this block.
+    pub fn source(self) -> &'a str {
+        match self {
+            Self::Fenced { source, .. } | Self::Html { source } => source,
+        }
+    }
+}
+
+/// Render-time facts shared by every markdown block renderer.
+#[derive(Clone, Copy)]
+#[non_exhaustive]
+pub struct MarkdownBlockContext<'a> {
+    /// Columns available after markdown nesting indentation.
+    pub width: u16,
+    /// The active color theme.
+    pub theme: &'a Theme,
+    /// The active semantic stylesheet.
+    pub sheet: &'a StyleSheet,
+}
+
+impl<'a> MarkdownBlockContext<'a> {
+    /// A block context using the host's complete active styling policy.
+    pub const fn new(width: u16, theme: &'a Theme, sheet: &'a StyleSheet) -> Self {
+        Self {
+            width,
+            theme,
+            sheet,
+        }
+    }
+}
+
+/// Parses and lays out host-defined presentations for structured markdown blocks.
 ///
-/// Renderers should be deterministic for `(language, source, width, theme)`.
-/// [`MarkdownState`] caches settled blocks and calls the renderer again only
-/// when a block is still streaming, the width changes, or the theme changes.
-pub trait FencedBlockRenderer {
-    /// Render a fenced block, or return `None` to use the normal code-block
-    /// presentation.
+/// One contract covers every block that needs a dependency kept outside core:
+/// fenced diagrams, mathematical notation, raw block HTML, query plans, and
+/// future parsed block forms. Implementations inspect [`MarkdownBlock`] and
+/// return `None` when they do not handle it or parsing fails. Renderer chains
+/// try each implementation in order.
+///
+/// An unhandled fence keeps the ordinary themed
+/// [`CodeBlock`](crate::components::CodeBlock) fallback. Unhandled block HTML is
+/// dropped, matching markdown's behavior without an HTML parser.
+/// Implementations should be deterministic, perform no I/O, bound work and
+/// output for untrusted source, and never emit control bytes into cells.
+pub trait MarkdownBlockRenderer {
+    /// Render `block` at the current width and styling context.
     fn render(
         &self,
-        language: &str,
-        source: &str,
-        width: u16,
-        theme: &Theme,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
     ) -> Option<Vec<Line<'static>>>;
 }
 
-/// Lays out a raw block-level HTML run (`<details>`, `<table>`, `<div>`, …).
+/// An ordered chain of host-supplied markdown block renderers.
 ///
-/// Markdown's own HTML support stops at the presentational *inline* tags, which
-/// need no parser. Block HTML does need one, and an HTML parser is exactly the
-/// kind of dependency tuika keeps out of the crate — so it is a seam, like
-/// [`FencedBlockRenderer`] and [`ImageResolver`] before it. `source` is the
-/// verbatim run pulldown-cmark reported, `width` the columns available at this
-/// block's indentation. Returning `None` drops the block, which is what markdown
-/// did with all block HTML before a renderer could be attached.
-///
-/// Implementations should be deterministic for `(source, width, theme, sheet)`, must
-/// not perform I/O, and are handed **untrusted** markup: bound the work and the
-/// output, and never emit control bytes into the cells.
-/// [`tuika-html`](https://crates.io/crates/tuika-html) is the batteries-included
-/// implementation.
-///
-/// Note that pulldown-cmark ends an HTML block at a blank line, so one element
-/// with blank lines inside arrives as several calls.
-///
-/// With [`tuika-html`](https://crates.io/crates/tuika-html) attached, the
-/// `<details>`, its nested `<ul>`, and the `<table>` below are raw HTML inside
-/// an otherwise ordinary markdown document:
-///
-/// ![HTML blocks in markdown](https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_markdown/html.png)
+/// The first renderer returning `Some` owns the block. The chain stores borrowed
+/// renderer references and lets unrelated companion crates compose:
 ///
 /// ```
-/// use ratatui_core::text::{Line, Span};
-/// use tuika::components::HtmlBlockRenderer;
-/// use tuika::style::{StyleSheet, Theme};
-///
-/// /// A renderer that shows `<details>` as a collapsed summary line.
-/// struct Details;
-///
-/// impl HtmlBlockRenderer for Details {
-///     fn render(
-///         &self,
-///         source: &str,
-///         _width: u16,
-///         _theme: &Theme,
-///         sheet: &StyleSheet,
-///     ) -> Option<Vec<Line<'static>>> {
-///         let summary = source.split("<summary>").nth(1)?.split('<').next()?;
-///         let style = sheet.heading.to_style();
-///         Some(vec![Line::from(Span::styled(format!("▸ {summary}"), style))])
-///     }
-/// }
-///
-/// let theme = Theme::default();
-/// let sheet = StyleSheet::from_theme(&theme);
-/// let lines = tuika::components::markdown::to_lines_with(
-///     "<details><summary>Notes</summary>Body</details>",
-///     40,
-///     &theme,
-///     &sheet,
-///     tuika::highlight::CodeHighlighter::Plain,
-///     tuika::components::Renderers::new().html(&Details),
-/// );
-/// assert_eq!(lines[0].spans[0].content, "▸ Notes");
-/// ```
-///
-/// See the [markdown guide](https://github.com/everruns/tuika/blob/main/docs/markdown.md#block-html).
-pub trait HtmlBlockRenderer {
-    /// Render a block of raw HTML, or return `None` to drop it.
-    ///
-    /// `sheet` is the active stylesheet, so an implementation resolves its
-    /// headings, links, and code through the same roles the surrounding markdown
-    /// does instead of inventing colors.
-    fn render(
-        &self,
-        source: &str,
-        width: u16,
-        theme: &Theme,
-        sheet: &StyleSheet,
-    ) -> Option<Vec<Line<'static>>>;
-}
-
-/// The host-supplied renderers a markdown render may consult.
-///
-/// Both are optional and independent; the default consults neither, which is
-/// the plain CommonMark rendering.
-///
-/// ```
-/// # use tuika::components::markdown::Renderers;
-/// # fn f(fenced: &dyn tuika::components::FencedBlockRenderer) {
-/// let renderers = Renderers::new().fenced(fenced);
+/// # use tuika::components::{MarkdownBlockRenderer, Renderers};
+/// # fn f(mermaid: &dyn MarkdownBlockRenderer, html: &dyn MarkdownBlockRenderer) {
+/// let renderers = Renderers::new().renderer(mermaid).renderer(html);
 /// # let _ = renderers;
 /// # }
 /// ```
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone)]
 pub struct Renderers<'a> {
-    fenced: Option<&'a dyn FencedBlockRenderer>,
-    html: Option<&'a dyn HtmlBlockRenderer>,
+    blocks: Vec<&'a dyn MarkdownBlockRenderer>,
 }
 
 impl<'a> Renderers<'a> {
-    /// No renderers: fenced blocks keep the themed code presentation, and block
-    /// HTML is dropped.
-    pub fn new() -> Self {
-        Self::default()
+    /// No structured block renderers.
+    pub const fn new() -> Self {
+        Self { blocks: Vec::new() }
     }
 
-    /// Render recognized fenced blocks through `renderer`.
-    pub fn fenced(mut self, renderer: &'a dyn FencedBlockRenderer) -> Self {
-        self.fenced = Some(renderer);
+    /// Append `renderer` to the ordered chain.
+    pub fn renderer(mut self, renderer: &'a dyn MarkdownBlockRenderer) -> Self {
+        self.blocks.push(renderer);
         self
     }
 
-    /// Render raw block-level HTML through `renderer`.
-    pub fn html(mut self, renderer: &'a dyn HtmlBlockRenderer) -> Self {
-        self.html = Some(renderer);
-        self
+    fn render_block(
+        &self,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
+    ) -> Option<Vec<Line<'static>>> {
+        self.blocks
+            .iter()
+            .find_map(|renderer| renderer.render(block, context))
+    }
+}
+
+impl MarkdownBlockRenderer for Renderers<'_> {
+    fn render(
+        &self,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
+    ) -> Option<Vec<Line<'static>>> {
+        self.render_block(block, context)
+    }
+}
+
+impl MarkdownBlockRenderer for [&dyn MarkdownBlockRenderer] {
+    fn render(
+        &self,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
+    ) -> Option<Vec<Line<'static>>> {
+        self.iter()
+            .find_map(|renderer| renderer.render(block, context))
+    }
+}
+
+impl MarkdownBlockRenderer for [Box<dyn MarkdownBlockRenderer>] {
+    fn render(
+        &self,
+        block: MarkdownBlock<'_>,
+        context: MarkdownBlockContext<'_>,
+    ) -> Option<Vec<Line<'static>>> {
+        self.iter()
+            .find_map(|renderer| renderer.render(block, context))
     }
 }
 
@@ -217,17 +228,18 @@ pub fn to_lines(
     to_linked_lines(source, width, theme, sheet, highlighter).0
 }
 
-/// Render markdown with a host-supplied fenced-block renderer.
+/// Render markdown with one host-supplied structured-block renderer.
 ///
-/// The renderer can replace any language fence with width-aware lines; returning
-/// `None` preserves the ordinary [`CodeBlock`](crate::components::CodeBlock).
+/// The renderer may handle fenced or raw HTML blocks. Returning `None` preserves
+/// the ordinary [`CodeBlock`](crate::components::CodeBlock) fallback for a fence
+/// and drops raw block HTML.
 pub fn to_lines_with_renderer(
     source: &str,
     width: u16,
     theme: &Theme,
     sheet: &StyleSheet,
     highlighter: CodeHighlighter,
-    block_renderer: &dyn FencedBlockRenderer,
+    block_renderer: &dyn MarkdownBlockRenderer,
 ) -> Vec<Line<'static>> {
     to_lines_with(
         source,
@@ -235,12 +247,11 @@ pub fn to_lines_with_renderer(
         theme,
         sheet,
         highlighter,
-        Renderers::new().fenced(block_renderer),
+        Renderers::new().renderer(block_renderer),
     )
 }
 
-/// Render markdown with any combination of host-supplied [`Renderers`] — a
-/// fenced-block renderer, an HTML-block renderer, or both.
+/// Render markdown with an ordered chain of host-supplied [`Renderers`].
 pub fn to_lines_with(
     source: &str,
     width: u16,
@@ -265,17 +276,24 @@ pub fn to_linked_lines(
     sheet: &StyleSheet,
     highlighter: CodeHighlighter,
 ) -> (Vec<Line<'static>>, Vec<BufferLink>) {
-    to_linked_lines_with(source, width, theme, sheet, highlighter, Renderers::new())
+    to_linked_lines_with(
+        source,
+        width,
+        theme,
+        sheet,
+        highlighter,
+        Renderers::default(),
+    )
 }
 
-/// Like [`to_linked_lines`], with a host-supplied [`FencedBlockRenderer`].
+/// Like [`to_linked_lines`], with a host-supplied [`MarkdownBlockRenderer`].
 pub fn to_linked_lines_with_renderer(
     source: &str,
     width: u16,
     theme: &Theme,
     sheet: &StyleSheet,
     highlighter: CodeHighlighter,
-    block_renderer: &dyn FencedBlockRenderer,
+    block_renderer: &dyn MarkdownBlockRenderer,
 ) -> (Vec<Line<'static>>, Vec<BufferLink>) {
     to_linked_lines_with(
         source,
@@ -283,7 +301,7 @@ pub fn to_linked_lines_with_renderer(
         theme,
         sheet,
         highlighter,
-        Renderers::new().fenced(block_renderer),
+        Renderers::new().renderer(block_renderer),
     )
 }
 
@@ -298,7 +316,7 @@ pub fn to_linked_lines_with(
     renderers: Renderers<'_>,
 ) -> (Vec<Line<'static>>, Vec<BufferLink>) {
     let items = parse(source, theme, sheet, highlighter);
-    flatten_linked(&items, width, theme, sheet, renderers)
+    flatten_linked(&items, width, theme, sheet, &renderers)
 }
 
 #[cfg(test)]
@@ -511,18 +529,19 @@ mod tests {
 
     struct DiagramRenderer;
 
-    impl FencedBlockRenderer for DiagramRenderer {
+    impl MarkdownBlockRenderer for DiagramRenderer {
         fn render(
             &self,
-            language: &str,
-            source: &str,
-            width: u16,
-            theme: &Theme,
+            block: MarkdownBlock<'_>,
+            context: MarkdownBlockContext<'_>,
         ) -> Option<Vec<Line<'static>>> {
+            let MarkdownBlock::Fenced { language, source } = block else {
+                return None;
+            };
             (language == "diagram").then(|| {
                 vec![Line::from(Span::styled(
-                    format!("rendered at {width}: {source}"),
-                    ratatui_core::style::Style::default().fg(theme.accent),
+                    format!("rendered at {}: {source}", context.width),
+                    ratatui_core::style::Style::default().fg(context.theme.accent),
                 ))]
             })
         }
@@ -566,6 +585,50 @@ mod tests {
             output.iter().any(|line| line.contains("fn main()")),
             "{output:?}"
         );
+    }
+
+    #[test]
+    fn fenced_block_renderer_receives_the_active_stylesheet() {
+        use ratatui_core::style::Color;
+
+        struct StyledFence;
+        impl MarkdownBlockRenderer for StyledFence {
+            fn render(
+                &self,
+                block: MarkdownBlock<'_>,
+                context: MarkdownBlockContext<'_>,
+            ) -> Option<Vec<Line<'static>>> {
+                matches!(
+                    block,
+                    MarkdownBlock::Fenced {
+                        language: "styled",
+                        ..
+                    }
+                )
+                .then(|| {
+                    vec![Line::from(Span::styled(
+                        "styled",
+                        context.sheet.heading.to_style(),
+                    ))]
+                })
+            }
+        }
+
+        let theme = Theme::default();
+        let sheet = StyleSheet {
+            heading: StyleBundle::new().fg(Color::Green),
+            ..StyleSheet::from_theme(&theme)
+        };
+        let lines = to_lines_with_renderer(
+            "```styled\nsource\n```",
+            20,
+            &theme,
+            &sheet,
+            CodeHighlighter::Plain,
+            &StyledFence,
+        );
+
+        assert_eq!(lines[0].spans[0].style.fg, Some(Color::Green));
     }
 
     #[test]
@@ -846,19 +909,20 @@ mod tests {
     /// Renders any HTML block as one line quoting its source and the width.
     struct EchoHtml;
 
-    impl HtmlBlockRenderer for EchoHtml {
+    impl MarkdownBlockRenderer for EchoHtml {
         fn render(
             &self,
-            source: &str,
-            width: u16,
-            theme: &Theme,
-            _: &StyleSheet,
+            block: MarkdownBlock<'_>,
+            context: MarkdownBlockContext<'_>,
         ) -> Option<Vec<Line<'static>>> {
+            let MarkdownBlock::Html { source } = block else {
+                return None;
+            };
             let text = source.split_whitespace().collect::<Vec<_>>().join(" ");
             (!text.is_empty()).then(|| {
                 vec![Line::from(Span::styled(
-                    format!("[{width}] {text}"),
-                    ratatui_core::style::Style::default().fg(theme.accent),
+                    format!("[{}] {text}", context.width),
+                    ratatui_core::style::Style::default().fg(context.theme.accent),
                 ))]
             })
         }
@@ -872,7 +936,7 @@ mod tests {
             &theme,
             &StyleSheet::from_theme(&theme),
             CodeHighlighter::Plain,
-            Renderers::new().html(&EchoHtml),
+            Renderers::new().renderer(&EchoHtml),
         )
         .iter()
         .map(text)
@@ -880,7 +944,7 @@ mod tests {
     }
 
     #[test]
-    fn html_block_renderer_lays_out_raw_html() {
+    fn structured_block_renderer_lays_out_raw_html() {
         let out = with_html(
             "before\n\n<details><summary>S</summary>body</details>\n\nafter",
             40,
@@ -918,15 +982,13 @@ mod tests {
     }
 
     #[test]
-    fn html_renderer_returning_none_drops_the_block() {
+    fn block_renderer_returning_none_drops_html() {
         struct Decline;
-        impl HtmlBlockRenderer for Decline {
+        impl MarkdownBlockRenderer for Decline {
             fn render(
                 &self,
-                _: &str,
-                _: u16,
-                _: &Theme,
-                _: &StyleSheet,
+                _: MarkdownBlock<'_>,
+                _: MarkdownBlockContext<'_>,
             ) -> Option<Vec<Line<'static>>> {
                 None
             }
@@ -938,7 +1000,7 @@ mod tests {
             &theme,
             &StyleSheet::from_theme(&theme),
             CodeHighlighter::Plain,
-            Renderers::new().html(&Decline),
+            Renderers::new().renderer(&Decline),
         )
         .iter()
         .map(text)
@@ -948,7 +1010,7 @@ mod tests {
     }
 
     #[test]
-    fn both_renderers_compose() {
+    fn independent_block_renderers_compose() {
         let theme = Theme::default();
         let out: Vec<String> = to_lines_with(
             "```diagram\nA --> B\n```\n\n<div>html</div>",
@@ -956,13 +1018,43 @@ mod tests {
             &theme,
             &StyleSheet::from_theme(&theme),
             CodeHighlighter::Plain,
-            Renderers::new().fenced(&DiagramRenderer).html(&EchoHtml),
+            Renderers::new()
+                .renderer(&DiagramRenderer)
+                .renderer(&EchoHtml),
         )
         .iter()
         .map(text)
         .collect();
         assert!(out.iter().any(|l| l.contains("rendered at 37")), "{out:?}");
         assert!(out.iter().any(|l| l.contains("[37] <div>html")), "{out:?}");
+    }
+
+    #[test]
+    fn renderer_chain_uses_the_first_handler() {
+        struct Named(&'static str);
+        impl MarkdownBlockRenderer for Named {
+            fn render(
+                &self,
+                block: MarkdownBlock<'_>,
+                _: MarkdownBlockContext<'_>,
+            ) -> Option<Vec<Line<'static>>> {
+                matches!(block, MarkdownBlock::Html { .. }).then(|| vec![Line::raw(self.0)])
+            }
+        }
+
+        let theme = Theme::default();
+        let first = Named("first");
+        let second = Named("second");
+        let out = to_lines_with(
+            "<div>html</div>",
+            20,
+            &theme,
+            &StyleSheet::from_theme(&theme),
+            CodeHighlighter::Plain,
+            Renderers::new().renderer(&first).renderer(&second),
+        );
+
+        assert_eq!(text(&out[0]), "first");
     }
 
     #[test]

--- a/src/components/markdown/stream.rs
+++ b/src/components/markdown/stream.rs
@@ -10,11 +10,11 @@ use ratatui_core::text::Line;
 use crate::highlight::CodeHighlighter;
 use crate::style::{StyleSheet, Theme};
 
+use super::MarkdownBlockRenderer;
 use super::flatten::flatten_into;
 use super::image::{ImageResolver, MarkdownImage};
 use super::item::MdItem;
 use super::parse::parse_with;
-use super::{FencedBlockRenderer, HtmlBlockRenderer, Renderers};
 
 /// Byte offset of the last *stable block boundary* in `source[from..]`, in
 /// absolute bytes: the position just past the last blank line that sits outside
@@ -90,10 +90,8 @@ pub struct MarkdownState {
     rendered_width: Option<u16>,
     /// Optional host hook turning image URLs into pixels; off ⇒ text placeholders.
     resolver: Option<Box<dyn ImageResolver>>,
-    /// Optional host hook replacing recognized fenced blocks with rendered lines.
-    block_renderer: Option<Box<dyn FencedBlockRenderer>>,
-    /// Optional host hook laying out raw block-level HTML.
-    html_renderer: Option<Box<dyn HtmlBlockRenderer>>,
+    /// Ordered host hooks parsing and laying out structured blocks.
+    block_renderers: Vec<Box<dyn MarkdownBlockRenderer>>,
     /// Block images in the settled prefix, with their absolute `rendered` rows —
     /// accumulated once as blocks settle, mirroring `settled_lines`.
     settled_images: Vec<MarkdownImage>,
@@ -121,38 +119,17 @@ impl MarkdownState {
         self
     }
 
-    /// Render recognized fenced blocks through `renderer`.
+    /// Append a renderer for structured blocks such as fenced diagrams or raw
+    /// block HTML.
     ///
-    /// A renderer returns `None` for languages or inputs it does not handle, and
-    /// markdown preserves the ordinary themed code block in that case.
-    pub fn with_block_renderer(mut self, renderer: Box<dyn FencedBlockRenderer>) -> Self {
-        self.block_renderer = Some(renderer);
+    /// Renderers are consulted in registration order; the first returning
+    /// `Some` owns a block. Call this repeatedly to compose independent
+    /// companion renderers. A settled block is laid out once per width, while
+    /// one still in the streaming tail may be attempted on each frame.
+    pub fn with_block_renderer(mut self, renderer: Box<dyn MarkdownBlockRenderer>) -> Self {
+        self.block_renderers.push(renderer);
         self.reset_cache();
         self
-    }
-
-    /// Lay out raw block-level HTML through `renderer`.
-    ///
-    /// Without one, block HTML is dropped; the presentational *inline* tags
-    /// render either way. Like a fenced block, a settled HTML block is laid out
-    /// once per width, while one still in the streaming tail is re-rendered each
-    /// frame.
-    pub fn with_html_renderer(mut self, renderer: Box<dyn HtmlBlockRenderer>) -> Self {
-        self.html_renderer = Some(renderer);
-        self.reset_cache();
-        self
-    }
-
-    /// The renderers this state consults, as flatten wants them.
-    fn renderers(&self) -> Renderers<'_> {
-        let mut renderers = Renderers::new();
-        if let Some(r) = self.block_renderer.as_deref() {
-            renderers = renderers.fenced(r);
-        }
-        if let Some(r) = self.html_renderer.as_deref() {
-            renderers = renderers.html(r);
-        }
-        renderers
     }
 
     /// The block images reserved by the last [`lines`](Self::lines) call, with
@@ -259,7 +236,7 @@ impl MarkdownState {
                 width,
                 theme,
                 sheet,
-                self.renderers(),
+                self.block_renderers.as_slice(),
                 &mut settled_imgs,
             );
             for mut img in settled_imgs {
@@ -279,7 +256,14 @@ impl MarkdownState {
             self.resolver.as_deref(),
         );
         let mut tail_imgs = Vec::new();
-        let tail_lines = flatten_into(&tail, width, theme, sheet, self.renderers(), &mut tail_imgs);
+        let tail_lines = flatten_into(
+            &tail,
+            width,
+            theme,
+            sheet,
+            self.block_renderers.as_slice(),
+            &mut tail_imgs,
+        );
         // The tail begins just past the boundary's blank line; keep that gap.
         if !self.rendered.is_empty()
             && !tail_lines.is_empty()
@@ -312,7 +296,7 @@ fn is_blank_line(line: &Line) -> bool {
 #[cfg(test)]
 mod tests {
     use super::super::testutil::*;
-    use super::super::{to_lines, to_lines_with};
+    use super::super::{Renderers, to_lines, to_lines_with};
     use super::*;
 
     use crate::style::StyleBundle;
@@ -324,7 +308,7 @@ mod tests {
     use std::cell::Cell;
     use std::rc::Rc;
 
-    use super::super::FencedBlockRenderer;
+    use super::super::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
 
     #[test]
     fn sheet_change_invalidates_stream_cache() {
@@ -403,17 +387,18 @@ mod tests {
     fn streaming_caches_settled_rendered_blocks_until_resize() {
         struct CountingRenderer(Rc<Cell<usize>>);
 
-        impl FencedBlockRenderer for CountingRenderer {
+        impl MarkdownBlockRenderer for CountingRenderer {
             fn render(
                 &self,
-                language: &str,
-                _source: &str,
-                width: u16,
-                _theme: &Theme,
+                block: MarkdownBlock<'_>,
+                context: MarkdownBlockContext<'_>,
             ) -> Option<Vec<Line<'static>>> {
+                let MarkdownBlock::Fenced { language, .. } = block else {
+                    return None;
+                };
                 (language == "diagram").then(|| {
                     self.0.set(self.0.get() + 1);
-                    vec![Line::raw(format!("width {width}"))]
+                    vec![Line::raw(format!("width {}", context.width))]
                 })
             }
         }
@@ -502,14 +487,15 @@ mod tests {
         // while streaming. That is what lets the cache settle an HTML block at
         // all: the framing does not depend on how much source has arrived.
         struct CountingHtml(Rc<Cell<usize>>);
-        impl HtmlBlockRenderer for CountingHtml {
+        impl MarkdownBlockRenderer for CountingHtml {
             fn render(
                 &self,
-                source: &str,
-                _: u16,
-                _: &Theme,
-                _: &StyleSheet,
+                block: MarkdownBlock<'_>,
+                _: MarkdownBlockContext<'_>,
             ) -> Option<Vec<Line<'static>>> {
+                let MarkdownBlock::Html { source } = block else {
+                    return None;
+                };
                 self.0.set(self.0.get() + 1);
                 Some(vec![Line::from(source.trim().to_string())])
             }
@@ -524,7 +510,7 @@ mod tests {
             &theme,
             &sheet,
             CodeHighlighter::Plain,
-            Renderers::new().html(&CountingHtml(Rc::new(Cell::new(0)))),
+            Renderers::new().renderer(&CountingHtml(Rc::new(Cell::new(0)))),
         )
         .iter()
         .map(text)
@@ -532,7 +518,7 @@ mod tests {
 
         let calls = Rc::new(Cell::new(0));
         let mut state =
-            MarkdownState::new().with_html_renderer(Box::new(CountingHtml(Rc::clone(&calls))));
+            MarkdownState::new().with_block_renderer(Box::new(CountingHtml(Rc::clone(&calls))));
         for ch in full.chars() {
             state.push_str(&ch.to_string());
             let _ = state.lines(40, &theme, &sheet, CodeHighlighter::Plain);

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -16,10 +16,10 @@ use crate::term::hyperlink::{BufferLink, LinkPolicy, apply_buffer_links};
 use crate::term::image::{ImageLayer, ImageSupport};
 use crate::view::{RenderCtx, View};
 
+use super::MarkdownBlockRenderer;
 use super::flatten::flatten_linked_into;
 use super::image::{ImageResolver, MarkdownImage};
 use super::parse::parse_with;
-use super::{FencedBlockRenderer, HtmlBlockRenderer, Renderers};
 
 /// A view that renders a static markdown string to its area — word-wrapping
 /// prose to the width and drawing code and tables verbatim.
@@ -36,7 +36,7 @@ use super::{FencedBlockRenderer, HtmlBlockRenderer, Renderers};
 ///
 /// ![markdown inline HTML demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/markdown_html.png)
 ///
-/// Block-level HTML is a seam — see [`html_renderer`](Self::html_renderer).
+/// Block-level HTML is a seam handled by [`block_renderer`](Self::block_renderer).
 ///
 /// GFM tables are laid out to the render width, cells keeping their inline
 /// styles, emoji, and links:
@@ -49,8 +49,7 @@ use super::{FencedBlockRenderer, HtmlBlockRenderer, Renderers};
 /// | --- | --- | --- |
 /// | [`new(source)`](Self::new) | — | the markdown source to render |
 /// | [`highlighter(&h)`](Self::highlighter) | plain | syntax-highlight fenced code |
-/// | [`block_renderer(&r)`](Self::block_renderer) | off | replace recognized fences with rendered blocks |
-/// | [`html_renderer(&r)`](Self::html_renderer) | off | lay out raw block-level HTML |
+/// | [`block_renderer(&r)`](Self::block_renderer) | off | append a structured block renderer |
 /// | [`images(&r, s, &l)`](Self::images) | off | render `![alt](url)` as real pixels |
 /// | [`link_policy(p)`](Self::link_policy) | [`LinkPolicy::WEB`] | OSC 8 schemes for links |
 ///
@@ -63,8 +62,7 @@ use super::{FencedBlockRenderer, HtmlBlockRenderer, Renderers};
 pub struct Markdown<'a> {
     source: String,
     highlighter: CodeHighlighter<'a>,
-    block_renderer: Option<&'a dyn FencedBlockRenderer>,
-    html_renderer: Option<&'a dyn HtmlBlockRenderer>,
+    block_renderers: Vec<&'a dyn MarkdownBlockRenderer>,
     resolver: Option<&'a dyn ImageResolver>,
     image_support: ImageSupport,
     image_layer: Option<ImageLayer>,
@@ -79,8 +77,7 @@ impl<'a> Markdown<'a> {
         Self {
             source: source.into(),
             highlighter: CodeHighlighter::Plain,
-            block_renderer: None,
-            html_renderer: None,
+            block_renderers: Vec::new(),
             resolver: None,
             image_support: ImageSupport::None,
             image_layer: None,
@@ -94,24 +91,15 @@ impl<'a> Markdown<'a> {
         self
     }
 
-    /// Render recognized fenced code blocks through `renderer`.
+    /// Append a renderer for structured blocks such as fenced diagrams or raw
+    /// block HTML.
     ///
-    /// The renderer receives the current viewport width. Returning `None` leaves
-    /// a fence in the ordinary themed code-block presentation.
-    pub fn block_renderer(mut self, renderer: &'a dyn FencedBlockRenderer) -> Self {
-        self.block_renderer = Some(renderer);
-        self
-    }
-
-    /// Render raw block-level HTML (`<details>`, `<table>`, `<div>`, …) through
-    /// `renderer`.
-    ///
-    /// Without one, block HTML is dropped; the presentational *inline* tags
-    /// (`<b>`, `<a>`, `<br>`, …) render either way and need no renderer.
-    ///
-    /// ![HTML blocks in markdown](https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-html/examples/html_markdown/html.png)
-    pub fn html_renderer(mut self, renderer: &'a dyn HtmlBlockRenderer) -> Self {
-        self.html_renderer = Some(renderer);
+    /// Renderers are consulted in registration order; the first returning
+    /// `Some` owns the block. Returning `None` leaves a fence in the ordinary
+    /// themed code-block presentation and drops raw block HTML. Call this
+    /// repeatedly to compose independent companion renderers.
+    pub fn block_renderer(mut self, renderer: &'a dyn MarkdownBlockRenderer) -> Self {
+        self.block_renderers.push(renderer);
         self
     }
 
@@ -154,15 +142,14 @@ impl<'a> Markdown<'a> {
     ) -> (Vec<Line<'static>>, Vec<MarkdownImage>, Vec<BufferLink>) {
         let items = parse_with(&self.source, theme, sheet, self.highlighter, self.resolver);
         let mut images = Vec::new();
-        let mut renderers = Renderers::new();
-        if let Some(r) = self.block_renderer {
-            renderers = renderers.fenced(r);
-        }
-        if let Some(r) = self.html_renderer {
-            renderers = renderers.html(r);
-        }
-        let (lines, links) =
-            flatten_linked_into(&items, width, theme, sheet, renderers, &mut images);
+        let (lines, links) = flatten_linked_into(
+            &items,
+            width,
+            theme,
+            sheet,
+            self.block_renderers.as_slice(),
+            &mut images,
+        );
         (lines, images, links)
     }
 }
@@ -228,7 +215,7 @@ impl View for Markdown<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::components::HtmlBlockRenderer;
+    use crate::components::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
     use crate::style::StyleBundle;
     use crate::testing::{grid, render_with_sheet};
     use ratatui_core::style::Color;
@@ -236,15 +223,18 @@ mod tests {
 
     struct ContextBlock;
 
-    impl HtmlBlockRenderer for ContextBlock {
+    impl MarkdownBlockRenderer for ContextBlock {
         fn render(
             &self,
-            _source: &str,
-            _width: u16,
-            theme: &Theme,
-            sheet: &StyleSheet,
+            block: MarkdownBlock<'_>,
+            context: MarkdownBlockContext<'_>,
         ) -> Option<Vec<Line<'static>>> {
-            if theme.accent == Color::Cyan && sheet.heading.fg == Some(Color::Magenta) {
+            if !matches!(block, MarkdownBlock::Html { .. }) {
+                return None;
+            }
+            if context.theme.accent == Color::Cyan
+                && context.sheet.heading.fg == Some(Color::Magenta)
+            {
                 Some(vec![
                     Line::from(Span::raw("alpha")),
                     Line::from(Span::raw("beta")),
@@ -267,7 +257,7 @@ mod tests {
             ..StyleSheet::from_theme(&theme)
         };
         let renderer = ContextBlock;
-        let view = Markdown::new("<div>context</div>").html_renderer(&renderer);
+        let view = Markdown::new("<div>context</div>").block_renderer(&renderer);
         let ctx = RenderCtx::new(&theme).with_sheet(sheet);
 
         assert_eq!(view.measure(Size::new(10, 10), &ctx), Size::new(5, 3));

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -67,8 +67,8 @@ pub use item_scroll::ItemScroll;
 pub use key_hints::{KeyHint, KeyHints, KeymapHelp};
 pub use loader::Loader;
 pub use markdown::{
-    FencedBlockRenderer, HtmlBlockRenderer, ImageResolver, Markdown, MarkdownImage, MarkdownState,
-    Renderers,
+    ImageResolver, Markdown, MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer,
+    MarkdownImage, MarkdownState, Renderers,
 };
 pub use progress_bar::ProgressBar;
 pub use qr::{QrCode, QrEcc};

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -198,14 +198,15 @@ fn component_modules_own_their_constants_and_free_functions() {
     assert_eq!(text::wrap_lines(&[], 10).len(), 0);
 
     struct Blocks;
-    impl FencedBlockRenderer for Blocks {
+    impl MarkdownBlockRenderer for Blocks {
         fn render(
             &self,
-            language: &str,
-            _source: &str,
-            _width: u16,
-            _theme: &Theme,
+            block: MarkdownBlock<'_>,
+            _context: MarkdownBlockContext<'_>,
         ) -> Option<Vec<ratatui_core::text::Line<'static>>> {
+            let MarkdownBlock::Fenced { language, .. } = block else {
+                return None;
+            };
             (language == "demo").then(|| vec![ratatui_core::text::Line::raw("rendered")])
         }
     }
@@ -223,17 +224,16 @@ fn component_modules_own_their_constants_and_free_functions() {
         "rendered"
     );
 
-    // Both seams reach markdown through one `Renderers` value.
+    // Independent block parsers compose through one ordered `Renderers` value.
     struct Html;
-    impl HtmlBlockRenderer for Html {
+    impl MarkdownBlockRenderer for Html {
         fn render(
             &self,
-            _source: &str,
-            _width: u16,
-            _theme: &Theme,
-            _sheet: &StyleSheet,
+            block: MarkdownBlock<'_>,
+            _context: MarkdownBlockContext<'_>,
         ) -> Option<Vec<ratatui_core::text::Line<'static>>> {
-            Some(vec![ratatui_core::text::Line::raw("html")])
+            matches!(block, MarkdownBlock::Html { .. })
+                .then(|| vec![ratatui_core::text::Line::raw("html")])
         }
     }
     let lines = markdown::to_lines_with(
@@ -242,7 +242,7 @@ fn component_modules_own_their_constants_and_free_functions() {
         &theme,
         &sheet,
         plain,
-        markdown::Renderers::new().fenced(&Blocks).html(&Html),
+        markdown::Renderers::new().renderer(&Blocks).renderer(&Html),
     );
     let rendered: Vec<String> = lines
         .iter()


### PR DESCRIPTION
## What changed

Markdown now has one open, ordered extension contract for parser-backed blocks. `MarkdownBlockRenderer` receives a non-exhaustive block descriptor plus the active width, theme, and semantic stylesheet. Repeated registration composes Mermaid, HTML, and host-defined renderers; the first handler wins.

The Mermaid and HTML companion crates use the same contract. HTML fences now inherit the host's active stylesheet instead of rebuilding theme defaults.

## Why

Fenced content and raw HTML previously used separate traits, fields, builder methods, and free-function slots. Every future structured syntax would have repeated that machinery, the two paths exposed inconsistent context, and hosts could not compose multiple renderers of the same category.

## Before / After

Before, a host registered separate categories:

```rust
Markdown::new(source)
    .block_renderer(&mermaid)
    .html_renderer(&html);
```

After, every independent renderer joins one ordered chain:

```rust
Markdown::new(source)
    .block_renderer(&mermaid)
    .block_renderer(&html);
```

Tests prove first-handler ordering, fallback behavior, one-shot and streaming composition, active stylesheet propagation, and both companion implementations.

## Risk

- Medium
- This deliberately replaces the pre-1.0 public `FencedBlockRenderer` and `HtmlBlockRenderer` traits. The changelog includes the migration path.
- Renderer ordering is observable; registration order is documented and tested.
- The Markdown flattening hot path changes from category lookup to a short renderer chain. The full Criterion suite passed locally; CI's instruction-count gate remains authoritative.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/markdown.md`, `knowledge/specs/goal.md`, the knowledge index and log, and maintainer guidance to record the single structured-block boundary and its dependency policy.

## Security

Reviewed untrusted-markdown and terminal-output boundaries. The change adds no dependency, I/O, unsafe code, network access, or escape-sequence path. Renderers remain required to bound work/output and avoid control bytes. Existing HTML nesting/input/output limits and Mermaid source/output/control-byte defenses are unchanged. An ordered chain adds work linear only in the number of explicitly registered renderers.

## Follow-ups

No follow-ups.
