### PR TITLE
docs: link project surfaces to tuika.dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2024"
 rust-version = "1.88"
 authors = ["Mykhailo Chalyi <mike@chaliy.name>", "Everruns <support@everruns.com>"]
 license = "MIT"
-homepage = "https://github.com/everruns/tuika"
+homepage = "https://tuika.dev"
 repository = "https://github.com/everruns/tuika"
 
 [package]
@@ -36,6 +36,7 @@ authors.workspace = true
 license.workspace = true
 description = "The application framework for Rust terminal UIs — flexbox layout, overlays, focus, keymap, components, and safe ratatui interoperability."
 homepage.workspace = true
+documentation = "https://docs.rs/tuika"
 repository.workspace = true
 readme = "README.md"
 keywords = ["tui", "terminal", "ratatui", "framework", "widgets"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![downloads](https://img.shields.io/crates/d/tuika.svg)](https://crates.io/crates/tuika)
 [![license](https://img.shields.io/crates/l/tuika.svg)](https://github.com/everruns/tuika/blob/main/LICENSE)
 ![msrv](https://img.shields.io/badge/rust-1.88%2B-blue.svg) \
-[Docs](https://docs.rs/tuika) · [Getting started](docs/getting-started.md) · [Components](docs/components.md) · [Layout](docs/layout.md) ·
+[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](docs/getting-started.md) · [Components](docs/components.md) · [Layout](docs/layout.md) ·
 [Markdown](docs/markdown.md) · [Charts](docs/charts.md) ·
 [Terminal features](docs/features.md) ·
 [Keymap](docs/keymap.md) · [Styling](docs/styling.md) ·


### PR DESCRIPTION
## What changed

- Make tuika.dev the prominent website link in the README while keeping docs.rs clearly labeled as the Rust API.
- Publish tuika.dev as the Cargo homepage and docs.rs as the root crate's documentation URL.

No public Rust API or runtime behavior changes.

## Why

tuika.dev is now the browsable home for the project guides, but the README and crate metadata still routed readers primarily to GitHub or labeled docs.rs generically as “Docs.” These links now distinguish the website/guides from the Rust API reference.

## Before / After

- Before: the README's “Docs” link opened docs.rs; Cargo advertised GitHub as the homepage and had no explicit documentation URL.
- After: the README exposes “Website” and “Rust API” separately; `cargo metadata` resolves `homepage=https://tuika.dev` and `documentation=https://docs.rs/tuika`.

## Risk

- Low.
- Only public links and package metadata change. No dependencies, runtime behavior, or public APIs are affected.

## Checklist

- [x] Tests added or updated — exempt because this is docs/config-only with no behavior change
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Validation

- `cargo fmt --all -- --check`
- public documentation boundary check
- `cargo test --locked --test packaging` (8 passed)
- `cargo publish --dry-run --locked --allow-dirty -p tuika`
- live endpoint checks for tuika.dev and docs.rs

Terminal smoke testing is not applicable to documentation links and package metadata.

## Knowledge

No knowledge update required — the documentation specification already defines tuika.dev as the browsable home for the repository's public guides; this change aligns discovery metadata with that existing contract.

## Security

No security-relevant code changes. The diff only changes public URLs in Markdown and Cargo package metadata, adds no dependency, and does not affect terminal escapes, terminal state, parsing, clipping, or runtime behavior.

## Follow-ups

No follow-ups.
