### PR TITLE
feat(runner): add borrowed application runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ described in the release process begins with the entry below.
 
 ### Added
 
+- `Application` and `Runner::{run_app, run_app_with_backend}` provide a
+  data-driven synchronous runtime whose frame tree can borrow application state
+  through `ScopedElement<'_>`; `TestHarness::{render_app, step_app}` exercises
+  the same contract without a terminal, and the existing owned-element closure
+  API remains.
 - `CompletionItem`, `CompletionState`, and `CompletionPalette` provide reusable
   fuzzy-ranked command and token completion with host-owned query/selection
   state and explicit replacement text.
@@ -24,6 +29,12 @@ described in the release process begins with the entry below.
 - `ActivityItem`, `ActivityStatus`, and `ActivityList` render multi-step task
   lifecycle state, including optional determinate progress for individual
   steps, without owning scheduling or workflow state.
+
+### Changed
+
+- Runner resize signals now force a frame even when application updates return
+  `UpdateResult::Clean`; headless harness resize signals also apply their new
+  viewport dimensions automatically.
 
 ## [0.7.0] - 2026-07-31
 

--- a/README.md
+++ b/README.md
@@ -661,10 +661,11 @@ uses that policy without replacing the runner loop.
 
 `Runner` is an optional synchronous event loop for dashboards and small tools.
 It owns `TerminalSession`, frame scheduling, Crossterm event translation, and
-state-driven redraws. It threads one state value through a pure `view(&State)`
-and an `update(&mut State, Signal)` function. The initial frame is painted once;
-a tick or input only repaints when update returns `UpdateResult::Dirty`, while a
-`RedrawHandle` can wake the loop from another thread:
+state-driven redraws. An `Application` keeps state and update policy together;
+its pure `view(&self)` may return a `ScopedElement<'_>` that borrows that state
+for exactly one frame. The initial frame is painted once; a tick or input only
+repaints when update returns `UpdateResult::Dirty`, while resize always repaints
+and a `RedrawHandle` can wake the loop from another thread:
 
 ```rust,ignore
 use std::time::Duration;
@@ -674,19 +675,29 @@ let runner = Runner::new(RunnerConfig {
     tick_rate: Duration::from_secs(2),
     ..RunnerConfig::default()
 });
-let mut stats = Stats::default();
-runner.run(
-    &Theme::default(),
-    &mut stats,
-    |stats, _frame| element(Text::raw(stats.summary())),
-    |stats, signal| match signal {
-        Signal::Tick if stats.refresh() => UpdateResult::Dirty,
-        Signal::Event(Event::Key(k)) if k.plain() && k.code == KeyCode::Char('q') =>
-            UpdateResult::Exit,
-        _ => UpdateResult::Clean,
-    },
-)?;
+impl Application for Stats {
+    fn update(&mut self, signal: Signal) -> UpdateResult {
+        match signal {
+            Signal::Tick if self.refresh() => UpdateResult::Dirty,
+            Signal::Event(Event::Key(k))
+                if k.plain() && k.code == KeyCode::Char('q') => UpdateResult::Exit,
+            _ => UpdateResult::Clean,
+        }
+    }
+
+    fn view(&self, _frame: u64) -> ScopedElement<'_> {
+        element(Text::raw(self.summary()))
+    }
+}
+
+let mut app = Stats::default();
+runner.run_app(&Theme::default(), &mut app)?;
 ```
+
+`Runner::run` and `run_with_backend` retain the separate state/view/update
+closure API for owned `Element` trees. The
+[`borrowed_app`](examples/borrowed_app.rs) example implements a custom `View`
+that directly borrows a `String` from its application.
 
 `Runner::with_clock` replaces the default `SystemClock` when a replayable host
 or deterministic test owns monotonic time. The same `Clock` seam drives
@@ -817,6 +828,8 @@ module draws a `View` into an in-memory ratatui `Buffer` and reads it back:
   of sizes, for resize and degenerate-size sweeps.
 - `TestHarness<State>` — drive `Signal`s through state/update/view functions,
   resize deterministically, and receive a buffer only for dirty updates.
