### PR TITLE
fix(ci): separate Rust pins from action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+# Pin action code separately from compiler policy. Rust-version action refs make
+# Dependabot mistake an intentional toolchain pin for an action update.
+
 on:
   push:
     branches: [main]
@@ -72,7 +75,9 @@ jobs:
       # it. Every published workspace crate declares the same floor, so check
       # them together.
       - name: Install Rust 1.88
-        uses: dtolnay/rust-toolchain@1.88.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.88.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -120,8 +125,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: 1.94.0
           components: rustfmt, clippy
 
       - name: Cache Rust
@@ -145,10 +151,14 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Install nightly for the docs.rs rehearsal
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -185,7 +195,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -270,7 +282,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -300,7 +314,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -342,7 +358,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/nightly-terminals.yml
+++ b/.github/workflows/nightly-terminals.yml
@@ -1,5 +1,8 @@
 name: Nightly Terminals
 
+# Pin action code separately from compiler policy. Rust-version action refs make
+# Dependabot mistake an intentional toolchain pin for an action update.
+
 # Cross-terminal integration for the tuika renderer. The in-repo tests (buffer,
 # vt100 grid, PTY protocol) prove tuika emits the right bytes; this runs the
 # `gallery` example inside *real* terminal emulators nightly to check how they
@@ -40,7 +43,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -89,7 +94,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -131,7 +138,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
@@ -191,7 +200,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish
 
+# Pin action code separately from compiler policy. Rust-version action refs make
+# Dependabot mistake an intentional toolchain pin for an action update.
+
 on:
   release:
     types: [published]
@@ -19,7 +22,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.94.0
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
 
       - name: Verify version matches tag
         env:


### PR DESCRIPTION
## What changed

CI now pins `dtolnay/rust-toolchain` action code to an immutable commit and selects Rust through the explicit `toolchain` input. The MSRV leg remains on 1.88.0; normal, nightly-terminal, and publish jobs remain on 1.94.0; the docs.rs rehearsal remains on nightly.

This has no public API or runtime behavior change.

## Why

The action uses Rust-version-shaped Git refs. Dependabot interpreted `@1.88.0` as a normal action version and repeatedly proposed `@1.100.0`, which would silently stop testing the declared MSRV.

## Before / After

Before: Dependabot could rewrite the MSRV job from Rust 1.88 to 1.100 while the job still claimed to test 1.88.

After: Dependabot can update the pinned action implementation without changing the explicit compiler inputs.

Validation:

- `actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/nightly-terminals.yml .github/workflows/publish.yml`
- `cargo fmt --all -- --check`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Confirmed the pinned upstream `action.yml` requires and supports the `toolchain` input
- PR CI directly exercises the changed CI workflow; config-only change, so no terminal smoke test applies

## Risk

- Low
- A malformed action pin or input could prevent CI toolchain setup; the full SHA resolves upstream and workflow syntax validates locally.

## Checklist

- [x] Tests added or updated — config-only; the changed workflow is exercised by PR CI
- [x] Backward compatibility considered — compiler selections are unchanged
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this enforces the existing MSRV and development-toolchain policy without changing it.

## Security

Reviewed TM-DEP. Pinning third-party action code to a full commit SHA improves supply-chain integrity. No dependencies, workflow permissions, secret access, or executable inputs changed. TM-ESC, TM-STATE, TM-PARSE, and TM-CLIP are not affected by CI-only configuration.

## Follow-ups

No follow-ups.