### PR TITLE
chore(ship): prompt for PR evidence in the ship skill

### DIFF
--- a/.agents/skills/ship/SKILL.md
+++ b/.agents/skills/ship/SKILL.md
@@ -153,7 +153,9 @@ Pick only what matches the changed surface:
 
 - Use a Conventional Commit style PR title under 70 characters.
 - In the PR body, explain what changed, why, how it was validated, notable risks, any API change, and an explicit **Follow-ups** section (or "No follow-ups.").
-- For visual changes, include a before/after — a recording or a `--dump` capture.
+- Attach a Before / After with proof a reviewer can check: for visual/TUI changes a
+  before/after screenshot, recording, or `--dump` capture; for other behavior, CLI
+  output or logs. State explicitly when a change has no observable behavior.
 - After CI is green, wait at least 2 minutes for async reviewer bots, then do one last comment sweep before merge.
 - Merge with `gh pr merge --squash` only after CI is green and the final review sweep is clean.
 - Do not use auto-merge: async review bots can post after the last push.


### PR DESCRIPTION
## What changed

The `/ship` skill's PR-and-merge section now prompts for **evidence in the PR body** — a Before / After with proof a reviewer can check: for visual/TUI changes a **before/after screenshot, recording, or `--dump` capture**; for other behavior, CLI output or logs. This broadens the prior visual-only line to cover all changes and to state when there's no observable behavior.

## Why

The skill already mentioned a before/after for visual changes, but not for other behavior, and didn't frame it as reviewer-checkable evidence. Reviewers benefit from seeing the change work, not reading that it does.

## Before / After

Docs/skill-guidance only — no runtime behavior changes.

- **Before:** "For visual changes, include a before/after — a recording or a `--dump` capture."
- **After:** "Attach a Before / After with proof a reviewer can check: for visual/TUI changes a before/after screenshot, recording, or `--dump` capture; for other behavior, CLI output or logs. State explicitly when a change has no observable behavior."

## Risk

- Low
- Skill/docs only; no source, config, or CI logic touched.

## Checklist

- [x] Tests added or updated — N/A (skill/docs only)
- [x] Backward compatibility considered — no code paths affected

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_