### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,24 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
-## Unreleased
+## [0.8.0] - 2026-08-07
+
+Released alongside `tuika-codeformatters` 0.4.1, `tuika-mermaid` 0.2.1, and
+`tuika-html` 0.1.1. Their tuika dependency requirements now track 0.8.
+
+### Highlights
+
+**Turn-key application shell.** `AppShell`, a borrowed `Application` runtime,
+completion palettes, dialog presets, and activity lists give hosts a coherent
+foundation for responsive tool-style applications without retained view state.
+
+![app shell demo](https://raw.githubusercontent.com/everruns/tuika/v0.8.0/docs/demos/app_shell.png)
+
+**Key-stable collection views.** `SelectionScreen` and `KeyedTable` render
+borrowed data while preserving application-key selection across reordering,
+filtering, and streaming updates.
+
+![selection screen demo](https://raw.githubusercontent.com/everruns/tuika/v0.8.0/docs/demos/selection_screen.png)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2323,7 +2323,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-html"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "html5ever",
  "markup5ever_rcdom",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "mmdflux",
  "ratatui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-codeformatters"
-version = "0.4.0"
+version = "0.4.1"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -26,7 +26,7 @@ exclude = ["docs/*.gif"]
 bench = false
 
 [dependencies]
-tuika = { version = "0.7.0", path = "../.." }
+tuika = { version = "0.8.0", path = "../.." }
 ratatui = "0.30.2"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"

--- a/crates/tuika-html/Cargo.toml
+++ b/crates/tuika-html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-html"
-version = "0.1.0"
+version = "0.1.1"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -24,7 +24,7 @@ categories = ["command-line-interface", "text-processing"]
 # tuika-html cannot be published until then. `publish_order.py` publishes tuika
 # first, and
 # the release process owns the bump; see `knowledge/processes/release.md`.
-tuika = { version = "0.7.0", path = "../.." }
+tuika = { version = "0.8.0", path = "../.." }
 ratatui-core = "0.1"
 # html5ever is the whole point of this crate existing separately: a spec
 # compliant tree builder (implied end tags, `<tbody>` insertion, malformed-input

--- a/crates/tuika-mermaid/Cargo.toml
+++ b/crates/tuika-mermaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-mermaid"
-version = "0.2.0"
+version = "0.2.1"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -19,6 +19,6 @@ keywords = ["tui", "mermaid", "markdown", "ratatui", "diagrams"]
 categories = ["command-line-interface", "text-processing"]
 
 [dependencies]
-tuika = { version = "0.7.0", path = "../.." }
+tuika = { version = "0.8.0", path = "../.." }
 ratatui-core = "0.1"
 mmdflux = { version = "2.6", default-features = false }


### PR DESCRIPTION
## [0.8.0] - 2026-08-07

Released alongside `tuika-codeformatters` 0.4.1, `tuika-mermaid` 0.2.1, and
`tuika-html` 0.1.1. Their tuika dependency requirements now track 0.8.

### Highlights

**Turn-key application shell.** `AppShell`, a borrowed `Application` runtime,
completion palettes, dialog presets, and activity lists give hosts a coherent
foundation for responsive tool-style applications without retained view state.

![app shell demo](https://raw.githubusercontent.com/everruns/tuika/v0.8.0/docs/demos/app_shell.png)

**Key-stable collection views.** `SelectionScreen` and `KeyedTable` render
borrowed data while preserving application-key selection across reordering,
filtering, and streaming updates.

![selection screen demo](https://raw.githubusercontent.com/everruns/tuika/v0.8.0/docs/demos/selection_screen.png)

### Breaking Changes

- `AppShell` no longer requests focus for its fallback region when an overlay
  closes unless `restore_focus_on_overlay_close(true)` is configured.

### What's Changed

* feat(components): add key-stable table component
* feat(components): add selection screen
* fix(app-shell): make overlay focus restoration opt-in
* feat(app-shell): add turn-key application shell
* feat(app-shell): add named overlay management
* feat(layout): add two-pane workspace primitive
* feat(components): add centered content view
* feat(components): add status bar

## Publish-readiness

- [x] `python3 scripts/validate_okf.py knowledge --check-links`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo run --example demo -- check`
- [x] `RUSTDOCFLAGS="--cfg docsrs" cargo doc --workspace --all-features --no-deps`
- [x] `cargo publish --dry-run --allow-dirty -p tuika` (companions are validated in CI after tuika publishes)
- [x] `cargo test --test packaging`
- [x] crates.io currently serves tuika 0.7.0 → publishing 0.8.0
- [x] root and companion manifests agree on tuika 0.8.0
- [x] highlight demos re-recorded, checked, and embedded pinned to `v0.8.0`

## Post-merge verification

- [ ] `release.yml` created tag `v0.8.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] crates.io serves tuika 0.8.0 and intended companion versions
- [ ] docs.rs built tuika 0.8.0

Produced by [yolop](https://everruns.com/yolop)