+  `render_app` / `step_app` do the same for an `Application`, including scoped
+  views and mandatory resize redraws.
 
 ```rust
 use tuika::testing::{grid, render};

--- a/examples/borrowed_app.rs
+++ b/examples/borrowed_app.rs
@@ -1,0 +1,64 @@
+//! Data-driven application whose custom view borrows application state.
+//!
+//! Run with `cargo run --example borrowed_app`. Press any key to increment the
+//! counter; press `q` or Escape to quit.
+
+use std::io;
+
+use tuika::prelude::*;
+
+struct CounterApp {
+    title: String,
+    count: u64,
+}
+
+struct CounterView<'app> {
+    title: &'app str,
+    count: u64,
+}
+
+impl View for CounterView<'_> {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
+        Size::new(available.width, 2.min(available.height))
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        surface.set_string(area.x, area.y, self.title, ctx.theme.text_style());
+        if area.height > 1 {
+            let count = format!("count: {}", self.count);
+            surface.set_string(area.x, area.y + 1, &count, ctx.theme.accent_style());
+        }
+    }
+}
+
+impl Application for CounterApp {
+    fn update(&mut self, signal: Signal) -> UpdateResult {
+        match signal {
+            Signal::Event(Event::Key(key))
+                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+            {
+                UpdateResult::Exit
+            }
+            Signal::Event(Event::Key(_)) => {
+                self.count = self.count.saturating_add(1);
+                UpdateResult::Dirty
+            }
+            _ => UpdateResult::Clean,
+        }
+    }
+
+    fn view(&self, _frame: u64) -> ScopedElement<'_> {
+        element(CounterView {
+            title: &self.title,
+            count: self.count,
+        })
+    }
+}
+
+fn main() -> io::Result<()> {
+    let mut app = CounterApp {
+        title: "Borrowed application state".into(),
+        count: 0,
+    };
+    Runner::new(RunnerConfig::default()).run_app(&Theme::default(), &mut app)
+}

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,16 @@
 # Knowledge Log
 
+## 2026-08-06
+
+- **Application frames may borrow application state**
+
+- The synchronous runner accepts an `Application` whose pure frame builder
+  returns `ScopedElement<'_>` from `&self`; persistent mutations remain confined
+  to signal updates through `&mut self`.
+- Resize signals always invalidate the frame because terminal geometry changes
+  layout even when application data does not change. The owned-element closure
+  runner remains compatible.
+
 ## 2026-08-05
 
 - **Agent interaction primitives remain host-owned compositions**

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`Element`/`ScopedElement`/`RenderCtx`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`Element`/`ScopedElement`/`RenderCtx`, `Application`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -83,10 +83,14 @@ rather than beside it.
 - **The host owns the terminal**: the screen mode (alternate screen or a split
   footer over live scrollback — see [screen-modes.md](./screen-modes.md)), raw
   mode, mouse capture, input translation, and frame compositing.
-- **Runners own application state directly**: rendering receives `&State`,
-  updates receive `&mut State` plus a tick or input signal, and repaint is an
-  explicit dirty result (or, synchronously, an external redraw request).
-  Rendering stays pure, and idle ticks do not churn the terminal. The
+- **Runners own application state directly**: `Application` receives signals
+  through `&mut self` and builds a `ScopedElement<'_>` through `&self`, so a
+  frame can borrow application data without shared interior mutability. The
+  compatible closure seam renders an owned `Element` from `&State` and updates
+  through `&mut State`. Repaint is an explicit dirty result (or, synchronously,
+  an external redraw request); terminal resize is the exception because layout
+  must be repainted even when application state is unchanged. Rendering stays
+  pure, and idle ticks do not churn the terminal. The
   synchronous runner's monotonic clock defaults to the process clock and is
   replaceable for deterministic hosts.
   `RunnerCore` is the runtime-neutral dirty/render/exit state machine used by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,9 @@ pub use output::{OneShotOptions, render_once, write_once};
 pub use overlay::{Overlay, OverlaySpec, TargetAlign, TargetPlacement, TargetSide};
 #[cfg(feature = "async")]
 pub use runner::AsyncRunner;
