### PR TITLE
fix(mermaid): work around mmdflux#387 and fit wide diagrams to the pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
+## Unreleased
+
+### Fixed
+
+- `tuika-mermaid` no longer lets a Mermaid decision node with a `<br/>` label
+  unwind out of `View::render` and take the host application down. The same
+  upstream defect ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387))
+  also fails silently — dropping the label in release builds, or painting a
+  short label over the shape's own borders — so all three now fall back to the
+  ordinary themed code block.
+
+### Changed
+
+- `tuika-mermaid` re-lays out a diagram wider than the available columns at
+  progressively tighter node separation until it fits, instead of letting it be
+  clipped at the pane's right edge. Fitting is best-effort: a graph with many
+  parallel branches can be irreducibly wider than the terminal, and the
+  narrowest layout is used there. Diagrams that already fit keep mmdflux's own
+  spacing, so existing renders are unchanged.
+
 ## [0.8.0] - 2026-08-07
 
 Released alongside `tuika-codeformatters` 0.4.1, `tuika-mermaid` 0.2.1, and

--- a/crates/tuika-mermaid/README.md
+++ b/crates/tuika-mermaid/README.md
@@ -19,9 +19,11 @@ let document = Markdown::new(
 # let _ = document;
 ```
 
-`MermaidRenderer` handles `mermaid` fences. Unsupported syntax and fences over
-64 KiB fall back to tuika's ordinary themed code-block presentation, so
-malformed or oversized content remains visible.
+`MermaidRenderer` handles `mermaid` fences. A diagram wider than the available
+columns is re-laid out at tighter node separation until it fits, best-effort —
+a graph with many parallel branches can be irreducibly wider than the terminal.
+Unsupported syntax and fences over 64 KiB fall back to tuika's ordinary themed
+code-block presentation, so malformed or oversized content remains visible.
 
 <img src="examples/mermaid_markdown/mermaid.gif" width="880" alt="Mermaid diagram rendered as Unicode cells inside tuika Markdown">
 

--- a/crates/tuika-mermaid/src/lib.rs
+++ b/crates/tuika-mermaid/src/lib.rs
@@ -18,7 +18,24 @@ const MAX_SOURCE_BYTES: usize = 64 * 1024;
 /// Upper bound for mmdflux text retained as terminal cells.
 const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
+/// Progressively tighter graph separations — `(node_sep, rank_sep, edge_sep)`
+/// in mmdflux's pixel units — tried when the default layout is wider than the
+/// pane.
+///
+/// mmdflux's defaults (50/50/20) are tuned for SVG, where a pixel of
+/// separation is a fraction of a glyph; on a character grid the same numbers
+/// spread a diagram far past any terminal. Tightening `node_sep` is what
+/// actually narrows a diagram, so the ladder squeezes it hardest. `rank_sep`
+/// is held at or above 25: below that the layered ranker starts collapsing
+/// ranks into each other, which trades height for a *much* wider result.
+const FIT_LADDER: [(f64, f64, f64); 3] = [(30.0, 30.0, 12.0), (20.0, 25.0, 8.0), (12.0, 25.0, 5.0)];
+
 /// Renders `mermaid` fenced blocks as Unicode terminal diagrams.
+///
+/// A diagram wider than the available columns is re-laid out with tighter
+/// node separation until it fits, or until mmdflux's text renderer has no
+/// slack left — a graph can be irreducibly wider than the pane, and the
+/// narrowest layout is used in that case.
 ///
 /// Fences larger than 64 KiB, invalid Mermaid, and unsupported diagram types
 /// return `None` so tuika keeps the visible source-code fallback.
@@ -48,14 +65,11 @@ impl MarkdownBlockRenderer for MermaidRenderer {
             return None;
         }
 
-        let config = RenderConfig {
-            text_color_mode: TextColorMode::Plain,
-            ..RenderConfig::default()
-        };
-        let rendered = render_diagram(source, OutputFormat::Text, &config).ok()?;
-        if rendered.len() > MAX_OUTPUT_BYTES {
+        if trips_diamond_label_bug(source) {
             return None;
         }
+
+        let rendered = fitted_diagram(source, context.width)?;
         Some(
             rendered
                 .lines()
@@ -63,6 +77,112 @@ impl MarkdownBlockRenderer for MermaidRenderer {
                 .collect(),
         )
     }
+}
+
+/// Whether `source` would hit mmdflux's broken multi-line diamond label.
+///
+/// Upstream: <https://github.com/kevinswiber/mmdflux/issues/387>. Fixed in no
+/// release as of 2.6.0 — drop this guard, and the `catch_unwind` in
+/// [`render_layout`], once it lands.
+///
+/// `render_diamond` renders a fixed three-row shape sized from the label's
+/// *widest line*, then centres the *whole* label — line breaks included —
+/// against that width. Mermaid accepts `<br/>` in a decision node and it is the
+/// natural way to keep a wide one readable, so this is reachable from ordinary
+/// documents rather than only from malformed ones, and it fails three different
+/// ways: a subtraction underflow that panics under debug overflow checks, the
+/// same underflow wrapping in release so the label is dropped and an empty
+/// diamond renders, and — for labels short enough not to underflow — the label
+/// written across the shape's own borders. Only the first is contained by
+/// `catch_unwind`; the other two look like success. So the shape is recognised
+/// up front and the fence keeps tuika's code-block fallback, where the diagram
+/// is at least readable as source.
+///
+/// Only `flowchart`/`graph` sources are scanned: `{}` delimits a node label
+/// there, while in a class or state diagram it opens a member block that
+/// legitimately spans lines.
+fn trips_diamond_label_bug(source: &str) -> bool {
+    let is_flowchart = source
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with("%%"))
+        .is_some_and(|line| line.starts_with("flowchart") || line.starts_with("graph"));
+    if !is_flowchart {
+        return false;
+    }
+
+    source.lines().any(|line| {
+        let Some(open) = line.find('{') else {
+            return false;
+        };
+        let Some(close) = line.rfind('}') else {
+            return false;
+        };
+        close > open && line[open..close].contains("<br")
+    })
+}
+
+/// The narrowest layout of `source` that fits `width`, or the narrowest one
+/// mmdflux can produce when none does.
+fn fitted_diagram(source: &str, width: u16) -> Option<String> {
+    let budget = usize::from(width);
+    // The default layout is the reference: a diagram that already fits keeps
+    // mmdflux's own spacing, so nothing that renders well today changes.
+    let mut best = render_layout(source, None)?;
+    if diagram_width(&best) <= budget {
+        return Some(best);
+    }
+
+    for separations in FIT_LADDER {
+        // A tighter layout that fails where the default succeeded is not a
+        // reason to lose the diagram — keep the widest-but-working one.
+        let Some(candidate) = render_layout(source, Some(separations)) else {
+            continue;
+        };
+        if diagram_width(&candidate) < diagram_width(&best) {
+            best = candidate;
+        }
+        if diagram_width(&best) <= budget {
+            break;
+        }
+    }
+    Some(best)
+}
+
+/// One mmdflux text render, containing any failure as `None`.
+fn render_layout(source: &str, separations: Option<(f64, f64, f64)>) -> Option<String> {
+    let mut config = RenderConfig {
+        text_color_mode: TextColorMode::Plain,
+        ..RenderConfig::default()
+    };
+    if let Some((node_sep, rank_sep, edge_sep)) = separations {
+        config.layout.node_sep = node_sep;
+        config.layout.rank_sep = rank_sep;
+        config.layout.edge_sep = edge_sep;
+    }
+
+    // Backstop only: `trips_diamond_label_bug` keeps the one panic we know
+    // about (https://github.com/kevinswiber/mmdflux/issues/387) out of this
+    // call, but a `View::render` must not be able to take the host application
+    // down mid-frame over a malformed diagram, so contain the rest too. The
+    // panic hook is deliberately left alone — `Markdown` re-renders every
+    // frame, and swapping a global hook that often would swallow unrelated
+    // panics from other threads for as long as the window is open.
+    let rendered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        render_diagram(source, OutputFormat::Text, &config)
+    }));
+
+    let rendered = rendered.ok()?.ok()?;
+    (rendered.len() <= MAX_OUTPUT_BYTES).then_some(rendered)
+}
+
+/// Columns the rendered diagram occupies.
+fn diagram_width(rendered: &str) -> usize {
+    rendered
+        .lines()
+        .map(|line| line.chars().count())
+        .max()
+        .unwrap_or(0)
 }
 
 fn styled_line(line: &str, theme: &Theme) -> Line<'static> {
@@ -166,6 +286,115 @@ mod tests {
                 source: "this is not Mermaid",
             })
             .is_none()
+        );
+    }
+
+    /// A multi-line diamond label degrades to the code-block fallback rather
+    /// than unwinding into the host — both the label wide enough to underflow
+    /// mmdflux's centering and the short one that silently paints over the
+    /// shape's borders. See <https://github.com/kevinswiber/mmdflux/issues/387>.
+    #[test]
+    fn multiline_diamond_label_uses_markdown_fallback() {
+        for source in [
+            "flowchart TD\n A[x] --> B{aaaa<br/>aaaa}\n",
+            "flowchart TD\n A[x] --> B{abc<br/>abc}\n",
+        ] {
+            assert!(
+                render_block(MarkdownBlock::Fenced {
+                    language: "mermaid",
+                    source,
+                })
+                .is_none(),
+                "{source}"
+            );
+        }
+    }
+
+    /// The `catch_unwind` backstop, exercised against the same input with the
+    /// pre-check bypassed: even reaching mmdflux, the seam must return rather
+    /// than unwind.
+    #[test]
+    fn panicking_layout_is_contained_rather_than_unwound() {
+        assert!(render_layout("flowchart TD\n A[x] --> B{aaaa<br/>aaaa}\n", None).is_none());
+    }
+
+    /// Only flowcharts use `{}` for a node label; a class diagram's member
+    /// block must not be mistaken for one.
+    #[test]
+    fn diamond_precheck_is_scoped_to_flowcharts() {
+        assert!(trips_diamond_label_bug(
+            "flowchart TD\n A --> B{one<br/>two}\n"
+        ));
+        assert!(trips_diamond_label_bug(
+            "%% a comment\ngraph LR\n A --> B{one<br>two}\n"
+        ));
+        assert!(!trips_diamond_label_bug(
+            "flowchart TD\n A[one<br/>two] --> B\n"
+        ));
+        assert!(!trips_diamond_label_bug("flowchart TD\n A --> B{plain}\n"));
+        assert!(!trips_diamond_label_bug(
+            "classDiagram\n class Foo {\n +bar()<br/>\n }\n"
+        ));
+    }
+
+    /// A branching flowchart whose default layout runs far past a terminal.
+    const BRANCHING: &str = "flowchart TD\n\
+         A[Gateway model id] --> B{Pi registry provider-exact match?}\n\
+         B -- yes --> C[Use registry]\n\
+         B -- no --> D{Pi registry model-id fallback?}\n\
+         D -- yes --> E[Use registry, minus cost]\n\
+         D -- no --> F{models.dev match?}\n\
+         F -- yes --> G[Use models.dev]\n\
+         F -- no --> H[Safe defaults]\n\
+         C --> I[Gateway pricing wins field-by-field]\n\
+         E --> I\n\
+         G --> I\n\
+         H --> I\n";
+
+    #[test]
+    fn wide_diagram_is_compressed_toward_the_pane() {
+        let relaxed = diagram_width(&render_layout(BRANCHING, None).expect("default layout"));
+        let fitted = diagram_width(&fitted_diagram(BRANCHING, 80).expect("fitted layout"));
+
+        assert!(
+            fitted <= 80,
+            "expected a fit within 80 columns, got {fitted}"
+        );
+        assert!(
+            fitted < relaxed,
+            "expected compression below the {relaxed}-column default, got {fitted}"
+        );
+    }
+
+    /// A width no layout can satisfy settles on the narrowest rung rather than
+    /// looping or losing the diagram. Degenerate widths reach this path, so it
+    /// is the one that must not misbehave.
+    #[test]
+    fn unsatisfiable_width_settles_on_the_narrowest_layout() {
+        let relaxed = diagram_width(&render_layout(BRANCHING, None).expect("default layout"));
+        let floor = diagram_width(
+            &render_layout(BRANCHING, Some(FIT_LADDER[FIT_LADDER.len() - 1])).expect("last rung"),
+        );
+
+        for width in [0, 1, 4] {
+            let fitted = diagram_width(&fitted_diagram(BRANCHING, width).expect("a layout"));
+            assert!(
+                fitted <= floor && fitted < relaxed,
+                "width {width}: expected the {floor}-column floor, got {fitted}"
+            );
+        }
+    }
+
+    /// Compression is only for diagrams that overflow: one that already fits
+    /// keeps mmdflux's own spacing.
+    #[test]
+    fn narrow_diagram_keeps_the_default_layout() {
+        let source = "flowchart LR\n A[Parse] --> B[Paint]\n";
+        let relaxed = render_layout(source, None).expect("default layout");
+
+        assert_eq!(
+            fitted_diagram(source, 80).as_deref(),
+            Some(relaxed.as_str())
         );
     }
 

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -280,6 +280,16 @@ into Unicode diagrams sized for the available terminal width. Unsupported
 syntax, malformed input, and fences over 64 KiB remain visible as ordinary
 themed code blocks instead of disappearing.
 
+A large graph is re-laid out at tighter node separation until it fits the pane,
+so a wide flowchart is not simply clipped at the right edge. Fitting is
+best-effort: a graph with many parallel branches can be irreducibly wider than
+the terminal, and the narrowest layout is used in that case. Two limits are
+worth knowing when authoring for a terminal — keep branch labels short, since
+label width compounds across a rank, and avoid `<br/>` inside a decision node
+(`{...}`), which the diagram engine
+[cannot lay out](https://github.com/kevinswiber/mmdflux/issues/387) and which
+falls back to the code block.
+
 Here are the flowchart and sequence diagram rendered by the runnable integration
 example:
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,22 @@
 
 ## 2026-08-07
 
+- **A block renderer owes the frame totality and a width budget**
+
+- An unrenderable fence is a `None` and the code-block fallback, never an
+  unwind: `tuika-mermaid` contains mmdflux's panics rather than assuming a
+  third-party layout engine is total. Containment stops at the panic hook,
+  which a per-frame renderer must not swap.
+- `catch_unwind` is not by itself a workaround for an upstream defect. The
+  multi-line decision-node bug ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387))
+  also fails silently — a dropped label, a label painted over its own borders —
+  so the adapter recognises the shape up front rather than only containing the
+  loud case.
+- `MarkdownBlockContext::width` is a budget to spend, not decoration. A diagram
+  engine sized for vector output overflows a pane, and `Markdown` clips rather
+  than scrolls, so the adapter re-lays out at tighter separations until it fits
+  — best-effort, since a graph can be irreducibly wider than the terminal.
+
 - **Inline custom regions remain ordinary borrowed views**
 
 - Separate `Fn` measurement and rendering closures adapt into the existing

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -107,6 +107,27 @@ diagram grammars outside tuika core. The adapter bounds source and output size,
 disables ANSI output, and strips control bytes before creating cells; a diagram
 fence is untrusted markdown, not permission to emit terminal commands.
 
+A block renderer sits inside `View::render`, so it must not be able to fail the
+frame: an unrenderable fence is a `None` and the code-block fallback, never an
+unwind. That is a constraint on the *adapter*, not on the engine behind it —
+`tuika-mermaid` contains mmdflux's panics rather than trusting a third-party
+layout engine to be total. Containment alone is not enough, though: the same
+upstream defect ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387),
+a multi-line decision-node label) also renders a diagram that merely *looks*
+successful, so the adapter additionally recognises the shape up front. A
+workaround that only catches the loud failure mode leaves the quiet ones.
+Containment does not extend to the panic hook: a
+renderer runs every frame, and swapping a global hook that often would swallow
+unrelated panics for as long as the window is open.
+
+The context carries width because a renderer is expected to *use* it. A diagram
+engine sized for vector output spreads a graph far past a terminal pane, and
+`Markdown` clips rather than scrolls, so the adapter re-lays out an overflowing
+diagram at tighter separations until it fits. Fitting is best-effort: a graph
+can be irreducibly wider than the pane, and the narrowest layout is still the
+right answer there. Diagrams that already fit keep the engine's own spacing, so
+tightening never changes what already renders well.
+
 The chain is deliberately open rather than one field per syntax. A host can
 register Mermaid, HTML, and its own query-plan renderer in one ordered list;
 each implementation sees every structured block and declines the kinds it does


### PR DESCRIPTION
## What changed

Two failures in `tuika-mermaid`, both reachable from ordinary Mermaid a host would render.

**A decision node with a `<br/>` label no longer takes the host application down.** It previously unwound straight out of `View::render`. The same upstream defect ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)) also fails *quietly*, which is why containing the panic alone was not enough: in release builds the underflow wraps and the label is silently dropped, leaving an empty diamond, and a label short enough not to underflow is painted over the shape's own borders. All three now degrade to tuika's code-block fallback, where the diagram is at least readable as source.

**A wide diagram is no longer clipped at the pane's right edge.** mmdflux's default separations are pixel units tuned for SVG output; on a character grid they spread a graph far past any terminal. An overflowing diagram is now re-laid out down a short ladder of tighter separations until it fits. Fitting is best-effort by design — a graph with many parallel branches can be irreducibly wider than the pane, and the narrowest layout is the right answer there.

Diagrams that already fit keep mmdflux's own spacing, so nothing that renders well today changes.

## Why

Reported from a host rendering an agent transcript: a 10-node reconciliation flowchart lost half its boxes off the right edge, and the obvious authoring fix for that — `<br/>` in the decision nodes — killed the app.

## Before / After

The reported flowchart, rendered through `Markdown` into an 80-column pane:

| | columns × rows | outcome |
|---|---|---|
| before | 98 × 65 | **27 rows hit the pane edge and are cut**; the tail never appears |
| after | 75 × 51 | fits, nothing cut |

Before — the right-hand branch is sliced off mid-box:

```
┌──────────────┐                          ┌────────────────────────────────
│ Use registry │                          < Pi registry model-id fallback?
└──────────────┘                          └────────────────────────────────
```

After — the same region intact, through to the terminal node:

```
                  ┌────────────────────┐
                  │ Final capabilities │
                  └────────────────────┘
```

The panic, before this change:

```
thread 'main' panicked at mmdflux-2.6.0/src/render/graph/text/shape.rs:595:27:
attempt to subtract with overflow
   ...
   10: <tuika_mermaid::MermaidRenderer as MarkdownBlockRenderer>::render
   16: <tuika::components::markdown::view::Markdown as tuika::view::View>::render
   19: tuika::host::paint
```

After: the fence renders as a themed code block and the frame completes.

The committed `mermaid_markdown` example's output is **byte-identical to the release commit**, so `examples/mermaid_markdown/mermaid.gif` stays truthful and needs no regeneration.

## Release sequencing

`v0.8.0` was tagged and published (`tuika` 0.8.0, `tuika-mermaid` 0.2.1) while this branch was in review, so this fix is rebased onto that commit and recorded under a fresh **`## Unreleased`** section in `CHANGELOG.md` rather than folded into the already-published 0.2.1. No version is bumped here — that belongs to the next `chore(release)` commit per the release process.

## Risk

- **Low**
- The fit ladder changes the appearance of diagrams that previously overflowed — they were clipped before, so this is strictly more legible, but it is a visible change for those documents. Diagrams that already fit are provably untouched (`narrow_diagram_keeps_the_default_layout`).
- The `<br/>`-in-a-diamond pre-check is a heuristic scan rather than a parse. It is scoped to `flowchart`/`graph` sources, so a class or state diagram's multi-line `{}` member block is not caught; a false positive would cost the diagram its rendering and fall back to source, not break the frame.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No API change: `MermaidRenderer` and `MermaidRenderer::new` are the only `pub` items and both are unchanged. No new dependency.

Tests added (`crates/tuika-mermaid/src/lib.rs`, 8 → 12):
- `multiline_diamond_label_uses_markdown_fallback` — both the underflowing label and the short one that paints over its borders
- `panicking_layout_is_contained_rather_than_unwound` — the `catch_unwind` backstop, with the pre-check bypassed
- `diamond_precheck_is_scoped_to_flowcharts` — including the class-diagram false-positive case
- `wide_diagram_is_compressed_toward_the_pane`, `narrow_diagram_keeps_the_default_layout`, `unsatisfiable_width_settles_on_the_narrowest_layout` (degenerate widths 0/1/4)

Evidence: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `cargo run --example demo -- check` (41 scenes in sync), `python3 scripts/validate_okf.py knowledge --check-links` (14 concepts, 0 errors).

## Knowledge

Updated `knowledge/specs/markdown.md` and `knowledge/log.md` with two durable points the change establishes: a block renderer owes the frame totality (an unrenderable fence is a `None`, never an unwind) and owes the width budget it is handed; and `catch_unwind` is not by itself a workaround for an upstream defect that also fails silently. No concepts added, removed, or renamed, so `knowledge/index.md` is unchanged.

Also updated `CHANGELOG.md`, `docs/markdown.md`, and the crate README.

## Security

Reviewed against the repository's threat-model categories.

- **TM-PARSE** — the primary category here, and the change is a net improvement: it removes a panic reachable from untrusted markdown. Resource use was measured rather than assumed. The ladder is bounded at 4 layout passes and only overflowing diagrams pay it: 3.5 ms worst case on the branching flowchart above versus ~0.9 ms for a single pass, and 117 µs for a diagram that fits immediately (one pass, early exit). A 60 KiB / 3183-edge fence costs 617 ms here versus 589 ms on the base commit — a deep chain is narrow, so it exits after the first layout and never pays for the ladder. That pre-existing cost is listed under Follow-ups. `MAX_SOURCE_BYTES` (64 KiB) and `MAX_OUTPUT_BYTES` (1 MiB) are unchanged and still bound each pass.
- **TM-CLIP** — degenerate widths (0, 1, 4) reach the ladder's exhaustion path; covered by `unsatisfiable_width_settles_on_the_narrowest_layout`. The adapter emits `Line`s and does not write cells itself, so clipping remains `Markdown`'s.
- **TM-ESC** — unchanged. Colour output stays disabled and `styled_line` still strips control bytes, so no caller-supplied string reaches the terminal as a control sequence.
- **TM-STATE** — not applicable; no terminal mode is entered or restored.
- **TM-DEP** — no new dependency.

One deliberate non-change: the panic hook is left alone. Swapping a global hook around a call that runs every frame would swallow unrelated panics from other threads for as long as the window is open, which is a worse trade than the rare unhandled message.

## Follow-ups

- **Report and track mmdflux#387 to resolution.** The pre-check and the `catch_unwind` backstop are both marked removable once it ships; upstream `main` is currently unchanged at the faulty line and 2.6.0 is the latest release. Deferred because the fix is in a third-party crate.
- **Large-fence render cost.** A 60 KiB flowchart takes ~600 ms per layout, and an in-flight fence is attempted every streaming frame. Pre-existing (measured on the base commit too) and out of scope for this fix, but `MAX_SOURCE_BYTES` is arguably too generous for an interactive renderer. Deferred rather than silently retuned, since lowering it changes what hosts can render.
- **Width fitting is separation-only.** Label wrapping would narrow diagrams further, but the diamond path is exactly what mmdflux#387 breaks, so it is blocked upstream.
- **`pty_palette::a_terminals_answer_becomes_the_theme` is flaky on macOS.** It failed on the first CI run of this branch with the terminal's OSC answer present in the captured stream but arriving after the probe deadline. Unrelated to this diff (which touches no file under `src/` or `tests/`). Not fixed here; worth a look if it recurs.