### PR TITLE
fix(mermaid): render multi-line decision-node labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ described in the release process begins with the entry below.
 
 ### Fixed
 
-- `tuika-mermaid` no longer lets a Mermaid decision node with a `<br/>` label
-  unwind out of `View::render` and take the host application down. The same
-  upstream defect ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387))
-  also fails silently — dropping the label in release builds, or painting a
-  short label over the shape's own borders — so all three now fall back to the
-  ordinary themed code block.
+- `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a
+  diagram, with every label line inside the shape. The upstream defect
+  ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)) — which
+  unwound out of `View::render` and took the host application down, and failed
+  silently in release builds by dropping the label or painting a short one over
+  the shape's own borders — is fixed in mmdflux 2.6.1, which `tuika-mermaid`
+  now requires. The adapter-side guard that degraded these fences to the
+  code-block fallback is gone with it; the unconditional panic containment
+  around the layout engine stays.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "mmdflux"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3d57274846e2bab54eeb7e77e5418c76b8ea3e3ef4c5808daf73e1e68b89a6"
+checksum = "c78ba54627b01d793871184731714c11b41796326207c1fb8fd378e118800721"
 dependencies = [
  "pest",
  "pest_derive",

--- a/crates/tuika-mermaid/Cargo.toml
+++ b/crates/tuika-mermaid/Cargo.toml
@@ -21,4 +21,4 @@ categories = ["command-line-interface", "text-processing"]
 [dependencies]
 tuika = { version = "0.8.0", path = "../.." }
 ratatui-core = "0.1"
-mmdflux = { version = "2.6", default-features = false }
+mmdflux = { version = "2.6.1", default-features = false }

--- a/crates/tuika-mermaid/src/lib.rs
+++ b/crates/tuika-mermaid/src/lib.rs
@@ -65,10 +65,6 @@ impl MarkdownBlockRenderer for MermaidRenderer {
             return None;
         }
 
-        if trips_diamond_label_bug(source) {
-            return None;
-        }
-
         let rendered = fitted_diagram(source, context.width)?;
         Some(
             rendered
@@ -77,49 +73,6 @@ impl MarkdownBlockRenderer for MermaidRenderer {
                 .collect(),
         )
     }
-}
-
-/// Whether `source` would hit mmdflux's broken multi-line diamond label.
-///
-/// Upstream: <https://github.com/kevinswiber/mmdflux/issues/387>. Fixed in no
-/// release as of 2.6.0 — drop this guard, and the `catch_unwind` in
-/// [`render_layout`], once it lands.
-///
-/// `render_diamond` renders a fixed three-row shape sized from the label's
-/// *widest line*, then centres the *whole* label — line breaks included —
-/// against that width. Mermaid accepts `<br/>` in a decision node and it is the
-/// natural way to keep a wide one readable, so this is reachable from ordinary
-/// documents rather than only from malformed ones, and it fails three different
-/// ways: a subtraction underflow that panics under debug overflow checks, the
-/// same underflow wrapping in release so the label is dropped and an empty
-/// diamond renders, and — for labels short enough not to underflow — the label
-/// written across the shape's own borders. Only the first is contained by
-/// `catch_unwind`; the other two look like success. So the shape is recognised
-/// up front and the fence keeps tuika's code-block fallback, where the diagram
-/// is at least readable as source.
-///
-/// Only `flowchart`/`graph` sources are scanned: `{}` delimits a node label
-/// there, while in a class or state diagram it opens a member block that
-/// legitimately spans lines.
-fn trips_diamond_label_bug(source: &str) -> bool {
-    let is_flowchart = source
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty() && !line.starts_with("%%"))
-        .is_some_and(|line| line.starts_with("flowchart") || line.starts_with("graph"));
-    if !is_flowchart {
-        return false;
-    }
-
-    source.lines().any(|line| {
-        let Some(open) = line.find('{') else {
-            return false;
-        };
-        let Some(close) = line.rfind('}') else {
-            return false;
-        };
-        close > open && line[open..close].contains("<br")
-    })
 }
 
 /// The narrowest layout of `source` that fits `width`, or the narrowest one
@@ -161,13 +114,12 @@ fn render_layout(source: &str, separations: Option<(f64, f64, f64)>) -> Option<S
         config.layout.edge_sep = edge_sep;
     }
 
-    // Backstop only: `trips_diamond_label_bug` keeps the one panic we know
-    // about (https://github.com/kevinswiber/mmdflux/issues/387) out of this
-    // call, but a `View::render` must not be able to take the host application
-    // down mid-frame over a malformed diagram, so contain the rest too. The
-    // panic hook is deliberately left alone — `Markdown` re-renders every
-    // frame, and swapping a global hook that often would swallow unrelated
-    // panics from other threads for as long as the window is open.
+    // Backstop: no panic in mmdflux is known to be reachable from here, but a
+    // `View::render` must not be able to take the host application down
+    // mid-frame over a diagram, so contain one if it appears. The panic hook is
+    // deliberately left alone — `Markdown` re-renders every frame, and swapping
+    // a global hook that often would swallow unrelated panics from other
+    // threads for as long as the window is open.
     let rendered = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         render_diagram(source, OutputFormat::Text, &config)
     }));
@@ -289,52 +241,43 @@ mod tests {
         );
     }
 
-    /// A multi-line diamond label degrades to the code-block fallback rather
-    /// than unwinding into the host — both the label wide enough to underflow
-    /// mmdflux's centering and the short one that silently paints over the
-    /// shape's borders. See <https://github.com/kevinswiber/mmdflux/issues/387>.
+    /// A decision node with a `<br/>` label renders as a diagram, with every
+    /// label line inside the shape rather than dropped or painted over the
+    /// borders. mmdflux sized the diamond from the label's widest line and then
+    /// centred the whole label against it, which underflowed for a wide label
+    /// and overran the borders for a short one; 2.6.1 grows the shape to the
+    /// full label instead. See
+    /// <https://github.com/kevinswiber/mmdflux/issues/387>.
     #[test]
-    fn multiline_diamond_label_uses_markdown_fallback() {
-        for source in [
-            "flowchart TD\n A[x] --> B{aaaa<br/>aaaa}\n",
-            "flowchart TD\n A[x] --> B{abc<br/>abc}\n",
+    fn multiline_diamond_label_renders_inside_the_shape() {
+        for (source, labels) in [
+            (
+                "flowchart TD\n A[x] --> B{aaaa<br/>aaaa}\n",
+                ["aaaa", "aaaa"],
+            ),
+            ("flowchart TD\n A[x] --> B{abc<br/>abc}\n", ["abc", "abc"]),
         ] {
-            assert!(
-                render_block(MarkdownBlock::Fenced {
-                    language: "mermaid",
-                    source,
-                })
-                .is_none(),
-                "{source}"
-            );
+            let lines = render_block(MarkdownBlock::Fenced {
+                language: "mermaid",
+                source,
+            })
+            .expect("a rendered diagram");
+            let rendered: Vec<String> = lines.iter().map(text).collect();
+
+            for label in labels {
+                // Each label line sits on its own row, fenced by the diamond's
+                // own side glyphs — not overlapping a border row.
+                assert!(
+                    rendered.iter().any(|line| {
+                        let trimmed = line.trim_end();
+                        trimmed.contains(label)
+                            && trimmed.starts_with('<')
+                            && trimmed.ends_with('>')
+                    }),
+                    "{source}: {label} missing from {rendered:#?}"
+                );
+            }
         }
-    }
-
-    /// The `catch_unwind` backstop, exercised against the same input with the
-    /// pre-check bypassed: even reaching mmdflux, the seam must return rather
-    /// than unwind.
-    #[test]
-    fn panicking_layout_is_contained_rather_than_unwound() {
-        assert!(render_layout("flowchart TD\n A[x] --> B{aaaa<br/>aaaa}\n", None).is_none());
-    }
-
-    /// Only flowcharts use `{}` for a node label; a class diagram's member
-    /// block must not be mistaken for one.
-    #[test]
-    fn diamond_precheck_is_scoped_to_flowcharts() {
-        assert!(trips_diamond_label_bug(
-            "flowchart TD\n A --> B{one<br/>two}\n"
-        ));
-        assert!(trips_diamond_label_bug(
-            "%% a comment\ngraph LR\n A --> B{one<br>two}\n"
-        ));
-        assert!(!trips_diamond_label_bug(
-            "flowchart TD\n A[one<br/>two] --> B\n"
-        ));
-        assert!(!trips_diamond_label_bug("flowchart TD\n A --> B{plain}\n"));
-        assert!(!trips_diamond_label_bug(
-            "classDiagram\n class Foo {\n +bar()<br/>\n }\n"
-        ));
     }
 
     /// A branching flowchart whose default layout runs far past a terminal.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -290,12 +290,9 @@ themed code blocks instead of disappearing.
 A large graph is re-laid out at tighter node separation until it fits the pane,
 so a wide flowchart is not simply clipped at the right edge. Fitting is
 best-effort: a graph with many parallel branches can be irreducibly wider than
-the terminal, and the narrowest layout is used in that case. Two limits are
-worth knowing when authoring for a terminal — keep branch labels short, since
-label width compounds across a rank, and avoid `<br/>` inside a decision node
-(`{...}`), which the diagram engine
-[cannot lay out](https://github.com/kevinswiber/mmdflux/issues/387) and which
-falls back to the code block.
+the terminal, and the narrowest layout is used in that case. One limit is worth
+knowing when authoring for a terminal: keep branch labels short, since label
+width compounds across a rank.
 
 Here are the flowchart and sequence diagram rendered by the runnable integration
 example:

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,20 @@
 # Knowledge Log
 
+## 2026-08-10
+
+- **A workaround is carried, then dropped; containment is kept**
+  - mmdflux 2.6.1 fixes the multi-line decision-node defect
+    ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)), so
+    `tuika-mermaid` requires it and renders those fences as diagrams instead of
+    recognising the shape up front and degrading them to the code block.
+  - The shape-recognition guard was scar tissue tied to one upstream release
+    window and left with it. The `catch_unwind` around the layout engine did
+    not: it is an unconditional property of the adapter seam, owed to the frame
+    whether or not a reachable panic is known.
+  - The regression test inverts with the fix — the same inputs now assert every
+    label line lands inside the diamond, so a re-broken upstream is caught by
+    the test that used to pin the workaround.
+
 ## 2026-08-09
 
 - **Paired adaptive chart gallery**

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -111,12 +111,11 @@ A block renderer sits inside `View::render`, so it must not be able to fail the
 frame: an unrenderable fence is a `None` and the code-block fallback, never an
 unwind. That is a constraint on the *adapter*, not on the engine behind it —
 `tuika-mermaid` contains mmdflux's panics rather than trusting a third-party
-layout engine to be total. Containment alone is not enough, though: the same
-upstream defect ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387),
-a multi-line decision-node label) also renders a diagram that merely *looks*
-successful, so the adapter additionally recognises the shape up front. A
-workaround that only catches the loud failure mode leaves the quiet ones.
-Containment does not extend to the panic hook: a
+layout engine to be total — the containment is unconditional and stays whether
+or not a reachable panic is currently known. Working *around* a specific
+upstream defect is the opposite: it is carried only while the defect is
+unfixed, and is removed on the release that fixes it rather than left as
+permanent scar tissue. Containment does not extend to the panic hook: a
 renderer runs every frame, and swapping a global hook that often would swallow
 unrelated panics for as long as the window is open.
 


### PR DESCRIPTION
## What changed

A Mermaid decision node with a `<br/>` label now renders as a diagram, with every
label line inside the shape. It previously degraded to the themed code-block
fallback, so the natural way to keep a wide decision node readable cost you the
diagram entirely.

`tuika-mermaid` now requires mmdflux **2.6.1** (was `2.6`), which fixes the
upstream defect. The adapter-side guard that recognised the shape up front is
gone with it. The `catch_unwind` around the layout engine stays: a `View::render`
must not be able to take the host application down mid-frame, and that is an
unconditional property of the adapter seam rather than a workaround for any one
upstream bug.

Authoring guidance in `docs/markdown.md` drops the "avoid `<br/>` in a decision
node" caveat, which is no longer true.

## Why

[mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387): `render_diamond`
sized a fixed three-row shape from the label's *widest line*, then centred the
*whole* label against that width. It failed three ways — a subtraction underflow
that panicked under debug overflow checks, the same underflow wrapping in release
so the label was dropped and an empty diamond rendered, and, for labels short
enough not to underflow, the label painted across the shape's own borders. Since
only the first was containable, the shape was recognised up front and the fence
kept the code-block fallback.

mmdflux 2.6.1 grows the diamond to the full label instead, so the workaround is
scar tissue tied to one upstream release window and is removed on the release
that fixes it.

## Before / After

Same source, rendered through `Markdown` at 72 columns
(`tuika::testing::{render, grid}`):

**Before** — the fence falls back to visible source:

```
▏ mermaid
▏ flowchart TD
▏   A[Gateway model id] --> B{Pi registry<br/>provider-exact match?}
▏   B -- yes --> C[Use registry]
▏   B -- no --> D[Safe defaults]
```

**After** — a diagram, with both label lines inside the diamond:

```
           ┌──────────────────┐
           │ Gateway model id │
           └──────────────────┘
                     │
                     ▼
         ┌───────────────────────┐
         <      Pi registry      >
         < provider-exact match? >
         └───────────────────────┘
        ┌─┘                     └┐
        │                        │
       yes                      no