-pub use runner::{Runner, RunnerAction, RunnerConfig, RunnerCore, Signal, UpdateResult};
+pub use runner::{
+    Application, Runner, RunnerAction, RunnerConfig, RunnerCore, Signal, UpdateResult,
+};
 pub use scene::{Backdrop, Scene, SceneOverlay, ScopedScene};
 pub use screen::{ScreenMode, Scrollback};
 pub use style::{SemanticRole, StyleResolver, StyleRole, StyleSheet, Theme};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,14 +39,14 @@ pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.
 pub use crate::view;
 pub use crate::{
-    Align, AlignContent, AvailableSpace, Backdrop, Clock, Dimension, Direction, DockEdge,
-    DockLayout, DockPlacement, DockSpec, DockState, Element, Event, EventFlow, FlexItemStyle,
-    FlexWrap, InputOutcome, Justify, Key, KeyCode, LayoutStyle, MeasureRequest, Mouse, MouseButton,
-    MouseCapture, MouseKind, OneShotOptions, Overlay, OverlaySpec, Padding, RenderCtx, Runner,
-    RunnerAction, RunnerConfig, RunnerCore, Scene, SceneOverlay, ScopedElement, ScopedScene,
-    ScreenMode, Scrollback, SemanticRole, Signal, Size, StyleSheet, Surface, SystemClock,
-    TargetAlign, TargetPlacement, TargetSide, TerminalSession, TerminalSessionConfig, Theme,
-    UpdateResult, View, element, paint, paint_scene, paint_with_context, paint_with_sheet,
+    Align, AlignContent, Application, AvailableSpace, Backdrop, Clock, Dimension, Direction,
+    DockEdge, DockLayout, DockPlacement, DockSpec, DockState, Element, Event, EventFlow,
+    FlexItemStyle, FlexWrap, InputOutcome, Justify, Key, KeyCode, LayoutStyle, MeasureRequest,
+    Mouse, MouseButton, MouseCapture, MouseKind, OneShotOptions, Overlay, OverlaySpec, Padding,
+    RenderCtx, Runner, RunnerAction, RunnerConfig, RunnerCore, Scene, SceneOverlay, ScopedElement,
+    ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal, Size, StyleSheet, Surface,
+    SystemClock, TargetAlign, TargetPlacement, TargetSide, TerminalSession, TerminalSessionConfig,
+    Theme, UpdateResult, View, element, paint, paint_scene, paint_with_context, paint_with_sheet,
     render_once, translate_event, write_once,
 };
 

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -259,9 +259,13 @@ impl AsyncRunner {
                 },
             };
 
+            let requires_redraw = signal.requires_redraw();
             core.apply(update(state, signal).await);
             if core.is_exited() {
                 break;
+            }
+            if requires_redraw {
+                core.request_redraw();
             }
             if split {
                 // Publishing scrolls the terminal and may clear the viewport,
@@ -434,6 +438,44 @@ mod tests {
             1,
             "clean input leaves the initial frame intact"
         );
+    }
+
+    #[tokio::test]
+    async fn clean_resize_updates_still_repaint() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(16, 1);
+        let mut state = ();
+        let views = std::cell::Cell::new(0usize);
+        let events = tokio_stream::iter([
+            Ok(Event::Resize {
+                width: 16,
+                height: 1,
+            }),
+            key(KeyCode::Esc),
+        ]);
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut state,
+                events,
+                |_state, _frame| {
+                    views.set(views.get() + 1);
+                    element(Text::raw("frame"))
+                },
+                async |_state, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    _ => UpdateResult::Clean,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(views.get(), 2, "resize repaints after the initial frame");
     }
 
     // The initial frame is painted before any signal is handled, so a run that

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -14,6 +14,10 @@
 //! question about the host's existing runtime, not about which part of tuika to
 //! reach for.
 //!
+//! Synchronous applications whose views borrow their own state implement
+//! [`Application`] and run through [`Runner::run_app`]. The original
+//! state/view/update closure API remains available for owned [`Element`] trees.
+//!
 //! A host with its own event loop needs neither: call [`paint`] directly.
 
 #[cfg(feature = "async")]
