### PR TITLE
feat(components): project keyed table rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ described in the release process begins with the entry below.
   preserving application-key selection across reorder, filtering, and
   streaming updates, with scrolling margins, keyboard/mouse navigation,
   responsive columns, aligned styled cells, and leading cursor/check indicators.
+- `KeyedRowSource` and `NavigableKeyedRowSource` let `KeyedTable` borrow an
+  indirect visible order from authoritative storage, compare computed composite
+  identity without per-frame key clones, and materialize a key only when input
+  changes selection. Indexed `KeyedColumn` constructors project parallel row
+  metadata such as fuzzy-match spans without cached wrapper rows.
 - `AppShell` composes a responsive tool-style application frame from borrowed
   or owned header, main, status, and footer views, with optional theme-aware
   rules and short-terminal chrome collapse.

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ component. Linked names below jump straight to their demo.
 | `Form` / `FormField` (+ `FormState`) | Responsive labeled controls and validation |
 | `DrawView` / `CanvasView` | Closure-based custom cell drawing |
 | [`SelectList`](docs/components.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
-| [`KeyedTable`](docs/components.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized rows whose selection follows stable application keys |
+| [`KeyedTable`](docs/components.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
 | [`CompletionPalette`](docs/components.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
 | `Slider` (+ `SliderState`) | One-row value picker over a numeric range |
 | [`TextInput`](docs/components.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |

--- a/docs/components.md
+++ b/docs/components.md
@@ -664,13 +664,16 @@ view! { node(Table::new(columns, rows, &state).selection_style(style).caret('▶
 ### `KeyedTable` + `KeyedSelectState`
 
 A virtualized table for large, changing host collections. It borrows domain
-rows for one frame and calls each `KeyedColumn` only for the visible window;
-row data is not cloned into widget-owned cells. `KeyedSelectState<K>` and
+rows for one frame—either directly from a slice or through a
+`KeyedRowSource<K>` that maps visible indices into authoritative storage—and
+calls each `KeyedColumn` only for the visible window. Row data is not cloned
+into widget-owned cells. `KeyedSelectState<K>` and
 `KeyedMultiSelectState<K>` store application keys rather than positions, so a
 selection follows the same record through reorder, insertion, filtering, and
 streaming refreshes. Keys must be unique within the authoritative collection.
 Filtering preserves absent keys; call `retain_present`
-with the authoritative collection when records are truly deleted.
+or `retain_present_source` with the authoritative collection when records are
+truly deleted.
 
 Columns support fixed, auto, and flex sizing, trailing alignment,
 `hide_below(width)` breakpoints, and optional-column shedding. Styled borrowed
@@ -680,9 +683,19 @@ common leading indicators. Keyboard aliases reuse `SelectNavigation`; Page
 Up/Down, Home/End, wheel scrolling, explicit mouse hit-testing, and configurable
 scroll margin share `VirtualWindow` geometry. Hosts with a key-to-position index
 can pass `selected_index` to avoid a collection scan without making the index
-persistent identity. The runnable
+persistent identity.
+
+For searchable application rows, `KeyedRowSource::key_eq` compares a projected
+row directly with the owned selection key. Composite identity such as
+`(Agent, session_id)` therefore needs no copied key per visible row, while
+`NavigableKeyedRowSource::key` materializes one only when keyboard or mouse
+input selects a row. The `*_indexed` column constructors receive the visible
+row index, which joins parallel fuzzy positions or other decoration metadata
+without a cached wrapper model. The runnable
 [`keyed_table` example](https://github.com/everruns/tuika/blob/main/examples/keyed_table.rs)
-reorders, filters, inserts, and deletes rows while selection stays keyed.
+uses an AGF-shaped `Vec<Session>` plus `Vec<usize>` visible order and parallel
+fuzzy positions; it reorders, filters, inserts, and deletes rows while
+composite-key selection stays stable.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.KeyedTable.html)
 
 <img src="demos/keyed_table.gif" width="880" alt="Keyed table selection following a row through reorder and filtering">
@@ -696,6 +709,49 @@ fn name(job: &Job) -> Line<'_> { Line::from(job.name.as_str()) }
 let state = KeyedSelectState::with_selected(42);
 let columns = vec![KeyedColumn::flex("job", 1, name)];
 let table = KeyedTable::new(columns, &jobs, key, &state);
+```
+
+An indirect source replaces per-frame wrapper construction. Counting nonblank
+Rust source lines exactly as shown, the per-frame caller falls from **20 LOC to
+8 LOC** (−60%); the source's trait implementation is one-time and shared by
+rendering, keyboard navigation, mouse hit-testing, and deletion reconciliation.
+
+Before—copied composite keys and metadata in wrapper rows:
+
+```rust
+struct VisibleSession<'a> {
+    session: &'a Session,
+    key: SessionKey,
+    fuzzy: &'a [usize],
+}
+let rows = visible.iter().enumerate().map(|(row, &source)| {
+    VisibleSession {
+        session: &sessions[source],
+        key: sessions[source].key(),
+        fuzzy: &fuzzy[row],
+    }
+}).collect::<Vec<_>>();
+let table = KeyedTable::new(
+    vec![KeyedColumn::flex("summary", 1, |row: &VisibleSession<'_>| {
+        highlighted(&row.session.summary, row.fuzzy)
+    })],
+    &rows,
+    |row| &row.key,
+    &state,
+);
+```
+
+After—authoritative rows and parallel metadata stay in place:
+
+```rust
+let source = SessionRows { sessions: &sessions, visible: &visible };
+let table = KeyedTable::source(
+    vec![KeyedColumn::flex_indexed("summary", 1, |row, session: &Session| {
+        highlighted(&session.summary, &fuzzy[row])
+    })],
+    &source,
+    &state,
+);
 ```
 
 ### `Tabs` + `TabsState`

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -398,7 +398,7 @@ const DEMOS: &[Demo] = &[
     demo(
         "keyed_table",
         "KeyedTable",
-        "borrowed rows with stable keyed selection",
+        "projected borrowed rows with stable keyed selection",
         11,
         true,
         scene_keyed_table,
@@ -1559,44 +1559,48 @@ static KEYED_ROWS: [KeyedDemoRow; 6] = [
     },
 ];
 
-static KEYED_REORDERED: [&KeyedDemoRow; 6] = [
-    &KEYED_ROWS[4],
-    &KEYED_ROWS[0],
-    &KEYED_ROWS[3],
-    &KEYED_ROWS[2],
-    &KEYED_ROWS[5],
-    &KEYED_ROWS[1],
-];
-static KEYED_ORIGINAL: [&KeyedDemoRow; 6] = [
-    &KEYED_ROWS[0],
-    &KEYED_ROWS[1],
-    &KEYED_ROWS[2],
-    &KEYED_ROWS[3],
-    &KEYED_ROWS[4],
-    &KEYED_ROWS[5],
-];
-static KEYED_FILTERED: [&KeyedDemoRow; 2] = [&KEYED_ROWS[0], &KEYED_ROWS[4]];
+static KEYED_REORDERED: [usize; 6] = [4, 0, 3, 2, 5, 1];
+static KEYED_ORIGINAL: [usize; 6] = [0, 1, 2, 3, 4, 5];
+static KEYED_FILTERED: [usize; 2] = [0, 4];
 static KEYED_SELECTION: KeyedSelectState<u64> = KeyedSelectState::with_selected(103);
 
-fn keyed_demo_key<'row>(row: &'row &KeyedDemoRow) -> &'row u64 {
-    &row.id
+struct KeyedDemoRows {
+    visible: &'static [usize],
 }
 
-fn keyed_demo_name<'row>(row: &'row &KeyedDemoRow) -> Line<'row> {
+impl KeyedRowSource<u64> for KeyedDemoRows {
+    type Row = KeyedDemoRow;
+
+    fn len(&self) -> usize {
+        self.visible.len()
+    }
+
+    fn row(&self, index: usize) -> Option<&Self::Row> {
+        self.visible
+            .get(index)
+            .and_then(|&index| KEYED_ROWS.get(index))
+    }
+
+    fn key_eq(&self, _index: usize, row: &Self::Row, key: &u64) -> bool {
+        row.id == *key
+    }
+}
+
+fn keyed_demo_name(row: &KeyedDemoRow) -> Line<'_> {
     Line::from(row.name)
 }
 
-fn keyed_demo_state<'row>(row: &'row &KeyedDemoRow) -> Line<'row> {
+fn keyed_demo_state(row: &KeyedDemoRow) -> Line<'_> {
     Line::from(row.state)
 }
 
-fn keyed_demo_age<'row>(row: &'row &KeyedDemoRow) -> Line<'row> {
+fn keyed_demo_age(row: &KeyedDemoRow) -> Line<'_> {
     Line::from(format!("{}s", row.age))
 }
 
 fn scene_keyed_table(frame: u64, _theme: &Theme) -> Element {
     let phase = (frame / 18) % 3;
-    let rows: &'static [&'static KeyedDemoRow] = match phase {
+    let visible: &'static [usize] = match phase {
         0 => &KEYED_REORDERED,
         1 => &KEYED_FILTERED,
         _ => &KEYED_ORIGINAL,
@@ -1610,15 +1614,14 @@ fn scene_keyed_table(frame: u64, _theme: &Theme) -> Element {
         col {
             fixed(1) { node(Text::raw(label)) }
             grow(1) {
-                node(KeyedTable::new(
+                node(KeyedTable::source(
                     vec![
-                        KeyedColumn::fixed("id", 5, |row: &&KeyedDemoRow| Line::from(row.id.to_string())).right(),
+                        KeyedColumn::fixed("id", 5, |row: &KeyedDemoRow| Line::from(row.id.to_string())).right(),
                         KeyedColumn::flex("task", 2, keyed_demo_name),
                         KeyedColumn::fixed("state", 8, keyed_demo_state).hide_below(34),
                         KeyedColumn::fixed("age", 5, keyed_demo_age).right().optional(),
                     ],
-                    rows,
-                    keyed_demo_key,
+                    KeyedDemoRows { visible },
                     &KEYED_SELECTION,
                 ))
             }

--- a/examples/keyed_table.rs
+++ b/examples/keyed_table.rs
@@ -1,4 +1,4 @@
-//! Dynamic borrowed rows with stable keyed selection and viewport rendering.
+//! AGF-shaped sessions projected from authoritative storage into a keyed table.
 //!
 //! Run with `cargo run --example keyed_table`. Use arrows, Page Up/Down,
 //! Home/End, the mouse wheel, or click a row. Space/Enter checks a row; `r`
@@ -12,98 +12,205 @@ use ratatui_core::terminal::Terminal;
 use ratatui_crossterm::CrosstermBackend;
 use tuika::prelude::*;
 
-struct Job {
-    id: u64,
-    name: String,
-    status: &'static str,
-    age: u16,
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum Agent {
+    Claude,
+    Codex,
+}
+
+impl Agent {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SessionKey {
+    agent: Agent,
+    session_id: String,
+}
+
+struct Session {
+    agent: Agent,
+    session_id: String,
+    summary: String,
+    branch: Option<String>,
+    pinned: bool,
+}
+
+struct SessionRows<'a> {
+    sessions: &'a [Session],
+    visible: &'a [usize],
+}
+
+impl KeyedRowSource<SessionKey> for SessionRows<'_> {
+    type Row = Session;
+
+    fn len(&self) -> usize {
+        self.visible.len()
+    }
+
+    fn row(&self, index: usize) -> Option<&Self::Row> {
+        self.visible
+            .get(index)
+            .and_then(|&source_index| self.sessions.get(source_index))
+    }
+
+    fn key_eq(&self, _index: usize, row: &Self::Row, key: &SessionKey) -> bool {
+        row.agent == key.agent && row.session_id == key.session_id
+    }
+}
+
+impl NavigableKeyedRowSource<SessionKey> for SessionRows<'_> {
+    fn key(&self, _index: usize, row: &Self::Row) -> SessionKey {
+        SessionKey {
+            agent: row.agent,
+            session_id: row.session_id.clone(),
+        }
+    }
 }
 
 struct App {
-    jobs: Vec<Job>,
-    selection: KeyedMultiSelectState<u64>,
-    filter_running: bool,
+    sessions: Vec<Session>,
+    visible: Vec<usize>,
+    fuzzy: Vec<Vec<usize>>,
+    selection: KeyedMultiSelectState<SessionKey>,
+    filter_codex: bool,
     next_id: u64,
 }
 
 impl App {
     fn new() -> Self {
-        let jobs = (1..=30)
-            .map(|id| Job {
-                id,
-                name: format!("worker-{id:02}"),
-                status: if id % 3 == 0 { "queued" } else { "running" },
-                age: id as u16 * 3,
+        let sessions = (1..=30)
+            .map(|id| Session {
+                agent: if id % 2 == 0 {
+                    Agent::Codex
+                } else {
+                    Agent::Claude
+                },
+                // Both agent namespaces deliberately contain the same ids.
+                session_id: format!("session-{:02}", (id + 1) / 2),
+                summary: format!("searchable session {id:02}"),
+                branch: (id % 3 == 0).then(|| format!("feature/{id}")),
+                pinned: id % 7 == 0,
             })
             .collect();
-        let mut selection = KeyedMultiSelectState::new();
-        selection.cursor_mut().select(Some(1));
-        selection.cursor_mut().set_scroll_margin(2);
-        Self {
-            jobs,
-            selection,
-            filter_running: false,
+        let mut app = Self {
+            sessions,
+            visible: Vec::new(),
+            fuzzy: Vec::new(),
+            selection: KeyedMultiSelectState::new(),
+            filter_codex: false,
             next_id: 31,
+        };
+        app.refresh_projection();
+        let first = app.source().row(0).map(|row| SessionKey {
+            agent: row.agent,
+            session_id: row.session_id.clone(),
+        });
+        app.selection.cursor_mut().select(first);
+        app.selection.cursor_mut().set_scroll_margin(2);
+        app
+    }
+
+    fn source(&self) -> SessionRows<'_> {
+        SessionRows {
+            sessions: &self.sessions,
+            visible: &self.visible,
         }
     }
 
-    fn visible(&self) -> Vec<&Job> {
-        visible_jobs(&self.jobs, self.filter_running)
+    fn refresh_projection(&mut self) {
+        self.visible = self
+            .sessions
+            .iter()
+            .enumerate()
+            .filter(|(_, session)| !self.filter_codex || session.agent == Agent::Codex)
+            .map(|(index, _)| index)
+            .collect();
+        self.fuzzy = self
+            .visible
+            .iter()
+            .map(|&index| {
+                self.sessions[index]
+                    .summary
+                    .chars()
+                    .enumerate()
+                    .filter_map(|(position, ch)| (ch == 's').then_some(position))
+                    .collect()
+            })
+            .collect();
     }
 
     fn reorder(&mut self) {
-        let distance = 7.min(self.jobs.len());
-        self.jobs.rotate_left(distance);
+        let distance = 7.min(self.sessions.len());
+        self.sessions.rotate_left(distance);
+        self.refresh_projection();
     }
 
     fn insert(&mut self) {
         let id = self.next_id;
         self.next_id += 1;
-        self.jobs.insert(
+        self.sessions.insert(
             0,
-            Job {
-                id,
-                name: format!("stream-{id:02}"),
-                status: "running",
-                age: 0,
+            Session {
+                agent: Agent::Codex,
+                session_id: format!("stream-{id:02}"),
+                summary: format!("streamed session {id:02}"),
+                branch: None,
+                pinned: false,
             },
         );
+        self.refresh_projection();
     }
 
     fn delete_selected(&mut self) {
-        let selected = self.selection.cursor().selected().copied();
-        if let Some(id) = selected {
-            self.jobs.retain(|job| job.id != id);
-            self.selection.retain_present(&self.jobs, |job| &job.id);
+        let selected = self.selection.cursor().selected().cloned();
+        if let Some(key) = selected {
+            self.sessions.retain(|session| {
+                session.agent != key.agent || session.session_id != key.session_id
+            });
+            self.refresh_projection();
+            let source = SessionRows {
+                sessions: &self.sessions,
+                visible: &self.visible,
+            };
+            self.selection.retain_present_source(&source);
         }
     }
 }
 
-fn visible_jobs(jobs: &[Job], filter_running: bool) -> Vec<&Job> {
-    jobs.iter()
-        .filter(|job| !filter_running || job.status == "running")
-        .collect()
-}
-
-fn visible_key<'row>(row: &'row &Job) -> &'row u64 {
-    &row.id
-}
-
-fn name<'row>(row: &'row &Job) -> Line<'row> {
-    Line::from(row.name.as_str())
-}
-
-fn status<'row>(row: &'row &Job) -> Line<'row> {
-    let color = if row.status == "running" {
-        Color::Green
-    } else {
-        Color::Yellow
-    };
-    Line::styled(row.status, Style::default().fg(color))
-}
-
-fn age<'row>(row: &'row &Job) -> Line<'row> {
-    Line::from(format!("{}s", row.age))
+fn summary_line<'a>(summary: &'a str, positions: &[usize]) -> Line<'a> {
+    let mut spans = Vec::new();
+    let mut run_start = 0;
+    let mut highlighted = false;
+    for (character, (byte, _)) in summary.char_indices().enumerate() {
+        let next_highlighted = positions.contains(&character);
+        if next_highlighted != highlighted {
+            if byte > run_start {
+                let text = &summary[run_start..byte];
+                spans.push(if highlighted {
+                    Span::styled(text, Style::default().fg(Color::Yellow).bold())
+                } else {
+                    Span::raw(text)
+                });
+            }
+            run_start = byte;
+            highlighted = next_highlighted;
+        }
+    }
+    if run_start < summary.len() {
+        let text = &summary[run_start..];
+        spans.push(if highlighted {
+            Span::styled(text, Style::default().fg(Color::Yellow).bold())
+        } else {
+            Span::raw(text)
+        });
+    }
+    Line::from(spans)
 }
 
 fn main() -> io::Result<()> {
@@ -115,17 +222,16 @@ fn main() -> io::Result<()> {
     loop {
         terminal.draw(|frame| {
             let area = frame.area();
-            let visible = app.visible();
             let table_area = Rect::new(
                 area.x,
                 area.y.saturating_add(2),
                 area.width,
                 area.height.saturating_sub(2),
             );
-            let title = if app.filter_running {
-                "Keyed jobs · running only"
+            let title = if app.filter_codex {
+                "Projected sessions · codex only"
             } else {
-                "Keyed jobs · all rows"
+                "Projected sessions · all agents"
             };
             let ctx = RenderCtx::new(&theme);
             let mut surface = Surface::new(frame.buffer_mut(), area);
@@ -135,18 +241,29 @@ fn main() -> io::Result<()> {
                 &mut surface,
                 &ctx,
             );
-            KeyedTable::multi(
+            let source = app.source();
+            KeyedTable::multi_source(
                 vec![
-                    KeyedColumn::fixed("id", 4, |row: &&Job| Line::from(row.id.to_string()))
-                        .right(),
-                    KeyedColumn::flex("worker", 2, name),
-                    KeyedColumn::fixed("status", 8, status).hide_below(34),
-                    KeyedColumn::fixed("age", 6, age).right().optional(),
+                    KeyedColumn::fixed("pin", 3, |row: &Session| {
+                        Line::from(if row.pinned { "pin" } else { "" })
+                    }),
+                    KeyedColumn::fixed("agent", 7, |row: &Session| Line::from(row.agent.label())),
+                    KeyedColumn::flex_indexed("summary", 2, |index, row: &Session| {
+                        summary_line(&row.summary, &app.fuzzy[index])
+                    }),
+                    KeyedColumn::fixed("branch", 12, |row: &Session| {
+                        Line::from(row.branch.as_deref().unwrap_or(""))
+                    })
+                    .hide_below(52),
+                    KeyedColumn::fixed("id", 10, |row: &Session| {
+                        Line::from(row.session_id.as_str())
+                    })
+                    .optional(),
                 ],
-                &visible,
-                visible_key,
+                &source,
                 &app.selection,
             )
+            .preserve_selection_fg(true)
             .render(table_area, &mut surface, &ctx);
         })?;
 
@@ -162,39 +279,46 @@ fn main() -> io::Result<()> {
             match key.code {
                 KeyCode::Char('q') | KeyCode::Esc => break,
                 KeyCode::Char('r') => app.reorder(),
-                KeyCode::Char('f') => app.filter_running = !app.filter_running,
+                KeyCode::Char('f') => {
+                    app.filter_codex = !app.filter_codex;
+                    app.refresh_projection();
+                }
                 KeyCode::Char('a') => app.insert(),
                 KeyCode::Char('d') => app.delete_selected(),
                 _ => {
-                    let visible = visible_jobs(&app.jobs, app.filter_running);
+                    let source = SessionRows {
+                        sessions: &app.sessions,
+                        visible: &app.visible,
+                    };
                     let selection = &mut app.selection;
-                    let _ = selection.handle(
+                    let _ = selection.handle_source(
                         &input,
-                        &visible,
+                        &source,
                         terminal.size()?.height.saturating_sub(3) as usize,
-                        visible_key,
                         SelectNavigation::common(),
                     );
                 }
             }
         } else {
-            let visible = visible_jobs(&app.jobs, app.filter_running);
+            let source = SessionRows {
+                sessions: &app.sessions,
+                visible: &app.visible,
+            };
             let size = terminal.size()?;
             let table = Rect::new(0, 3, size.width, size.height.saturating_sub(3));
-            let window =
-                app.selection
-                    .cursor()
-                    .window(&visible, usize::from(table.height), visible_key);
+            let window = app
+                .selection
+                .cursor()
+                .window_source(&source, usize::from(table.height));
             let selection = &mut app.selection;
             let _ = match input {
                 Event::Mouse(ref mouse) if mouse.kind == MouseKind::Down(MouseButton::Left) => {
-                    selection.handle_mouse(&input, &visible, table, window, visible_key)
+                    selection.handle_mouse_source(&input, &source, table, window)
                 }
-                _ => selection.handle(
+                _ => selection.handle_source(
                     &input,
-                    &visible,
+                    &source,
                     usize::from(table.height),
-                    visible_key,
                     SelectNavigation::common(),
                 ),
             };
@@ -208,17 +332,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn dynamic_updates_keep_key_identity() {
+    fn projection_preserves_composite_identity() {
         let mut app = App::new();
-        app.selection.cursor_mut().select(Some(9));
+        app.selection.cursor_mut().select(Some(SessionKey {
+            agent: Agent::Codex,
+            session_id: "session-05".into(),
+        }));
         app.reorder();
-        assert_eq!(app.selection.cursor().selected(), Some(&9));
-        app.filter_running = true;
-        assert!(!app.visible().iter().any(|job| job.id == 9));
-        assert_eq!(app.selection.cursor().selected(), Some(&9));
-        app.filter_running = false;
-        assert!(app.visible().iter().any(|job| job.id == 9));
+        assert_eq!(
+            app.selection.cursor().selected().unwrap().agent,
+            Agent::Codex
+        );
+        app.filter_codex = true;
+        app.refresh_projection();
+        assert!(app.source().row(0).is_some());
         app.delete_selected();
-        assert_eq!(app.selection.cursor().selected(), None);
+        assert!(app.selection.cursor().selected().is_none());
     }
 }

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -31,6 +31,10 @@
   authoritative collection when deletion should remove it.
 - These keys are domain identity only. Views remain ephemeral and Tuika gains
   no virtual DOM, keyed lifecycle, or retained row components.
+- Indirect keyed row sources project visible indices into authoritative storage,
+  compare computed composite identity without allocation, and join parallel
+  metadata through indexed cells. Owned keys are created only on selection
+  changes, not during frame rendering.
 
 - **Composable application chrome remains frame-scoped**
 

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -187,12 +187,17 @@ thumb math without collapsing the distinct line/item measurement models.
 `SelectList::windowed` and `Table::windowed` let a host supply only that range;
 selection remains absolute and auto-width table columns intentionally measure
 only supplied rows, so stable virtualized widths use fixed or flex columns.
-`KeyedTable` instead borrows an ordered row slice, resolves a viewport from its
-host-owned keyed cursor and offset, and invokes cell adapters only inside that
-window. Temporary absence preserves a key because the component cannot infer
-filtering versus deletion; `retain_present` is the explicit authoritative-delete
-boundary. A host may supply the selected key's ephemeral current position to
-avoid a full lookup scan; the key remains the persisted identity.
+`KeyedTable` borrows either an ordered row slice or a source that projects
+visible indices into authoritative storage. A projected source compares its
+row fields directly with the host-owned key, so composite identity needs no
+cached key or per-frame allocation; it materializes an owned key only when an
+input action changes selection. Indexed cell adapters join parallel metadata
+without creating wrapper rows, and all cell work remains inside the resolved
+viewport. Temporary absence preserves a key because the component cannot infer
+filtering versus deletion; `retain_present` or `retain_present_source` is the
+explicit authoritative-delete boundary. A host may supply the selected key's
+ephemeral current position to avoid a full lookup scan; the key remains the
+persisted identity.
 
 ## Input and focus
 

--- a/src/components/keyed_table.rs
+++ b/src/components/keyed_table.rs
@@ -9,6 +9,7 @@
 //! indistinguishable to selection state.
 
 use std::collections::BTreeSet;
+use std::marker::PhantomData;
 
 use ratatui_core::layout::Rect;
 use ratatui_core::style::Style;
@@ -31,6 +32,8 @@ enum CellAlign {
     Right,
 }
 
+type KeyedCell<'a, R> = dyn for<'r> Fn(usize, &'r R) -> Line<'r> + 'a;
+
 /// One column in a [`KeyedTable`].
 ///
 /// The cell callback returns a borrowed, styled [`Line`]. It is invoked only
@@ -42,7 +45,7 @@ pub struct KeyedColumn<'a, R> {
     align: CellAlign,
     hide_below: Option<u16>,
     optional: bool,
-    cell: Box<dyn for<'r> Fn(&'r R) -> Line<'r> + 'a>,
+    cell: Box<KeyedCell<'a, R>>,
 }
 
 impl<'a, R> KeyedColumn<'a, R> {
@@ -50,6 +53,16 @@ impl<'a, R> KeyedColumn<'a, R> {
     pub fn new<F>(header: impl Into<Line<'a>>, width: Dimension, cell: F) -> Self
     where
         F: for<'r> Fn(&'r R) -> Line<'r> + 'a,
+    {
+        Self::new_indexed(header, width, move |_, row| cell(row))
+    }
+
+    /// A column whose borrowed cell callback also receives the row's visible index.
+    ///
+    /// Use the index to project parallel metadata such as fuzzy-match positions.
+    pub fn new_indexed<F>(header: impl Into<Line<'a>>, width: Dimension, cell: F) -> Self
+    where
+        F: for<'r> Fn(usize, &'r R) -> Line<'r> + 'a,
     {
         Self {
             header: header.into(),
@@ -69,6 +82,14 @@ impl<'a, R> KeyedColumn<'a, R> {
         Self::new(header, Dimension::Auto, cell)
     }
 
+    /// An auto-width column with a visible-index-aware cell callback.
+    pub fn auto_indexed<F>(header: impl Into<Line<'a>>, cell: F) -> Self
+    where
+        F: for<'r> Fn(usize, &'r R) -> Line<'r> + 'a,
+    {
+        Self::new_indexed(header, Dimension::Auto, cell)
+    }
+
     /// A column with a fixed cell width.
     pub fn fixed<F>(header: impl Into<Line<'a>>, cells: u16, cell: F) -> Self
     where
@@ -77,12 +98,28 @@ impl<'a, R> KeyedColumn<'a, R> {
         Self::new(header, Dimension::Fixed(cells), cell)
     }
 
+    /// A fixed-width column with a visible-index-aware cell callback.
+    pub fn fixed_indexed<F>(header: impl Into<Line<'a>>, cells: u16, cell: F) -> Self
+    where
+        F: for<'r> Fn(usize, &'r R) -> Line<'r> + 'a,
+    {
+        Self::new_indexed(header, Dimension::Fixed(cells), cell)
+    }
+
     /// A column sharing leftover width by `weight`.
     pub fn flex<F>(header: impl Into<Line<'a>>, weight: u16, cell: F) -> Self
     where
         F: for<'r> Fn(&'r R) -> Line<'r> + 'a,
     {
         Self::new(header, Dimension::Flex(weight), cell)
+    }
+
+    /// A flex-width column with a visible-index-aware cell callback.
+    pub fn flex_indexed<F>(header: impl Into<Line<'a>>, weight: u16, cell: F) -> Self
+    where
+        F: for<'r> Fn(usize, &'r R) -> Line<'r> + 'a,
+    {
+        Self::new_indexed(header, Dimension::Flex(weight), cell)
     }
 
     /// Align cells against the trailing edge of the column.
@@ -102,6 +139,125 @@ impl<'a, R> KeyedColumn<'a, R> {
     pub fn optional(mut self) -> Self {
         self.optional = true;
         self
+    }
+}
+
+/// Borrowed visible rows with application-defined stable identity.
+///
+/// A source can project an ordered view over authoritative storage without
+/// allocating wrapper rows. [`key_eq`](Self::key_eq) compares a row to an owned
+/// selection key without constructing or cloning that key during rendering.
+///
+/// ```
+/// use tuika::prelude::*;
+///
+/// #[derive(PartialEq)]
+/// struct Key { namespace: u8, id: String }
+/// struct Row { namespace: u8, id: String }
+/// struct Visible<'a> { rows: &'a [Row], order: &'a [usize] }
+///
+/// impl KeyedRowSource<Key> for Visible<'_> {
+///     type Row = Row;
+///     fn len(&self) -> usize { self.order.len() }
+///     fn row(&self, index: usize) -> Option<&Row> {
+///         self.order.get(index).and_then(|&source| self.rows.get(source))
+///     }
+///     fn key_eq(&self, _index: usize, row: &Row, key: &Key) -> bool {
+///         row.namespace == key.namespace && row.id == key.id
+///     }
+/// }
+/// ```
+pub trait KeyedRowSource<K> {
+    /// The authoritative row type borrowed by the table.
+    type Row;
+
+    /// Number of rows in the current visible order.
+    fn len(&self) -> usize;
+
+    /// Whether the current visible order is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Borrow the row at a visible index.
+    ///
+    /// This must return `Some` for every index below [`len`](Self::len).
+    fn row(&self, index: usize) -> Option<&Self::Row>;
+
+    /// Compare a row's stable identity with a host-owned key.
+    ///
+    /// Exactly one authoritative row may match a key.
+    fn key_eq(&self, index: usize, row: &Self::Row, key: &K) -> bool;
+}
+
+/// A keyed row source that can materialize identity when selection changes.
+///
+/// Rendering and lookup use [`KeyedRowSource::key_eq`]; this method is called
+/// only for keyboard or mouse actions that select a row.
+pub trait NavigableKeyedRowSource<K>: KeyedRowSource<K> {
+    /// Materialize the selected row's stable key for host-owned state.
+    ///
+    /// The result must compare equal through [`KeyedRowSource::key_eq`] for
+    /// this row.
+    fn key(&self, index: usize, row: &Self::Row) -> K;
+}
+
+impl<K, S: KeyedRowSource<K> + ?Sized> KeyedRowSource<K> for &S {
+    type Row = S::Row;
+
+    fn len(&self) -> usize {
+        (**self).len()
+    }
+
+    fn row(&self, index: usize) -> Option<&Self::Row> {
+        (**self).row(index)
+    }
+
+    fn key_eq(&self, index: usize, row: &Self::Row, key: &K) -> bool {
+        (**self).key_eq(index, row, key)
+    }
+}
+
+impl<K, S: NavigableKeyedRowSource<K> + ?Sized> NavigableKeyedRowSource<K> for &S {
+    fn key(&self, index: usize, row: &Self::Row) -> K {
+        (**self).key(index, row)
+    }
+}
+
+/// Slice adapter used by the existing [`KeyedTable::new`] API.
+#[doc(hidden)]
+pub struct SliceKeyedRows<'a, R, F> {
+    rows: &'a [R],
+    key: F,
+}
+
+impl<'a, R, F> SliceKeyedRows<'a, R, F> {
+    fn new(rows: &'a [R], key: F) -> Self {
+        Self { rows, key }
+    }
+}
+
+impl<R, K: PartialEq, F: Fn(&R) -> &K> KeyedRowSource<K> for SliceKeyedRows<'_, R, F> {
+    type Row = R;
+
+    fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn row(&self, index: usize) -> Option<&Self::Row> {
+        self.rows.get(index)
+    }
+
+    fn key_eq(&self, _index: usize, row: &Self::Row, key: &K) -> bool {
+        (self.key)(row) == key
+    }
+}
+
+impl<R, K: Clone + PartialEq, F: Fn(&R) -> &K> NavigableKeyedRowSource<K>
+    for SliceKeyedRows<'_, R, F>
+{
+    fn key(&self, _index: usize, row: &Self::Row) -> K {
+        (self.key)(row).clone()
     }
 }
 
@@ -177,11 +333,24 @@ impl<K> KeyedSelectState<K> {
         K: PartialEq,
         F: Fn(&R) -> &K,
     {
-        if self
-            .selected
-            .as_ref()
-            .is_some_and(|selected| !rows.iter().any(|row| key(row) == selected))
-        {
+        self.retain_present_source(&SliceKeyedRows::new(rows, key));
+    }
+
+    /// Remove a selected key only when it is absent from an authoritative source.
+    ///
+    /// As with [`retain_present`](Self::retain_present), do not call this on a
+    /// filtered source when temporary absence should preserve selection.
+    pub fn retain_present_source<S>(&mut self, source: &S)
+    where
+        S: KeyedRowSource<K>,
+    {
+        if self.selected.as_ref().is_some_and(|selected| {
+            !(0..source.len()).any(|index| {
+                source
+                    .row(index)
+                    .is_some_and(|row| source.key_eq(index, row, selected))
+            })
+        }) {
             self.selected = None;
         }
     }
@@ -192,11 +361,22 @@ impl<K> KeyedSelectState<K> {
         K: PartialEq,
         F: Fn(&R) -> &K,
     {
-        let selected_index = self
-            .selected
-            .as_ref()
-            .and_then(|selected| rows.iter().position(|row| key(row) == selected));
-        self.window_at(rows.len(), visible, selected_index)
+        self.window_source(&SliceKeyedRows::new(rows, key), visible)
+    }
+
+    /// Resolve the visible window for a projected row source.
+    pub fn window_source<S>(&self, source: &S, visible: usize) -> VirtualWindow
+    where
+        S: KeyedRowSource<K>,
+    {
+        let selected_index = self.selected.as_ref().and_then(|selected| {
+            (0..source.len()).find(|&index| {
+                source
+                    .row(index)
+                    .is_some_and(|row| source.key_eq(index, row, selected))
+            })
+        });
+        self.window_at(source.len(), visible, selected_index)
     }
 
     fn window_at(
@@ -253,9 +433,28 @@ impl<K: Clone + PartialEq> KeyedSelectState<K> {
     where
         F: Fn(&R) -> &K,
     {
+        self.handle_source(
+            event,
+            &SliceKeyedRows::new(rows, key),
+            viewport_rows,
+            navigation,
+        )
+    }
+
+    /// Handle keyboard navigation and wheel scrolling over a projected source.
+    pub fn handle_source<S>(
+        &mut self,
+        event: &Event,
+        source: &S,
+        viewport_rows: usize,
+        navigation: SelectNavigation,
+    ) -> InputOutcome
+    where
+        S: NavigableKeyedRowSource<K>,
+    {
         if let Event::Mouse(mouse) = event {
-            let max = VirtualWindow::max_start_for(rows.len(), viewport_rows);
-            let before = self.window(rows, viewport_rows, &key).start();
+            let max = VirtualWindow::max_start_for(source.len(), viewport_rows);
+            let before = self.window_source(source, viewport_rows).start();
             self.offset = before;
             match mouse.kind {
                 MouseKind::ScrollUp => self.offset = self.offset.saturating_sub(3),
@@ -272,17 +471,20 @@ impl<K: Clone + PartialEq> KeyedSelectState<K> {
         let Event::Key(k) = event else {
             return InputOutcome::Ignored;
         };
-        if rows.is_empty() {
+        if source.is_empty() {
             return match k.code {
                 KeyCode::Esc if k.plain() => InputOutcome::Cancelled,
                 _ => InputOutcome::Ignored,
             };
         }
 
-        let current = self
-            .selected
-            .as_ref()
-            .and_then(|selected| rows.iter().position(|row| key(row) == selected));
+        let current = self.selected.as_ref().and_then(|selected| {
+            (0..source.len()).find(|&index| {
+                source
+                    .row(index)
+                    .is_some_and(|row| source.key_eq(index, row, selected))
+            })
+        });
         let page = viewport_rows.saturating_sub(1).max(1);
         let command = if navigation.ctrl_n_p && k.ctrl && !k.alt && !k.shift {
             match k.code {
@@ -306,8 +508,8 @@ impl<K: Clone + PartialEq> KeyedSelectState<K> {
                 KeyCode::End => Some(isize::MAX),
                 KeyCode::Char(digit @ '1'..='9') if navigation.numeric => {
                     let index = digit as usize - '1' as usize;
-                    if let Some(row) = rows.get(index) {
-                        self.selected = Some(key(row).clone());
+                    if let Some(row) = source.row(index) {
+                        self.selected = Some(source.key(index, row));
                         self.follow_selection = true;
                         return InputOutcome::Submitted;
                     }
@@ -325,17 +527,22 @@ impl<K: Clone + PartialEq> KeyedSelectState<K> {
         };
         let next = match delta {
             isize::MIN => 0,
-            isize::MAX => rows.len() - 1,
+            isize::MAX => source.len() - 1,
             d if d < 0 => current
-                .unwrap_or(rows.len())
+                .unwrap_or(source.len())
                 .saturating_sub(d.unsigned_abs()),
             d => current
                 .map_or(0, |index| index.saturating_add(d as usize))
-                .min(rows.len() - 1),
+                .min(source.len() - 1),
         };
-        let before = self.selected.as_ref();
-        let changed = before != Some(key(&rows[next]));
-        self.selected = Some(key(&rows[next]).clone());
+        let Some(row) = source.row(next) else {
+            return InputOutcome::Ignored;
+        };
+        let changed = !self
+            .selected
+            .as_ref()
+            .is_some_and(|selected| source.key_eq(next, row, selected));
+        self.selected = Some(source.key(next, row));
         self.follow_selection = true;
         if changed {
             InputOutcome::Changed
@@ -356,6 +563,20 @@ impl<K: Clone + PartialEq> KeyedSelectState<K> {
     where
         F: Fn(&R) -> &K,
     {
+        self.handle_mouse_source(event, &SliceKeyedRows::new(rows, key), bounds, window)
+    }
+
+    /// Select a clicked row in an already resolved projected-source viewport.
+    pub fn handle_mouse_source<S>(
+        &mut self,
+        event: &Event,
+        source: &S,
+        bounds: Rect,
+        window: VirtualWindow,
+    ) -> InputOutcome
+    where
+        S: NavigableKeyedRowSource<K>,
+    {
         let Event::Mouse(mouse) = event else {
             return InputOutcome::Ignored;
         };
@@ -369,10 +590,10 @@ impl<K: Clone + PartialEq> KeyedSelectState<K> {
             return InputOutcome::Ignored;
         }
         let index = window.start() + usize::from(mouse.row - bounds.y);
-        let Some(row) = rows.get(index).filter(|_| index < window.end()) else {
+        let Some(row) = source.row(index).filter(|_| index < window.end()) else {
             return InputOutcome::Ignored;
         };
-        self.selected = Some(key(row).clone());
+        self.selected = Some(source.key(index, row));
         self.follow_selection = true;
         InputOutcome::Submitted
     }
@@ -444,9 +665,23 @@ impl<K> KeyedMultiSelectState<K> {
         K: Ord,
         F: Fn(&R) -> &K + Copy,
     {
-        self.cursor.retain_present(rows, key);
-        self.selected
-            .retain(|selected| rows.iter().any(|row| key(row) == selected));
+        self.retain_present_source(&SliceKeyedRows::new(rows, key));
+    }
+
+    /// Remove checked and cursor keys absent from an authoritative source.
+    pub fn retain_present_source<S>(&mut self, source: &S)
+    where
+        K: Ord,
+        S: KeyedRowSource<K>,
+    {
+        self.cursor.retain_present_source(source);
+        self.selected.retain(|selected| {
+            (0..source.len()).any(|index| {
+                source
+                    .row(index)
+                    .is_some_and(|row| source.key_eq(index, row, selected))
+            })
+        });
     }
 }
 
@@ -463,14 +698,36 @@ impl<K: Clone + Ord> KeyedMultiSelectState<K> {
     where
         F: Fn(&R) -> &K + Copy,
     {
+        self.handle_source(
+            event,
+            &SliceKeyedRows::new(rows, key),
+            viewport_rows,
+            navigation,
+        )
+    }
+
+    /// Navigate and toggle rows from a projected source.
+    pub fn handle_source<S>(
+        &mut self,
+        event: &Event,
+        source: &S,
+        viewport_rows: usize,
+        navigation: SelectNavigation,
+    ) -> InputOutcome
+    where
+        S: NavigableKeyedRowSource<K>,
+    {
         if let Event::Key(k) = event
             && k.plain()
             && k.code == KeyCode::Char(' ')
         {
-            let visible = self
-                .cursor
-                .selected()
-                .is_some_and(|selected| rows.iter().any(|row| key(row) == selected));
+            let visible = self.cursor.selected().is_some_and(|selected| {
+                (0..source.len()).any(|index| {
+                    source
+                        .row(index)
+                        .is_some_and(|row| source.key_eq(index, row, selected))
+                })
+            });
             return if visible {
                 self.toggle_cursor()
             } else {
@@ -479,7 +736,7 @@ impl<K: Clone + Ord> KeyedMultiSelectState<K> {
         }
         match self
             .cursor
-            .handle_with(event, rows, viewport_rows, key, navigation)
+            .handle_source(event, source, viewport_rows, navigation)
         {
             InputOutcome::Submitted => self.toggle_cursor(),
             outcome => outcome,
@@ -498,7 +755,24 @@ impl<K: Clone + Ord> KeyedMultiSelectState<K> {
     where
         F: Fn(&R) -> &K,
     {
-        match self.cursor.handle_mouse(event, rows, bounds, window, key) {
+        self.handle_mouse_source(event, &SliceKeyedRows::new(rows, key), bounds, window)
+    }
+
+    /// Hit-test and toggle a row from a projected source.
+    pub fn handle_mouse_source<S>(
+        &mut self,
+        event: &Event,
+        source: &S,
+        bounds: Rect,
+        window: VirtualWindow,
+    ) -> InputOutcome
+    where
+        S: NavigableKeyedRowSource<K>,
+    {
+        match self
+            .cursor
+            .handle_mouse_source(event, source, bounds, window)
+        {
             InputOutcome::Submitted => self.toggle_cursor(),
             outcome => outcome,
         }
@@ -532,10 +806,15 @@ impl<K: PartialEq> Selection<'_, K> {
         }
     }
 
-    fn checked(&self, key: &K) -> bool {
+    fn checked_source<S>(&self, source: &S, index: usize, row: &S::Row) -> bool
+    where
+        S: KeyedRowSource<K>,
+    {
         match self {
             Self::Single(_) => false,
-            Self::Multi(state) => state.selected().any(|selected| selected == key),
+            Self::Multi(state) => state
+                .selected()
+                .any(|selected| source.key_eq(index, row, selected)),
         }
     }
 
@@ -571,10 +850,10 @@ impl<K: PartialEq> Selection<'_, K> {
 /// ![keyed table demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/keyed_table.gif)
 ///
 /// Run the dynamic example with `cargo run --example keyed_table`.
-pub struct KeyedTable<'a, R, K, F> {
+pub struct KeyedTable<'a, R, K, F, S = SliceKeyedRows<'a, R, F>> {
     columns: Vec<KeyedColumn<'a, R>>,
-    rows: &'a [R],
-    key: F,
+    source: S,
+    slice_key: PhantomData<F>,
     selection: Selection<'a, K>,
     selected_index: Option<Option<usize>>,
     viewport: Option<u16>,
@@ -598,7 +877,11 @@ impl<'a, R, K: PartialEq, F: Fn(&R) -> &K> KeyedTable<'a, R, K, F> {
         key: F,
         state: &'a KeyedSelectState<K>,
     ) -> Self {
-        Self::build(columns, rows, key, Selection::Single(state))
+        Self::build(
+            columns,
+            SliceKeyedRows::new(rows, key),
+            Selection::Single(state),
+        )
     }
 
     /// Build a table with keyed cursor and checked-row state.
@@ -609,19 +892,40 @@ impl<'a, R, K: PartialEq, F: Fn(&R) -> &K> KeyedTable<'a, R, K, F> {
         key: F,
         state: &'a KeyedMultiSelectState<K>,
     ) -> Self {
-        Self::build(columns, rows, key, Selection::Multi(state))
+        Self::build(
+            columns,
+            SliceKeyedRows::new(rows, key),
+            Selection::Multi(state),
+        )
+    }
+}
+
+impl<'a, R, K: PartialEq, S: KeyedRowSource<K, Row = R>> KeyedTable<'a, R, K, (), S> {
+    /// Build a table over an indirect or decorated borrowed row source.
+    pub fn source(
+        columns: Vec<KeyedColumn<'a, R>>,
+        source: S,
+        state: &'a KeyedSelectState<K>,
+    ) -> Self {
+        Self::build(columns, source, Selection::Single(state))
     }
 
-    fn build(
+    /// Build a multi-selection table over an indirect borrowed row source.
+    pub fn multi_source(
         columns: Vec<KeyedColumn<'a, R>>,
-        rows: &'a [R],
-        key: F,
-        selection: Selection<'a, K>,
+        source: S,
+        state: &'a KeyedMultiSelectState<K>,
     ) -> Self {
+        Self::build(columns, source, Selection::Multi(state))
+    }
+}
+
+impl<'a, R, K: PartialEq, F, S: KeyedRowSource<K, Row = R>> KeyedTable<'a, R, K, F, S> {
+    fn build(columns: Vec<KeyedColumn<'a, R>>, source: S, selection: Selection<'a, K>) -> Self {
         Self {
             columns,
-            rows,
-            key,
+            source,
+            slice_key: PhantomData,
             selection,
             selected_index: None,
             viewport: None,
@@ -693,7 +997,7 @@ impl<'a, R, K: PartialEq, F: Fn(&R) -> &K> KeyedTable<'a, R, K, F> {
         self
     }
 
-    /// Supply the selected key's position in the current ordered `rows` slice.
+    /// Supply the selected key's position in the current ordered rows.
     ///
     /// This optional virtualization hint avoids scanning the whole collection
     /// to anchor the viewport. Keys remain the only persistent identity; the
@@ -717,12 +1021,12 @@ impl<'a, R, K: PartialEq, F: Fn(&R) -> &K> KeyedTable<'a, R, K, F> {
             Some(index) => {
                 self.selection
                     .cursor()
-                    .window_at(self.rows.len(), usize::from(visible), index)
+                    .window_at(self.source.len(), usize::from(visible), index)
             }
             None => self
                 .selection
                 .cursor()
-                .window(self.rows, usize::from(visible), &self.key),
+                .window_source(&self.source, usize::from(visible)),
         }
     }
 
@@ -769,8 +1073,8 @@ impl<'a, R, K: PartialEq, F: Fn(&R) -> &K> KeyedTable<'a, R, K, F> {
                 let column = &self.columns[index];
                 let cells = window
                     .range()
-                    .filter_map(|row| self.rows.get(row))
-                    .map(|row| line_width(&(column.cell)(row)))
+                    .filter_map(|index| self.source.row(index).map(|row| (index, row)))
+                    .map(|(index, row)| line_width(&(column.cell)(index, row)))
                     .max()
                     .unwrap_or(0);
                 Item::new(
@@ -809,7 +1113,7 @@ impl<'a, R, K: PartialEq, F: Fn(&R) -> &K> KeyedTable<'a, R, K, F> {
     }
 }
 
-impl<R, K: PartialEq, F: Fn(&R) -> &K> View for KeyedTable<'_, R, K, F> {
+impl<R, K: PartialEq, F, S: KeyedRowSource<K, Row = R>> View for KeyedTable<'_, R, K, F, S> {
     fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         let body = available.height.saturating_sub(self.header_rows());
         let window = self.window(body);
@@ -825,8 +1129,8 @@ impl<R, K: PartialEq, F: Fn(&R) -> &K> View for KeyedTable<'_, R, K, F> {
                 let column = &self.columns[index];
                 window
                     .range()
-                    .filter_map(|row| self.rows.get(row))
-                    .map(|row| line_width(&(column.cell)(row)))
+                    .filter_map(|index| self.source.row(index).map(|row| (index, row)))
+                    .map(|(index, row)| line_width(&(column.cell)(index, row)))
                     .max()
                     .unwrap_or(0)
                     .max(line_width(&column.header))
@@ -879,15 +1183,18 @@ impl<R, K: PartialEq, F: Fn(&R) -> &K> View for KeyedTable<'_, R, K, F> {
 
         let body_y = area.y.saturating_add(self.header_rows());
         for (screen_row, index) in window.range().enumerate() {
-            let Some(row) = self.rows.get(index) else {
+            let Some(row) = self.source.row(index) else {
                 break;
             };
             let y = body_y.saturating_add(screen_row as u16);
             if y >= area.bottom() {
                 break;
             }
-            let key = (self.key)(row);
-            let focused = self.selection.cursor().selected() == Some(key);
+            let focused = self
+                .selection
+                .cursor()
+                .selected()
+                .is_some_and(|key| self.source.key_eq(index, row, key));
             let row_style = focused.then(|| {
                 self.selection_style
                     .unwrap_or_else(|| ctx.theme.selection_style())
@@ -919,7 +1226,7 @@ impl<R, K: PartialEq, F: Fn(&R) -> &K> View for KeyedTable<'_, R, K, F> {
                 surface.set(
                     area.x.saturating_add(2),
                     y,
-                    if self.selection.checked(key) {
+                    if self.selection.checked_source(&self.source, index, row) {
                         self.checked
                     } else {
                         self.unchecked
@@ -929,7 +1236,7 @@ impl<R, K: PartialEq, F: Fn(&R) -> &K> View for KeyedTable<'_, R, K, F> {
             }
             for (&column_index, &rect) in indices.iter().zip(&rects) {
                 let column = &self.columns[column_index];
-                let cell = (column.cell)(row);
+                let cell = (column.cell)(index, row);
                 self.draw_line(&cell, rect, y, column.align, cell_style, surface);
             }
         }
@@ -951,9 +1258,12 @@ impl<R, K: PartialEq, F: Fn(&R) -> &K> View for KeyedTable<'_, R, K, F> {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::Cell;
+    use std::rc::Rc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use ratatui_core::style::{Color, Style};
+    use ratatui_core::text::Span;
 
     use super::*;
     use crate::event::{Key, Mouse};
@@ -1386,5 +1696,240 @@ mod tests {
             &state,
         );
         assert!(grid(&render(&table, 10, 2, &Theme::default())).contains("alpha"));
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    enum Agent {
+        Claude,
+        Codex,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct SessionKey {
+        agent: Agent,
+        session_id: String,
+    }
+
+    struct Session {
+        agent: Agent,
+        session_id: String,
+        summary: String,
+        branch: Option<String>,
+        pinned: bool,
+    }
+
+    struct SessionRows<'a> {
+        sessions: &'a [Session],
+        visible: &'a [usize],
+        fuzzy: &'a [Vec<usize>],
+        key_checks: Rc<Cell<usize>>,
+        key_builds: Rc<Cell<usize>>,
+    }
+
+    impl KeyedRowSource<SessionKey> for SessionRows<'_> {
+        type Row = Session;
+
+        fn len(&self) -> usize {
+            self.visible.len()
+        }
+
+        fn row(&self, index: usize) -> Option<&Self::Row> {
+            self.visible
+                .get(index)
+                .and_then(|&source_index| self.sessions.get(source_index))
+        }
+
+        fn key_eq(&self, _index: usize, row: &Self::Row, key: &SessionKey) -> bool {
+            self.key_checks.set(self.key_checks.get() + 1);
+            row.agent == key.agent && row.session_id == key.session_id
+        }
+    }
+
+    impl NavigableKeyedRowSource<SessionKey> for SessionRows<'_> {
+        fn key(&self, _index: usize, row: &Self::Row) -> SessionKey {
+            self.key_builds.set(self.key_builds.get() + 1);
+            SessionKey {
+                agent: row.agent,
+                session_id: row.session_id.clone(),
+            }
+        }
+    }
+
+    fn sessions() -> Vec<Session> {
+        vec![
+            Session {
+                agent: Agent::Claude,
+                session_id: "same".into(),
+                summary: "alpha".into(),
+                branch: Some("main".into()),
+                pinned: false,
+            },
+            Session {
+                agent: Agent::Codex,
+                session_id: "same".into(),
+                summary: "bravo".into(),
+                branch: None,
+                pinned: true,
+            },
+            Session {
+                agent: Agent::Codex,
+                session_id: "third".into(),
+                summary: "charlie".into(),
+                branch: Some("feat".into()),
+                pinned: false,
+            },
+        ]
+    }
+
+    fn session_rows<'a>(
+        sessions: &'a [Session],
+        visible: &'a [usize],
+        fuzzy: &'a [Vec<usize>],
+    ) -> SessionRows<'a> {
+        SessionRows {
+            sessions,
+            visible,
+            fuzzy,
+            key_checks: Rc::new(Cell::new(0)),
+            key_builds: Rc::new(Cell::new(0)),
+        }
+    }
+
+    #[test]
+    fn projected_rows_keep_composite_identity_through_collection_changes() {
+        let sessions = sessions();
+        let fuzzy = vec![vec![], vec![0, 2], vec![]];
+        let state = KeyedSelectState::with_selected(SessionKey {
+            agent: Agent::Codex,
+            session_id: "same".into(),
+        });
+
+        let original = [0, 1, 2];
+        let source = session_rows(&sessions, &original, &fuzzy);
+        assert_eq!(
+            state.window_source(&source, 1).range(),
+            1..2,
+            "the same id in another agent namespace is not selected"
+        );
+
+        let reordered = [2, 1, 0];
+        let source = session_rows(&sessions, &reordered, &fuzzy);
+        assert_eq!(state.window_source(&source, 2).range(), 0..2);
+
+        let filtered = [0, 2];
+        let source = session_rows(&sessions, &filtered, &fuzzy);
+        assert_eq!(state.window_source(&source, 2).range(), 0..2);
+        assert_eq!(state.selected().unwrap().agent, Agent::Codex);
+
+        let inserted = [2, 0, 1];
+        let source = session_rows(&sessions, &inserted, &fuzzy);
+        assert!(state.window_source(&source, 2).contains(2));
+
+        let mut state = state;
+        state.retain_present_source(&source);
+        assert!(state.selected().is_some());
+        let deleted = [0, 2];
+        state.retain_present_source(&session_rows(&sessions, &deleted, &fuzzy));
+        assert!(state.selected().is_none());
+    }
+
+    #[test]
+    fn projected_metadata_renders_styled_optional_cells_and_stays_virtualized() {
+        let sessions = sessions();
+        let visible = [0, 1, 2];
+        let fuzzy = vec![vec![0], vec![0, 2], vec![]];
+        let source = session_rows(&sessions, &visible, &fuzzy);
+        let cell_calls = Rc::new(Cell::new(0));
+        let calls = Rc::clone(&cell_calls);
+        let state = KeyedSelectState::with_selected(SessionKey {
+            agent: Agent::Codex,
+            session_id: "same".into(),
+        });
+        let table = KeyedTable::source(
+            vec![
+                KeyedColumn::fixed_indexed("", 1, |index, _row: &Session| {
+                    Line::from(if source.fuzzy[index].is_empty() {
+                        " "
+                    } else {
+                        "*"
+                    })
+                }),
+                KeyedColumn::flex_indexed("summary", 1, move |index, row: &Session| {
+                    calls.set(calls.get() + 1);
+                    let split = source.fuzzy[index]
+                        .first()
+                        .copied()
+                        .unwrap_or(0)
+                        .min(row.summary.len());
+                    Line::from(vec![
+                        Span::raw(&row.summary[..split]),
+                        Span::styled(
+                            &row.summary[split..split.saturating_add(1).min(row.summary.len())],
+                            Style::default().fg(Color::Yellow),
+                        ),
+                        Span::raw(&row.summary[split.saturating_add(1).min(row.summary.len())..]),
+                    ])
+                }),
+                KeyedColumn::fixed("pin", 3, |row: &Session| {
+                    Line::from(if row.pinned { "yes" } else { "" })
+                })
+                .hide_below(24),
+                KeyedColumn::fixed("branch", 6, |row: &Session| {
+                    Line::from(row.branch.as_deref().unwrap_or(""))
+                })
+                .optional(),
+            ],
+            &source,
+            &state,
+        )
+        .selected_index(Some(1))
+        .viewport(2)
+        .gap(1)
+        .preserve_selection_fg(true);
+        let buf = render(&table, 8, 3, &Theme::default());
+        let text = grid(&buf);
+        assert!(text.contains("bra"));
+        assert!(!text.contains("pin"), "narrow breakpoint hides pin");
+        assert!(!text.contains("branch"), "optional branch is shed");
+        assert_eq!(buf[(4, 2)].fg, Color::Yellow, "fuzzy span keeps style");
+        assert_eq!(cell_calls.get(), 4, "cell work is twice the visible rows");
+        assert_eq!(source.key_builds.get(), 0, "rendering never clones a key");
+        assert_eq!(
+            source.key_checks.get(),
+            2,
+            "the index hint limits identity work"
+        );
+    }
+
+    #[test]
+    fn projected_keyboard_and_mouse_materialize_only_selected_keys() {
+        let sessions = sessions();
+        let visible = [2, 0, 1];
+        let fuzzy = vec![vec![], vec![], vec![]];
+        let source = session_rows(&sessions, &visible, &fuzzy);
+        let mut state = KeyedSelectState::new();
+        assert_eq!(
+            state.handle_source(
+                &Event::Key(Key::new(KeyCode::Down)),
+                &source,
+                2,
+                SelectNavigation::default(),
+            ),
+            InputOutcome::Changed
+        );
+        assert_eq!(state.selected().unwrap().session_id, "third");
+        assert_eq!(source.key_builds.get(), 1);
+
+        state.set_offset(1);
+        let window = state.window_source(&source, 2);
+        let body = Rect::new(4, 7, 12, 2);
+        let click = Event::Mouse(Mouse::at(MouseKind::Down(MouseButton::Left), 5, 8));
+        assert_eq!(
+            state.handle_mouse_source(&click, &source, body, window),
+            InputOutcome::Submitted
+        );
+        assert_eq!(state.selected().unwrap().agent, Agent::Codex);
+        assert_eq!(state.selected().unwrap().session_id, "same");
+        assert_eq!(source.key_builds.get(), 2);
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -81,7 +81,10 @@ pub use grid::Grid;
 pub use image::Image;
 pub use item_scroll::ItemScroll;
 pub use key_hints::{KeyHint, KeyHints, KeymapHelp};
-pub use keyed_table::{KeyedColumn, KeyedMultiSelectState, KeyedSelectState, KeyedTable};
+pub use keyed_table::{
+    KeyedColumn, KeyedMultiSelectState, KeyedRowSource, KeyedSelectState, KeyedTable,
+    NavigableKeyedRowSource,
+};
 pub use loader::Loader;
 pub use markdown::{
     ImageResolver, Markdown, MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -143,8 +143,9 @@ fn components_are_reachable_flat() {
         ActivityItem, ActivityList, ActivityStatus, AsciiFont, Boxed, ChoiceDialog,
         ChoiceDialogState, CompletionItem, CompletionPalette, CompletionState, ConfirmDialog,
         ConfirmDialogState, Console, Dialog, Diff, Form, FormField, FormState, Image, InputDialog,
-        InputDialogState, KeyedColumn, KeyedMultiSelectState, KeyedSelectState, KeyedTable,
-        Markdown, MultiChoiceDialog, MultiChoiceDialogState, QrCode, Toasts, Viewport,
+        InputDialogState, KeyedColumn, KeyedMultiSelectState, KeyedRowSource, KeyedSelectState,
+        KeyedTable, Markdown, MultiChoiceDialog, MultiChoiceDialogState, NavigableKeyedRowSource,
+        QrCode, Toasts, Viewport,
     };
 
     let theme = Theme::default();
@@ -194,13 +195,33 @@ fn components_are_reachable_flat() {
     }
     let rows = [Row(1)];
     let keyed = KeyedSelectState::with_selected(1);
-    let _ = KeyedTable::new(
+    let _: KeyedTable<'_, Row, u64, fn(&Row) -> &u64> = KeyedTable::new(
         vec![KeyedColumn::auto("id", row_cell)],
         &rows,
-        row_key,
+        row_key as fn(&Row) -> &u64,
         &keyed,
     );
     let _ = KeyedMultiSelectState::<u64>::new();
+    struct Source([Row; 1]);
+    impl KeyedRowSource<u64> for Source {
+        type Row = Row;
+        fn len(&self) -> usize {
+            1
+        }
+        fn row(&self, index: usize) -> Option<&Row> {
+            self.0.get(index)
+        }
+        fn key_eq(&self, _index: usize, row: &Row, key: &u64) -> bool {
+            row.0 == *key
+        }
+    }
+    impl NavigableKeyedRowSource<u64> for Source {
+        fn key(&self, _index: usize, row: &Row) -> u64 {
+            row.0
+        }
+    }
+    let source = Source([Row(1)]);
+    let _ = KeyedTable::source(vec![KeyedColumn::auto("id", row_cell)], &source, &keyed);
 }
 
 /// Owned and scoped composition belong to the framework spine; custom canvases


### PR DESCRIPTION
## What changed

`KeyedTable` can now render indirect/decorated rows through `KeyedRowSource<K>` while preserving the existing slice API. Sources map visible indices into authoritative storage, compare computed composite identity without allocating keys during frames, and materialize an owned key only when keyboard or mouse selection changes. Indexed column constructors join parallel fuzzy/decorative metadata while retaining responsive columns, scrolling, selection hints, and hit testing.

The keyed-table example now models the AGF shape directly: authoritative `Vec<Session>`, visible `Vec<usize>`, parallel fuzzy positions, `(Agent, session_id)` identity, and optional pin/branch cells.

Public API additions: `KeyedRowSource`, `NavigableKeyedRowSource`, `KeyedTable::{source,multi_source}`, projected-source state methods, and indexed `KeyedColumn` constructors. The pre-existing four-parameter `KeyedTable` type form and slice constructors/handlers remain source-compatible through a defaulted source adapter, pinned by an external API test. No dependency changes.

## Why

Searchable application tables otherwise need a duplicate wrapper-row vector every frame solely to combine visible order, copied composite keys, and projected metadata. That duplicates model state and clones key data outside the viewport.

## Before / After

The documented representative per-frame caller falls from 20 to 8 nonblank LOC (60% fewer): wrapper allocation/key copies are replaced by one borrowed source plus an indexed fuzzy-cell callback. The one-time source implementation is shared by rendering, navigation, mouse hit testing, and deletion reconciliation.

Automated complexity evidence asserts two visible rows cause four summary-cell calls (measure + paint), only two identity comparisons with `selected_index`, and zero owned-key constructions during render. A real PTY run of `cargo run --example keyed_table` painted the projected session table and restored alternate-screen, cursor, mouse, and keyboard state on `q`.

The gallery scene now exercises projected visible indices. Its rendered appearance is intentionally unchanged, so the existing recording remains truthful; `demo -- check` confirms all 40 recordings and references are synchronized.

## Risk

- Medium: published generic component and selection/input paths changed.
- Main risks are source/index mismatch, composite-key collisions, work escaping the viewport, and narrow clipping. Tests cover the source invariant, agent-namespace collisions, reorder/filter/stream insert/delete, styled parallel fuzzy spans, selected-index complexity, keyboard/mouse mapping, optional/narrow columns, and degenerate sizes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (580 library tests plus integration, PTY, examples, and companion crates)
- `cargo +1.88 check -p tuika --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo run --example demo -- check`
- real-PTY `cargo run --example keyed_table`, exited with `q`

## Knowledge

Updated the rendering architecture and knowledge log: projected sources remain ephemeral borrowed frame inputs; stable keys remain host-owned identity, not retained view identity.

## Security

Reviewed TM-ESC, TM-STATE, TM-PARSE, TM-CLIP, and TM-DEP. No escape emission, terminal lifecycle, parsing, filesystem/network, dependency, or process surface changed. Source access remains bounds-checked and fallible; clipping uses the existing child surfaces and is covered across narrow/degenerate sizes. Rendering performs no key construction and cell callbacks remain viewport-bounded. No findings.

## Follow-ups

No follow-ups.