```

## Risk

- **Low**
- The change is scoped to Mermaid fences that contain a multi-line decision-node
  label — exactly the inputs that previously produced no diagram. Fences that
  render today are untouched: the fit ladder, size caps, control-byte stripping,
  and panic containment are unchanged, and the full suite passes.
- What could break: a re-broken upstream. The regression test inverts rather than
  disappears, so that fails CI here rather than reaching a host.
- The committed `mermaid.gif` recording needs no refresh — the integration example
  contains no `<br/>` label, so its render is byte-identical.

Evidence: `cargo fmt --all -- --check`,
`cargo clippy --workspace --all-targets --all-features -- -D warnings`,
`cargo test --workspace --all-features` (all green, 601 core + 10 mermaid),
`cargo run --example demo -- check` (*41 scenes, recordings, and references in
sync*), `python3 scripts/validate_okf.py knowledge --check-links` (*15 concepts,
0 errors*), and the dump above as the real-render smoke, a terminal being
unavailable here.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

`multiline_diamond_label_renders_inside_the_shape` replaces the two tests that
pinned the workaround, asserting on the same two inputs that each label line lands
on its own row fenced by the diamond's side glyphs — which catches all three
upstream failure modes, not just the panic. Verified as a genuine regression test
by pinning `=2.6.0` locally: it fails there and passes on 2.6.1.

`panicking_layout_is_contained_rather_than_unwound` is removed, not replaced: it
drove the retained `catch_unwind` through the one input known to panic, and no
mmdflux panic is reachable from the adapter any more. Noted under **Follow-ups**.

No API change — no `pub` item added, renamed, removed, or resignatured. No new
dependency; the `Cargo.lock` delta is one version and checksum, with no new
transitive crates.

## Knowledge

Updated `knowledge/specs/markdown.md` — the block-renderer totality section
conflated two things it now separates: unconditional panic containment, which is
owed to the frame permanently, and a workaround for a specific upstream defect,
which is carried only while the defect is unfixed. Logged in `knowledge/log.md`.

## Security

Reviewed against the threat-model categories; **TM-DEP** and **TM-PARSE** are the
ones this diff touches.

- **TM-DEP** — a patch bump of an existing dependency, not a new crate. No new
  transitive tree (`Cargo.lock` delta is version + checksum only), and `ratatui`
  stays a dev-dependency.
- **TM-PARSE** — removing the pre-check means these fences now reach mmdflux's
  layout rather than being turned away, so the trust boundary is worth stating
  explicitly: it is unchanged. The guard was a correctness workaround for one
  diagram shape, never a control against hostile input, and every actual control
  is retained — the 64 KiB source cap, the 1 MiB output cap, `catch_unwind` around
  the layout call, and control-byte stripping before cells are created. The tests
  covering the caps and the escape-smuggling case still pass.
- **TM-ESC** — unchanged. mmdflux colour output stays `TextColorMode::Plain` and
  no caller-supplied string reaches the terminal as a control sequence.
- **TM-STATE**, **TM-CLIP** — no terminal lifecycle or clipping code touched.

## Follow-ups

- The retained `catch_unwind` in `render_layout` no longer has a test that drives
  it, because no reachable mmdflux panic is known. Deferred rather than faked: a
  test needs an input that actually panics, and inventing a seam to inject one
  would add public surface for a guard that is deliberately invisible. It is
  three lines wrapping one call, and the *containment* it provides is asserted
  wherever a render fails for other reasons.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RHmnhGNgkMjCcQiz5YyQQq)_