@@ -33,7 +37,10 @@ use ratatui_crossterm::CrosstermBackend;
 
 use crate::live::RedrawHandle;
 use crate::screen::{ScreenMode, Scrollback, close_footer, pin_footer};
-use crate::{Clock, Element, Event, SystemClock, TerminalSession, Theme, paint, translate_event};
+use crate::{
+    Clock, Element, Event, ScopedElement, SystemClock, TerminalSession, Theme, View, paint,
+    translate_event,
+};
 
 #[derive(Clone, Copy, Debug)]
 /// Options for [`Runner`] and [`AsyncRunner`].
@@ -59,8 +66,15 @@ impl Default for RunnerConfig {
 pub enum Signal {
     /// The configured tick interval elapsed.
     Tick,
-    /// A translated terminal input event arrived.
+    /// A translated terminal input event arrived. Resize events force a redraw
+    /// after the update unless it exits, even when the update is clean.
     Event(Event),
+}
+
+impl Signal {
+    fn requires_redraw(&self) -> bool {
+        matches!(self, Self::Event(Event::Resize { .. }))
+    }
 }
 
 /// What a runner should do after an update.
@@ -73,6 +87,24 @@ pub enum UpdateResult {
     Dirty,
     /// Stop the runner without painting another frame.
     Exit,
+}
+
+/// A data-driven synchronous terminal application.
+///
+/// The runner mutably borrows the application only while delivering a
+/// [`Signal`], then immutably borrows it to build the next frame. Because the
+/// returned tree is scoped to that immutable borrow, custom views can read
+/// application data directly without cloning it into an owned [`Element`] or
+/// sharing it through `Rc<RefCell<_>>`.
+///
+/// Rendering should be pure: persistent UI and domain state belongs on the
+/// application and changes only in [`update`](Self::update).
+pub trait Application {
+    /// Update application state in response to a tick or terminal event.
+    fn update(&mut self, signal: Signal) -> UpdateResult;
+
+    /// Build the ephemeral view tree for one numbered frame.
+    fn view(&self, frame: u64) -> ScopedElement<'_>;
 }
 
 /// Runtime-neutral decision produced by [`RunnerCore`].
@@ -224,9 +256,65 @@ impl Runner {
         )
     }
 
+    /// Run a data-driven [`Application`] on the real terminal.
+    ///
+    /// This is the borrowed-view counterpart to [`run`](Self::run). It uses the
+    /// same terminal lifecycle, scheduling, redraw, and split-footer behavior.
+    pub fn run_app<A: Application>(&self, theme: &Theme, app: &mut A) -> io::Result<()> {
+        self.run_app_with_backend(theme, CrosstermBackend::new(io::stdout()), app)
+    }
+
     /// Run with a caller-provided backend, such as
     /// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend).
     pub fn run_with_backend<S, B, V, U>(
+        &self,
+        theme: &Theme,
+        backend: B,
+        state: &mut S,
+        mut view: V,
+        update: U,
+    ) -> io::Result<()>
+    where
+        B: Backend<Error = io::Error>,
+        V: FnMut(&S, u64) -> Element,
+        U: FnMut(&mut S, Signal) -> UpdateResult,
+    {
+        self.run_with_backend_inner(
+            theme,
+            backend,
+            state,
+            |state, frame, paint_root| {
+                let root = view(state, frame);
+                paint_root(root.as_ref());
+            },
+            update,
+        )
+    }
+
+    /// Run a data-driven [`Application`] with a caller-provided backend.
+    pub fn run_app_with_backend<A, B>(
+        &self,
+        theme: &Theme,
+        backend: B,
+        app: &mut A,
+    ) -> io::Result<()>
+    where
+        A: Application,
+        B: Backend<Error = io::Error>,
+    {
+        self.run_with_backend_inner(
+            theme,
+            backend,
+            app,
+            |app, frame, paint_root| {
+                let root = app.view(frame);
+                paint_root(root.as_ref());
+            },
+            Application::update,
+        )
+    }
+
+    fn run_with_backend_inner<S, B, V, U>(
         &self,
         theme: &Theme,
         backend: B,
@@ -236,7 +324,7 @@ impl Runner {
     ) -> io::Result<()>
     where
         B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64) -> Element,
+        V: FnMut(&S, u64, &mut dyn FnMut(&dyn View)),
         U: FnMut(&mut S, Signal) -> UpdateResult,
     {
         let mode = self.config.screen_mode;
@@ -298,9 +386,14 @@ impl Runner {
             if event::poll(timeout)?
                 && let Some(event) = translate_event(event::read()?)
             {
-                core.apply(update(state, Signal::Event(event)));
+                let signal = Signal::Event(event);
+                let requires_redraw = signal.requires_redraw();
+                core.apply(update(state, signal));
                 if core.is_exited() {
                     break 'running;
+                }
+                if requires_redraw {
+                    core.request_redraw();
                 }
             }
         }
@@ -328,12 +421,13 @@ fn draw<S, B, V, Er>(
 ) -> Result<(), Er>
 where
     B: Backend<Error = Er>,
-    V: FnMut(&S, u64) -> Element,
+    V: FnMut(&S, u64, &mut dyn FnMut(&dyn View)),
 {
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
-        let root = view(state, frame);
-        paint(terminal_frame.buffer_mut(), area, theme, root.as_ref(), &[]);
+        view(state, frame, &mut |root| {
+            paint(terminal_frame.buffer_mut(), area, theme, root, &[]);
+        });
     })?;
     Ok(())
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -4,8 +4,8 @@ use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 
 use crate::{
-    Element, RenderCtx, Signal, StyleSheet, Theme, UpdateResult, View, paint, paint_with_context,
-    paint_with_sheet,
+    Application, Element, Event, RenderCtx, Signal, StyleSheet, Theme, UpdateResult, View, paint,
+    paint_with_context, paint_with_sheet,
 };
 
 /// A deterministic, terminal-free application harness.
@@ -79,16 +79,52 @@ impl<S> TestHarness<S> {
 
     /// Deliver a signal, rendering only when the update marks the app dirty.
     ///
-    /// `None` represents both a clean update and exit; inspect the returned
-    /// [`UpdateResult`] to distinguish them.
+    /// Resize updates also render because layout depends on viewport geometry.
+    /// Otherwise, `None` represents both a clean update and exit; inspect the
+    /// returned [`UpdateResult`] to distinguish them.
     pub fn step(
         &mut self,
         signal: Signal,
         update: impl FnOnce(&mut S, Signal) -> UpdateResult,
         view: impl FnOnce(&S, u64) -> Element,
     ) -> (UpdateResult, Option<Buffer>) {
+        let resized = self.apply_resize_signal(&signal);
         let result = update(&mut self.state, signal);
-        let frame = (result == UpdateResult::Dirty).then(|| self.render(view));
+        let frame = (result != UpdateResult::Exit && (result == UpdateResult::Dirty || resized))
+            .then(|| self.render(view));
+        (result, frame)
+    }
+
+    fn apply_resize_signal(&mut self, signal: &Signal) -> bool {
+        if let Signal::Event(Event::Resize { width, height }) = signal {
+            self.resize(*width, *height);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<A: Application> TestHarness<A> {
+    /// Build and render the application's next frame, including borrowed views.
+    pub fn render_app(&mut self) -> Buffer {
+        let root = self.state.view(self.frame);
+        let buffer = render(root.as_ref(), self.width, self.height, &self.theme);
+        drop(root);
+        self.frame = self.frame.wrapping_add(1);
+        buffer
+    }
+
+    /// Deliver a signal through [`Application::update`] and render when needed.
+    ///
+    /// Resize events always produce a frame unless the application exits,
+    /// matching the terminal runners even when `update` returns
+    /// [`UpdateResult::Clean`].
+    pub fn step_app(&mut self, signal: Signal) -> (UpdateResult, Option<Buffer>) {
+        let resized = self.apply_resize_signal(&signal);
+        let result = self.state.update(signal);
+        let frame = (result != UpdateResult::Exit && (result == UpdateResult::Dirty || resized))
+            .then(|| self.render_app());
         (result, frame)
     }
 }

--- a/tests/application_runtime.rs
+++ b/tests/application_runtime.rs
@@ -1,0 +1,60 @@
+use tuika::prelude::*;
+use tuika::testing::{TestHarness, grid};
+
+struct BorrowedLabel<'app> {
+    text: &'app str,
+}
+
+impl View for BorrowedLabel<'_> {
+    fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
+        Size::new(available.width, available.height.min(1))
+    }
+
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        surface.set_string(area.x, area.y, self.text, ctx.theme.text_style());
+    }
+}
+
+struct App {
+    label: String,
+}
+
+impl Application for App {
+    fn update(&mut self, signal: Signal) -> UpdateResult {
+        match signal {
+            Signal::Tick => {
+                self.label.push('!');
+                UpdateResult::Dirty
+            }
+            Signal::Event(Event::Resize { .. }) => UpdateResult::Clean,
+            Signal::Event(_) => UpdateResult::Exit,
+        }
+    }
+
+    fn view(&self, _frame: u64) -> ScopedElement<'_> {
+        element(BorrowedLabel { text: &self.label })
+    }
+}
+
+#[test]
+fn application_frames_borrow_state_and_resize_repaints() {
+    let mut harness = TestHarness::new(
+        App {
+            label: "borrowed".into(),
+        },
+        10,
+        1,
+    );
+
+    assert_eq!(grid(&harness.render_app()), "borrowed  ");
+    let (result, frame) = harness.step_app(Signal::Tick);
+    assert_eq!(result, UpdateResult::Dirty);
+    assert_eq!(grid(&frame.unwrap()), "borrowed! ");
+
+    let (result, frame) = harness.step_app(Signal::Event(Event::Resize {
+        width: 12,
+        height: 1,
+    }));
+    assert_eq!(result, UpdateResult::Clean);
+    assert_eq!(grid(&frame.unwrap()), "borrowed!   ");
+}


### PR DESCRIPTION
## What changed

Adds a data-driven `Application` runtime for synchronous Tuika applications. `Application::update` owns mutation and `Application::view` returns `ScopedElement<'_>`, allowing custom views to borrow application state for one frame without `Rc<RefCell<_>>` or an owned static tree.

`Runner::run_app` and `run_app_with_backend` use the existing terminal lifecycle and scheduling loop. Resize signals now force a repaint after clean updates in both synchronous and async runners. `TestHarness::render_app` and `step_app` provide terminal-free coverage of the same contract.

This is an additive, non-breaking public API change. Existing `Runner::run` and `run_with_backend` closure signatures remain available.

## Why

Scoped elements already support borrowed frame trees, but the runner closure API required an owned `Element`, preventing applications from using that capability at the runtime boundary. The new trait connects the existing borrowed view model to the runner while keeping rendering pure and state host-owned.

## Before / After

Before: runner views had to return an owned static `Element`; borrowed custom views required cloning or interior-mutability wrappers.

After: `Application::view(&self, frame) -> ScopedElement<'_>` directly borrows application data. The consumer integration test renders borrowed text, updates it, then verifies a clean resize still redraws at the new dimensions. A PTY smoke run of `cargo run --example borrowed_app` rendered `count: 0`, processed input to render `count: 1`, exited through `q`, and restored terminal state.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --strict --check-links`
- PTY smoke: `cargo run --example borrowed_app`

## Risk

- Medium
- The synchronous runner was internally adapted to paint borrowed and owned roots through one callback-style loop. Existing public closure signatures are unchanged, and full workspace, PTY, packaging, and doctest suites pass.
- Resize behavior intentionally changes: an application cannot suppress the layout repaint by returning `Clean`; `Exit` still prevents another frame.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/architecture.md`, `knowledge/specs/api-surface.md`, and `knowledge/log.md` to record the borrowed application boundary and mandatory resize invalidation.

## Security

- TM-ESC: no new escape encoder or caller-controlled escape path; rendering still uses the existing cell-buffer painter.
- TM-STATE: `run_app` shares the existing `TerminalSession` guard, cleanup, split-footer lifecycle, and error paths. The PTY smoke confirmed normal restoration.
- TM-PARSE: no parser or untrusted-content changes.
- TM-CLIP: borrowed views use the existing clipped `Surface`; integration coverage asserts cells before and after resize.
- TM-DEP: no dependencies added.

## Follow-ups

No follow-ups.
