### PR TITLE
feat(runner)!: restore text selection by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ described in the release process begins with the entry below.
 
 ## Unreleased
 
+### Added
+
+- `Runner` and `AsyncRunner` restore drag-to-select behavior by default when
+  their terminal session captures the mouse. Selection is painted over the
+  final cell frame, releasing copies through OSC 52 on real-terminal runs, and
+  wheel events continue to reach application scrolling. Applications can claim
+  gestures with `UpdateResult::Consumed` / `Dirty` or opt out with
+  `with_text_selection(false)`.
+
 ### Fixed
 
 - `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a
@@ -26,6 +35,11 @@ described in the release process begins with the entry below.
   around the layout engine stays.
 
 ### Changed
+
+- **Breaking**: `UpdateResult::Clean` now means an input was unhandled and may
+  receive runner default behavior; return the new `UpdateResult::Consumed` for
+  a handled input that does not need a repaint. Exhaustive matches over
+  `UpdateResult` must add the new variant.
 
 - `tuika-mermaid` re-lays out a diagram wider than the available columns at
   progressively tighter node separation until it fits, instead of letting it be

--- a/README.md
+++ b/README.md
@@ -747,6 +747,10 @@ let mut app = Stats::default();
 runner.run_app(&Theme::default(), &mut app)?;
 ```
 
+`UpdateResult::Clean` leaves an input available to runner defaults such as text
+selection. Return `Consumed` when the application handled it without changing
+the frame, `Dirty` when handling changed the frame, or `Exit` to stop.
+
 `Runner::run` and `run_with_backend` retain the separate state/view/update
 closure API for owned `Element` trees. The
 [`borrowed_app`](examples/borrowed_app.rs) example implements a custom `View`
@@ -769,8 +773,8 @@ network or disk I/O — and lets its update closure `.await`. It ties
 `TerminalSession`, `paint`, and `translate_event` to crossterm's async
 `EventStream` and a tick timer in one `tokio::select!`, so the host keeps a
 single event loop. Its update closure returns the same
-`UpdateResult::{Clean, Dirty, Exit}` as `Runner`, so awaited work only rebuilds
-and repaints when it actually changes visible state.
+`UpdateResult::{Clean, Consumed, Dirty, Exit}` as `Runner`, so awaited work only
+rebuilds and repaints when it actually changes visible state.
 
 Enabling `async` adds Tokio (timer + `select!`) and crossterm's `event-stream`
 feature; it stays off by default so sync-only hosts pull in no runtime. The
@@ -831,8 +835,15 @@ To check support across every terminal feature in one place — `graphics`,
 
 Enabling mouse capture (which `AltScreen` / `TerminalSession` do) means the
 terminal stops doing its own click-drag text selection and hands every drag to
-the app instead. The `mouse` module rebuilds those affordances over the grid
-you already rendered:
+the app instead. `Runner` and `AsyncRunner` restore selection by default over
+the final rendered grid: a plain left drag highlights text, a same-cell double
+click selects a word, and releasing copies through OSC 52. Wheel events still
+reach application scrolling. An
+application claims a mouse gesture by returning `UpdateResult::Consumed` (no
+repaint) or `UpdateResult::Dirty` (repaint), and can disable the default
+entirely with `with_text_selection(false)`.
+
+Hosts with their own loop use the `mouse` module to build the same affordances:
 
 - **Text selection.** `SelectionState` turns a left-button `Down → Drag → Up`
   gesture into a `SelectionRange` (a plain click selects nothing; a new press

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,7 +39,7 @@ content:
 | Boundary | Consideration |
 | --- | --- |
 | Terminal escape sequences | Host-supplied text is rendered as cell content. Out-of-band escapes (OSC 8 hyperlinks, OSC 52 clipboard, OSC 9;4 progress, and the graphics protocols) are emitted only through tuika's own encoders, from data the host passes explicitly. A defect that let arbitrary caller text reach the terminal as an unescaped control sequence would be in scope. |
-| Clipboard | OSC 52 writes are host-initiated. Terminals differ in whether they honor clipboard writes from a remote session; tuika never reads the clipboard back. |
+| Clipboard | OSC 52 writes are host-initiated, or runner-initiated after an explicit user drag selection over rendered cells. Terminals differ in whether they honor clipboard writes from a remote session; tuika never reads the clipboard back. |
 | Graphics protocols | Image payloads are host-decoded RGBA. tuika does not decode image files, so image-parser vulnerabilities belong to the host's dependency surface, not tuika's. |
 | Untrusted content | Markdown and code passed to `Markdown`/`CodeBlock` is parsed and laid out, never executed. Pathological input should degrade to slow or truncated rendering; a reproducible panic or unbounded allocation from parsed content is in scope. |
 

--- a/crates/tuika-codeformatters/README.md
+++ b/crates/tuika-codeformatters/README.md
@@ -42,7 +42,8 @@ cargo run -p tuika-codeformatters --example highlight_file -- path/to/file.rs
 
 The viewer detects the language from the file extension and falls back to plain
 code for unknown extensions. Use ↑/↓, j/k, Page Up/Page Down, Home/End, or
-the mouse wheel to scroll; `q` or Esc quits.
+the mouse wheel to scroll. Drag selects and copies rendered code; `q` or Esc
+quits.
 
 ## Supported languages
 

--- a/crates/tuika-codeformatters/examples/highlight_file.rs
+++ b/crates/tuika-codeformatters/examples/highlight_file.rs
@@ -105,7 +105,7 @@ impl Application for FileViewer {
         };
         let header = format!("{language} · {}", self.path.display());
         let status = format!(
-            "lines {}-{} of {} · ↑/↓ or j/k, PgUp/PgDn, Home/End scroll · q quit",
+            "lines {}-{} of {} · drag select/copy · ↑/↓, j/k, PgUp/PgDn scroll · q quit",
             start.saturating_add(1).min(self.lines.len()),
             end,
             self.lines.len()

--- a/docs/features.md
+++ b/docs/features.md
@@ -241,9 +241,18 @@ must be enabled: `set -g allow-passthrough on`.
 ## Mouse: selection, highlight & clicks
 
 Once an app captures the mouse, the terminal stops doing its own click-drag text
-selection. The `mouse` module rebuilds those affordances over the grid you
-already rendered — selection, copy, and hit-testing — from tuika's enriched
-event model (`MouseKind` carries `Down`/`Up`/`Drag`, `Moved`, and scroll, with
+selection. `Runner` and `AsyncRunner` restore it by default over the final cell
+frame: a plain left drag highlights text, a same-cell double click selects a
+word, and releasing copies through OSC 52. Wheel events continue to reach the
+application. Return
+`UpdateResult::Consumed` for a handled gesture that needs no repaint, or
+`UpdateResult::Dirty` for one that does; either result keeps draggable controls
+from also becoming a text selection. `with_text_selection(false)` disables the
+runner default.
+
+The `mouse` module exposes the same primitives for hosts with their own loop —
+selection, copy, and hit-testing — from tuika's enriched event model
+(`MouseKind` carries `Down`/`Up`/`Drag`, `Moved`, and scroll, with
 `shift`/`ctrl`/`alt`).
 [API](https://docs.rs/tuika/latest/tuika/mouse/index.html)
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-08-10
 
+- **Mouse capture does not remove basic text selection from runner apps**
+  - Synchronous and asynchronous runners apply unclaimed plain left drags to
+    the final rendered cell buffer, paint the theme selection style, and copy
+    through OSC 52 on release while continuing to route wheel input normally.
+  - `UpdateResult` now distinguishes unhandled clean input from handled input
+    that needs no repaint, giving draggable controls explicit ownership without
+    requiring every read-only view to rebuild terminal selection itself.
+  - Custom-loop hosts retain the lower-level `SelectionState` path; selection
+    remains runner policy rather than hidden component state.
+
 - **A workaround is carried, then dropped; containment is kept**
   - mmdflux 2.6.1 fixes the multi-line decision-node defect
     ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)), so

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -32,7 +32,7 @@ terminal encoder, not the component, and belongs in the PTY layer.
 | Property | `src/tests/proptests.rs` | solver and overlay invariants for *any* input — children stay in bounds, flex fills exactly |
 | Golden snapshot | `src/tests/snapshots.rs` | whole screens diffed against checked-in glyph grids |
 | Size sweep | unit | no panic and no out-of-clip writes from `0×0` upward |
-| PTY smoke | `tests/pty_smoke.rs` | the terminal-facing protocol in both screen modes: alt-screen and cursor/mouse lifecycle pairs, OSC 9;4, OSC 8, truecolor and Braille cells through a reference terminal parser, resize survival, clean exit; and for a split footer, that it stays off the alternate screen, pins to the bottom, publishes above itself, and releases its rows |
+| PTY smoke | `tests/pty_smoke.rs` | the terminal-facing protocol in both screen modes: alt-screen and cursor/mouse lifecycle pairs, runner selection through OSC 52, OSC 9;4, OSC 8, truecolor and Braille cells through a reference terminal parser, resize survival, clean exit; and for a split footer, that it stays off the alternate screen, pins to the bottom, publishes above itself, and releases its rows |
 | Packaging | `tests/packaging.rs` | what the published `.crate` contains |
 
 Snapshots refresh with `UPDATE_SNAPSHOTS=1`. A snapshot diff is a prompt to

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -101,6 +101,12 @@ rather than beside it.
 - **The host owns the terminal**: the screen mode (alternate screen or a split
   footer over live scrollback — see [screen-modes.md](./screen-modes.md)), raw
   mode, mouse capture, input translation, and frame compositing.
+- **A runner restores the terminal affordance its mouse capture removes.** Plain
+  left drags that application update code leaves clean select from the final
+  rendered cell buffer, receive the theme selection style, and copy through OSC
+  52 on release. Wheel input still routes to the application. A handled gesture
+  returns `UpdateResult::Consumed` or `Dirty`; custom-loop hosts keep using the
+  public selection primitives directly.
 - **Runners own application state directly**: `Application` receives signals
   through `&mut self` and builds a `ScopedElement<'_>` through `&self`, so a
   frame can borrow application data without shared interior mutability. The

--- a/knowledge/specs/out-of-band.md
+++ b/knowledge/specs/out-of-band.md
@@ -25,7 +25,7 @@ Six out-of-band capabilities, in three families:
 | Capability | Sequence | Module | Emission point |
 | --- | --- | --- | --- |
 | Hyperlinks | OSC 8 | `term::hyperlink` | spliced into the drawn cell run by `HyperlinkBackend` |
-| Clipboard | OSC 52 | `term::clipboard` | host-initiated, any time |
+| Clipboard | OSC 52 | `term::clipboard` | host- or runner-initiated, any time |
 | Native progress | OSC 9;4 | `term::progress` | host-initiated, any time |
 | Pointer shape | OSC 22 | `term::pointer` | host-initiated, any time |
 | Images | Kitty / iTerm2 / Sixel | `term::image` | after `terminal.draw()` returns |
@@ -113,6 +113,12 @@ the host passed explicitly. Host text is never interpolated into an escape
 unescaped. This is the property that keeps the "arbitrary caller text reaching
 the terminal as a control sequence" class of bug out of scope by construction —
 see [`SECURITY.md`](../../SECURITY.md).
+
+Runner-provided mouse selection is the one framework-initiated clipboard path.
+It reads only the cells the runner just rendered and passes that text through
+the same base64 OSC 52 encoder on release. A caller-owned async event loop gets
+the selection overlay only; it can disable that default and compose the public
+selection primitives when it needs a custom clipboard sink.
 
 ## Constraints
 

--- a/knowledge/specs/screen-modes.md
+++ b/knowledge/specs/screen-modes.md
@@ -29,6 +29,10 @@ until it happens.
 | `Alternate` (default) | the whole window, alternate buffer | n/a — restored on exit | on |
 | `SplitFooter { height }` | `height` rows at the bottom of the main screen | the terminal's, live | off by default |
 
+When a runner captures the mouse, it restores plain drag selection over its
+final cell frame while continuing to route wheel events to the application.
+Custom-loop hosts opt into capture and selection independently.
+
 A split footer renders into a ratatui `Viewport::Inline`. The pieces around it:
 
 - `TerminalSession::enter_with(mode)` takes only what the mode needs and

--- a/src/host.rs
+++ b/src/host.rs
@@ -144,7 +144,7 @@ impl TerminalSessionConfig {
         }
     }
 
-    fn captures_mouse(self) -> bool {
+    pub(crate) fn captures_mouse(self) -> bool {
         match self.mouse_capture {
             MouseCapture::ModeDefault => self.screen_mode.captures_mouse(),
             MouseCapture::Enabled => true,

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -66,11 +66,12 @@ use tokio::time::{Instant as TokioInstant, MissedTickBehavior, interval, sleep_u
 use tokio_stream::{Stream, StreamExt};
 
 use super::{
-    FrameGraphics, FrameGraphicsCleanup, RESIZE_FRAME_INTERVAL, RunnerAction, RunnerCore, Signal,
+    FrameGraphics, FrameGraphicsCleanup, RESIZE_FRAME_INTERVAL, RunnerAction, RunnerCore,
+    RunnerSelection, Signal,
 };
 use crate::screen::{Scrollback, close_footer, pin_footer};
 use crate::{
-    Element, Event, RenderCtx, RunnerConfig, TerminalSession, Theme, UpdateResult,
+    Element, Event, RenderCtx, RunnerConfig, SystemClock, TerminalSession, Theme, UpdateResult,
     paint_with_context, translate_event,
 };
 
@@ -86,6 +87,7 @@ pub struct AsyncRunner {
     config: RunnerConfig,
     scrollback: Scrollback,
     session_config: Option<crate::TerminalSessionConfig>,
+    text_selection: bool,
 }
 
 impl AsyncRunner {
@@ -99,6 +101,7 @@ impl AsyncRunner {
             config,
             scrollback: Scrollback::new(),
             session_config: None,
+            text_selection: true,
         }
     }
 
@@ -107,6 +110,23 @@ impl AsyncRunner {
         self.config.screen_mode = config.screen_mode;
         self.session_config = Some(config);
         self
+    }
+
+    /// Enable or disable runner-provided drag selection over the final cell
+    /// frame. It is enabled by default whenever the terminal session captures
+    /// the mouse. Applications claim a gesture by returning
+    /// [`UpdateResult::Consumed`] or [`UpdateResult::Dirty`] for its events.
+    pub fn with_text_selection(mut self, enabled: bool) -> Self {
+        self.text_selection = enabled;
+        self
+    }
+
+    fn selects_text(&self) -> bool {
+        self.text_selection
+            && self.session_config.map_or_else(
+                || self.config.screen_mode.captures_mouse(),
+                crate::TerminalSessionConfig::captures_mouse,
+            )
     }
 
     /// Return a handle for publishing content above a
@@ -209,7 +229,15 @@ impl AsyncRunner {
                 view,
                 update,
                 graphics,
-                || graphics.map_or(Ok(()), FrameGraphics::finish_frame),
+                |copied| {
+                    if let Some(graphics) = graphics {
+                        graphics.finish_frame()?;
+                    }
+                    if let Some(text) = copied {
+                        let _ = crate::term::clipboard::write(&mut io::stdout(), text)?;
+                    }
+                    Ok(())
+                },
             )
             .await;
 
@@ -258,16 +286,9 @@ impl AsyncRunner {
         V: FnMut(&S, u64) -> Element,
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
-        self.run_with_events_inner(
-            terminal,
-            theme,
-            state,
-            events,
-            view,
-            update,
-            None,
-            || Ok(()),
-        )
+        self.run_with_events_inner(terminal, theme, state, events, view, update, None, |_| {
+            Ok(())
+        })
         .await
     }
 
@@ -288,10 +309,11 @@ impl AsyncRunner {
         E: Stream<Item = Result<Event, Er>> + Unpin,
         V: FnMut(&S, u64) -> Element,
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
-        F: FnMut() -> Result<(), Er>,
+        F: FnMut(Option<&str>) -> Result<(), Er>,
     {
         let mut events_done = false;
         let mut core = RunnerCore::new();
+        let mut selection = RunnerSelection::new(self.selects_text());
         let split = !self.config.screen_mode.is_alternate();
 
         let mut ticker = interval(self.config.tick_rate);
@@ -305,8 +327,16 @@ impl AsyncRunner {
             pin_footer(terminal)?;
         }
         if let RunnerAction::Render(frame) = core.next_action() {
-            draw(terminal, theme, &mut view, state, frame, graphics)?;
-            finish_frame()?;
+            let copied = draw(
+                terminal,
+                theme,
+                &mut view,
+                state,
+                frame,
+                graphics,
+                &mut selection,
+            )?;
+            finish_frame(copied.as_deref())?;
         }
         let mut last_frame = TokioInstant::now();
         let mut redraw_at = None;
@@ -341,8 +371,16 @@ impl AsyncRunner {
                         terminal.autoresize()?;
                         pin_footer(terminal)?;
                     }
-                    draw(terminal, theme, &mut view, state, frame, graphics)?;
-                    finish_frame()?;
+                    let copied = draw(
+                        terminal,
+                        theme,
+                        &mut view,
+                        state,
+                        frame,
+                        graphics,
+                        &mut selection,
+                    )?;
+                    finish_frame(copied.as_deref())?;
                     last_frame = TokioInstant::now();
                 }
                 redraw_at = None;
@@ -353,12 +391,18 @@ impl AsyncRunner {
                 unreachable!()
             };
             let requires_redraw = signal.requires_redraw();
+            let selection_event = match &signal {
+                Signal::Event(event) => Some(event.clone()),
+                Signal::Tick => None,
+            };
             let result = update(state, signal).await;
             core.apply(result);
             if core.is_exited() {
                 break;
             }
-            if requires_redraw || result == UpdateResult::Dirty {
+            let selection_changed = selection_event
+                .is_some_and(|event| selection.handle_event(&event, result, &SystemClock));
+            if requires_redraw || result == UpdateResult::Dirty || selection_changed {
                 core.request_redraw();
                 let now = TokioInstant::now();
                 let deadline = if requires_redraw {
@@ -388,8 +432,16 @@ impl AsyncRunner {
                         terminal.autoresize()?;
                         pin_footer(terminal)?;
                     }
-                    draw(terminal, theme, &mut view, state, frame, graphics)?;
-                    finish_frame()?;
+                    let copied = draw(
+                        terminal,
+                        theme,
+                        &mut view,
+                        state,
+                        frame,
+                        graphics,
+                        &mut selection,
+                    )?;
+                    finish_frame(copied.as_deref())?;
                     last_frame = TokioInstant::now();
                 }
                 redraw_at = None;
@@ -408,18 +460,21 @@ fn draw<S, B, V, Er>(
     state: &S,
     frame: u64,
     graphics: Option<&FrameGraphics>,
-) -> Result<(), Er>
+    selection: &mut RunnerSelection,
+) -> Result<Option<String>, Er>
 where
     B: Backend<Error = Er>,
     V: FnMut(&S, u64) -> Element,
 {
+    let mut copied = None;
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let root = view(state, frame);
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
         paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root.as_ref(), &[]);
+        copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);
     })?;
-    Ok(())
+    Ok(copied)
 }
 
 #[cfg(test)]
@@ -428,7 +483,7 @@ mod tests {
 
     use super::*;
     use crate::components::Text;
-    use crate::event::{Key, KeyCode};
+    use crate::event::{Key, KeyCode, Mouse, MouseButton, MouseKind};
     use crate::view::element;
     use ratatui_core::backend::TestBackend;
 
@@ -440,6 +495,10 @@ mod tests {
             alt: false,
             shift: false,
         }))
+    }
+
+    fn mouse(kind: MouseKind, column: u16, row: u16) -> Result<Event, Infallible> {
+        Ok(Event::Mouse(Mouse::at(kind, column, row)))
     }
 
     fn terminal(width: u16, height: u16) -> Terminal<TestBackend> {
@@ -545,6 +604,127 @@ mod tests {
             1,
             "clean input leaves the initial frame intact"
         );
+    }
+
+    #[tokio::test]
+    async fn clean_mouse_drag_uses_default_text_selection() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(11, 1);
+        let mut mouse_events = 0usize;
+        let events = tokio_stream::iter([
+            mouse(MouseKind::Down(MouseButton::Left), 0, 0),
+            mouse(MouseKind::Drag(MouseButton::Left), 4, 0),
+            key(KeyCode::Esc),
+        ]);
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut mouse_events,
+                events,
+                |_state, _frame| element(Text::raw("hello world")),
+                async |mouse_events, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    Signal::Event(Event::Mouse(_)) => {
+                        *mouse_events += 1;
+                        UpdateResult::Clean
+                    }
+                    _ => UpdateResult::Clean,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            mouse_events, 2,
+            "selection does not hide events from the app"
+        );
+        let buffer = terminal.backend().buffer();
+        for column in 0..=4 {
+            assert_eq!(
+                buffer[(column, 0)].bg,
+                Theme::default().selection_bg,
+                "dragged cell {column} is highlighted"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn consumed_mouse_drag_claims_the_gesture() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(11, 1);
+        let mut state = ();
+        let events = tokio_stream::iter([
+            mouse(MouseKind::Down(MouseButton::Left), 0, 0),
+            mouse(MouseKind::Drag(MouseButton::Left), 4, 0),
+            key(KeyCode::Esc),
+        ]);
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut state,
+                events,
+                |_state, _frame| element(Text::raw("hello world")),
+                async |_state, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    Signal::Event(Event::Mouse(_)) => UpdateResult::Consumed,
+                    _ => UpdateResult::Clean,
+                },
+            )
+            .await
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        assert!(
+            (0..=4).all(|column| buffer[(column, 0)].bg != Theme::default().selection_bg),
+            "claimed drag is left entirely to the application"
+        );
+    }
+
+    #[tokio::test]
+    async fn mouse_wheel_still_drives_application_scrolling() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(12, 1);
+        let mut scrolled = false;
+        let events = tokio_stream::iter([mouse(MouseKind::ScrollDown, 0, 0), key(KeyCode::Esc)]);
+
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut scrolled,
+                events,
+                |scrolled, _frame| {
+                    element(Text::raw(if *scrolled { "line two" } else { "line one" }))
+                },
+                async |scrolled, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    Signal::Event(Event::Mouse(Mouse {
+                        kind: MouseKind::ScrollDown,
+                        ..
+                    })) => {
+                        *scrolled = true;
+                        UpdateResult::Dirty
+                    }
+                    _ => UpdateResult::Clean,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(buffer_text(&terminal).contains("line two"));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -9,6 +9,8 @@
 //! On real terminals they also detect image support, supply a per-frame image
 //! layer through [`RenderCtx`], emit it after the cell frame, and bound resize
 //! redraws to one frame every 16 ms.
+//! When their session captures the mouse, they also restore plain drag text
+//! selection over the final rendered cells and copy it through OSC 52.
 //!
 //! [`Runner`] is the synchronous loop and is always available. [`AsyncRunner`]
 //! (`feature = "async"`) is the same loop for hosts already on Tokio; it lives
@@ -35,11 +37,15 @@ use std::time::{Duration, Instant};
 
 use crossterm::event;
 use ratatui_core::backend::Backend;
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
 use ratatui_core::terminal::{Terminal, TerminalOptions};
 use ratatui_crossterm::CrosstermBackend;
 
 use crate::live::RedrawHandle;
+use crate::mouse::{SelectionState, paint_selection, selected_text};
 use crate::screen::{ScreenMode, Scrollback, close_footer, pin_footer};
+use crate::term::clipboard;
 use crate::term::image::{ImageLayer, ImageSupport};
 use crate::{
     Clock, Element, Event, RenderCtx, ScopedElement, SystemClock, TerminalSession, Theme, View,
@@ -134,10 +140,15 @@ impl Signal {
 /// What a runner should do after an update.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum UpdateResult {
-    /// Keep waiting without rebuilding or repainting the view.
+    /// The signal was not handled. Keep waiting without rebuilding or
+    /// repainting; the runner may apply a default interaction such as text
+    /// selection.
     #[default]
     Clean,
-    /// Rebuild and repaint the view from the updated state.
+    /// The signal was handled without changing persistent state or repainting.
+    /// This prevents runner-provided default interactions.
+    Consumed,
+    /// The signal was handled and the view must be rebuilt and repainted.
     Dirty,
     /// Stop the runner without painting another frame.
     Exit,
@@ -154,7 +165,9 @@ pub enum UpdateResult {
 /// Rendering should be pure: persistent UI and domain state belongs on the
 /// application and changes only in [`update`](Self::update).
 pub trait Application {
-    /// Update application state in response to a tick or terminal event.
+    /// Update application state in response to a tick or terminal event. Return
+    /// [`UpdateResult::Clean`] only when the signal was unhandled, or
+    /// [`UpdateResult::Consumed`] when it was handled without a repaint.
     fn update(&mut self, signal: Signal) -> UpdateResult;
 
     /// Build the ephemeral view tree for one numbered frame.
@@ -204,7 +217,7 @@ impl RunnerCore {
     /// Apply an application's update result.
     pub fn apply(&mut self, result: UpdateResult) {
         match result {
-            UpdateResult::Clean => {}
+            UpdateResult::Clean | UpdateResult::Consumed => {}
             UpdateResult::Dirty => self.dirty = true,
             UpdateResult::Exit => self.exited = true,
         }
@@ -244,6 +257,7 @@ pub struct Runner {
     redraw: RedrawHandle,
     scrollback: Scrollback,
     session_config: Option<crate::host::TerminalSessionConfig>,
+    text_selection: bool,
 }
 
 impl Runner {
@@ -268,6 +282,7 @@ impl Runner {
             redraw: RedrawHandle::default(),
             scrollback: Scrollback::new(),
             session_config: None,
+            text_selection: true,
         }
     }
 
@@ -289,6 +304,23 @@ impl Runner {
         self.config.screen_mode = config.screen_mode;
         self.session_config = Some(config);
         self
+    }
+
+    /// Enable or disable runner-provided drag selection over the final cell
+    /// frame. It is enabled by default whenever the terminal session captures
+    /// the mouse. Applications claim a gesture by returning
+    /// [`UpdateResult::Consumed`] or [`UpdateResult::Dirty`] for its events.
+    pub fn with_text_selection(mut self, enabled: bool) -> Self {
+        self.text_selection = enabled;
+        self
+    }
+
+    fn selects_text(&self) -> bool {
+        self.text_selection
+            && self.session_config.map_or_else(
+                || self.config.screen_mode.captures_mouse(),
+                crate::host::TerminalSessionConfig::captures_mouse,
+            )
     }
 
     /// Run until `update` returns [`UpdateResult::Exit`].
@@ -423,13 +455,22 @@ impl Runner {
         // while placements still belong to the screen on which they were made.
         let _graphics_cleanup = graphics.map(FrameGraphicsCleanup);
         let mut core = RunnerCore::new();
+        let mut selection = RunnerSelection::new(self.selects_text());
         let mut last_tick = self.clock.now();
 
         if split {
             pin_footer(&mut terminal)?;
         }
         if let RunnerAction::Render(frame) = core.next_action() {
-            draw(&mut terminal, theme, &mut view, state, frame, graphics)?;
+            draw(
+                &mut terminal,
+                theme,
+                &mut view,
+                state,
+                frame,
+                graphics,
+                &mut selection,
+            )?;
         }
         let mut last_frame = self.clock.now();
         let mut redraw_at = None;
@@ -469,7 +510,15 @@ impl Runner {
                         terminal.autoresize()?;
                         pin_footer(&mut terminal)?;
                     }
-                    draw(&mut terminal, theme, &mut view, state, frame, graphics)?;
+                    draw(
+                        &mut terminal,
+                        theme,
+                        &mut view,
+                        state,
+                        frame,
+                        graphics,
+                        &mut selection,
+                    )?;
                     last_frame = self.clock.now();
                 }
                 redraw_at = None;
@@ -486,12 +535,19 @@ impl Runner {
             {
                 let signal = Signal::Event(event);
                 let requires_redraw = signal.requires_redraw();
+                let selection_event = match &signal {
+                    Signal::Event(event) => Some(event.clone()),
+                    Signal::Tick => None,
+                };
                 let result = update(state, signal);
                 core.apply(result);
                 if core.is_exited() {
                     break 'running;
                 }
-                if requires_redraw || result == UpdateResult::Dirty {
+                let selection_changed = selection_event.is_some_and(|event| {
+                    selection.handle_event(&event, result, self.clock.as_ref())
+                });
+                if requires_redraw || result == UpdateResult::Dirty || selection_changed {
                     core.request_redraw();
                     let now = self.clock.now();
                     let deadline = if requires_redraw {
@@ -525,22 +581,118 @@ fn draw<S, B, V>(
     state: &S,
     frame: u64,
     graphics: Option<&FrameGraphics>,
+    selection: &mut RunnerSelection,
 ) -> io::Result<()>
 where
     B: Backend<Error = io::Error>,
     V: FnMut(&S, u64, &mut dyn FnMut(&dyn View)),
 {
+    let mut copied = None;
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
         view(state, frame, &mut |root| {
             paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root, &[]);
         });
+        copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);
     })?;
     if let Some(graphics) = graphics {
         graphics.finish_frame()?;
     }
+    if let Some(text) = copied {
+        let _ = clipboard::write(&mut io::stdout(), &text)?;
+    }
     Ok(())
+}
+
+struct RunnerSelection {
+    enabled: bool,
+    state: SelectionState,
+    pending_copy: bool,
+}
+
+impl RunnerSelection {
+    fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            state: SelectionState::new(),
+            pending_copy: false,
+        }
+    }
+
+    fn handle_event(&mut self, event: &Event, result: UpdateResult, clock: &dyn Clock) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        let Event::Mouse(mouse) = event else {
+            if matches!(event, Event::Resize { .. }) {
+                return self.clear();
+            }
+            return false;
+        };
+        if !mouse.plain() {
+            return false;
+        }
+
+        if matches!(
+            mouse.kind,
+            crate::MouseKind::ScrollUp
+                | crate::MouseKind::ScrollDown
+                | crate::MouseKind::ScrollLeft
+                | crate::MouseKind::ScrollRight
+        ) && result == UpdateResult::Dirty
+        {
+            return self.clear();
+        }
+
+        let left_gesture = matches!(
+            mouse.kind,
+            crate::MouseKind::Down(crate::MouseButton::Left)
+                | crate::MouseKind::Drag(crate::MouseButton::Left)
+                | crate::MouseKind::Up(crate::MouseButton::Left)
+        );
+        if !left_gesture {
+            return false;
+        }
+        if result != UpdateResult::Clean {
+            return self.clear();
+        }
+
+        let changed = self.state.handle_with_clock(mouse, clock);
+        if changed
+            && matches!(mouse.kind, crate::MouseKind::Up(crate::MouseButton::Left))
+            && self.state.range().is_some()
+        {
+            self.pending_copy = true;
+        }
+        changed
+    }
+
+    fn finish_frame(&mut self, buffer: &mut Buffer, area: Rect, theme: &Theme) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+        if self.state.resolve(buffer, area) {
+            self.pending_copy = true;
+        }
+        let Some(range) = self.state.range() else {
+            self.pending_copy = false;
+            return None;
+        };
+        let copied = self
+            .pending_copy
+            .then(|| selected_text(buffer, area, range));
+        self.pending_copy = false;
+        paint_selection(buffer, area, range, theme.selection_style());
+        copied
+    }
+
+    fn clear(&mut self) -> bool {
+        let changed = self.state.is_active();
+        self.state.clear();
+        self.pending_copy = false;
+        changed
+    }
 }
 
 #[cfg(test)]
@@ -614,13 +766,78 @@ mod tests {
         assert_eq!(core.next_action(), RunnerAction::Wait);
         core.apply(UpdateResult::Dirty);
         assert_eq!(core.next_action(), RunnerAction::Render(1));
+        core.apply(UpdateResult::Consumed);
+        assert_eq!(core.next_action(), RunnerAction::Wait);
         core.apply(UpdateResult::Exit);
         assert_eq!(core.next_action(), RunnerAction::Exit);
     }
 
     #[test]
+    fn default_selection_highlights_and_returns_dragged_text() {
+        let clock = FixedClock(Instant::now());
+        let mut selection = RunnerSelection::new(true);
+        let mut buffer = crate::testing::render(
+            &crate::components::Text::raw("hello world"),
+            11,
+            1,
+            &Theme::default(),
+        );
+        let area = buffer.area;
+        let down = crate::Mouse::at(crate::MouseKind::Down(crate::MouseButton::Left), 0, 0);
+        let drag = crate::Mouse::at(crate::MouseKind::Drag(crate::MouseButton::Left), 4, 0);
+        let up = crate::Mouse::at(crate::MouseKind::Up(crate::MouseButton::Left), 4, 0);
+
+        assert!(!selection.handle_event(&Event::Mouse(down), UpdateResult::Clean, &clock));
+        assert!(selection.handle_event(&Event::Mouse(drag), UpdateResult::Clean, &clock));
+        assert!(selection.handle_event(&Event::Mouse(up), UpdateResult::Clean, &clock));
+
+        let copied = selection.finish_frame(&mut buffer, area, &Theme::default());
+        assert_eq!(copied.as_deref(), Some("hello"));
+        for column in 0..=4 {
+            assert_eq!(buffer[(column, 0)].bg, Theme::default().selection_bg);
+        }
+    }
+
+    #[test]
+    fn consumed_mouse_gesture_is_not_selected() {
+        let clock = FixedClock(Instant::now());
+        let mut selection = RunnerSelection::new(true);
+        let down = crate::Mouse::at(crate::MouseKind::Down(crate::MouseButton::Left), 0, 0);
+        let drag = crate::Mouse::at(crate::MouseKind::Drag(crate::MouseButton::Left), 4, 0);
+
+        assert!(!selection.handle_event(&Event::Mouse(down), UpdateResult::Consumed, &clock,));
+        assert!(!selection.handle_event(&Event::Mouse(drag), UpdateResult::Consumed, &clock,));
+        assert!(selection.state.range().is_none());
+    }
+
+    #[test]
     fn the_default_config_owns_the_alternate_screen() {
         assert_eq!(RunnerConfig::default().screen_mode, ScreenMode::Alternate);
+    }
+
+    #[test]
+    fn text_selection_follows_capture_and_can_be_disabled() {
+        assert!(Runner::new(RunnerConfig::default()).selects_text());
+        assert!(
+            !Runner::new(RunnerConfig {
+                screen_mode: ScreenMode::split_footer(3),
+                ..RunnerConfig::default()
+            })
+            .selects_text()
+        );
+        assert!(
+            !Runner::new(RunnerConfig::default())
+                .with_text_selection(false)
+                .selects_text()
+        );
+        assert!(
+            !Runner::new(RunnerConfig::default())
+                .with_session_config(crate::TerminalSessionConfig {
+                    mouse_capture: crate::MouseCapture::Disabled,
+                    ..crate::TerminalSessionConfig::default()
+                })
+                .selects_text()
+        );
     }
 
     #[test]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -80,8 +80,8 @@ impl<S> TestHarness<S> {
     /// Deliver a signal, rendering only when the update marks the app dirty.
     ///
     /// Resize updates also render because layout depends on viewport geometry.
-    /// Otherwise, `None` represents both a clean update and exit; inspect the
-    /// returned [`UpdateResult`] to distinguish them.
+    /// Otherwise, `None` represents a clean/consumed update or exit; inspect
+    /// the returned [`UpdateResult`] to distinguish them.
     pub fn step(
         &mut self,
         signal: Signal,

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -4,11 +4,11 @@
 //! and never touch a real terminal. This drives real examples under a
 //! pseudo-terminal (`portable-pty`) and asserts the terminal-facing behavior a
 //! buffer test cannot see: entering and restoring the alternate screen, enhanced
-//! keyboard reporting, cursor and mouse-capture lifecycle, the native OSC 9;4
-//! progress indicator, OSC 8 hyperlinks, truecolor and Braille cells surviving a
-//! reference terminal parser, resize survival, and a clean exit — the `gallery`
-//! example for the alternate screen, and `split_footer` for a footer over live
-//! scrollback.
+//! keyboard reporting, cursor and mouse-capture lifecycle, runner-provided OSC
+//! 52 text selection, the native OSC 9;4 progress indicator, OSC 8 hyperlinks,
+//! truecolor and Braille cells surviving a reference terminal parser, resize
+//! survival, and a clean exit — `hello` and `gallery` for the alternate screen,
+//! and `split_footer` for a footer over live scrollback.
 //!
 //! This covers the *protocol* a terminal receives. Whether a specific emulator
 //! paints those bytes correctly is the cross-terminal nightly plus the manual
@@ -451,6 +451,24 @@ fn gallery_drives_altscreen_and_native_progress() {
     assert!(
         text.contains("spinners") && text.contains("progress"),
         "gallery chrome should render: {text:?}"
+    );
+}
+
+#[test]
+fn runner_drag_selection_copies_the_rendered_cells() {
+    // `Hello` begins at zero-based cell (3, 2). SGR mouse coordinates are
+    // one-based: press on H, drag through o, then release there.
+    let drag_hello = b"\x1b[<0;4;3M\x1b[<32;8;3M\x1b[<0;8;3m";
+    let run = Script::new("hello")
+        .size(8, 40)
+        .settle(Duration::from_millis(500))
+        .key(drag_hello, Duration::from_millis(500))
+        .run();
+
+    assert!(run.exited_ok, "hello should exit cleanly after selection");
+    assert!(
+        contains(&run.output, b"\x1b]52;c;SGVsbG8=\x1b\\"),
+        "drag release should copy `Hello` through OSC 52"
     );
 }
 


### PR DESCRIPTION
## What changed

`Runner` and `AsyncRunner` now restore plain drag text selection whenever their terminal session captures the mouse. Selection is painted over the final rendered cells and copied through OSC 52 on release, while wheel input still reaches application scrolling.

Applications can claim gestures with `UpdateResult::Consumed` or `UpdateResult::Dirty`, and can disable the default with `with_text_selection(false)`. The `highlight_file` example and public guidance now expose the behavior.

## Why

Full-screen mouse capture disables native terminal selection. That made a basic viewer such as `highlight_file` scrollable but not selectable unless every application rebuilt the same selection behavior itself.

## Before / After

Before: an unhandled drag in a full-screen runner did nothing because the terminal had yielded mouse events to the app.

After: the same drag highlights the final cell buffer and emits OSC 52 on release. The PTY test selects `Hello` from the real `hello` example and verifies the exact payload `ESC ] 52 ; c ; SGVsbG8= ST`. A manual real-terminal run of `highlight_file` also verified wheel scrolling, selection repaint, OSC 52 output, and clean terminal restoration.

## Risk

- Medium
- This changes default mouse-input policy and adds a public enum variant. Mouse-driven applications must return `Consumed`/`Dirty` for claimed gestures or opt out. The migration is documented in the changelog and README.

## API

- Added `Runner::with_text_selection` and `AsyncRunner::with_text_selection`.
- Added `UpdateResult::Consumed`.
- Breaking: `UpdateResult::Clean` now means unhandled input; exhaustive matches must add `Consumed`.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated architecture, screen-mode, out-of-band output, and testing concepts, plus the durable decision log.

## Security

- TM-ESC: selected cell text passes through the existing base64 OSC 52 encoder; raw selected text is not interpolated into an escape sequence.
- TM-STATE: terminal lifecycle is unchanged, and the real-terminal smoke verified mouse/alternate-screen restoration after selection.
- TM-PARSE: no new parser; selection reads the already-rendered, bounded cell buffer, and the existing OSC 52 size limit remains enforced.
- TM-CLIP: painting is clamped to the final frame area; tests cover selection, resize clearing, gesture ownership, and the terminal protocol.
- TM-DEP: no dependencies added.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --lib --bins --examples -q`
- `cargo test --workspace --all-features --doc -q`
- `cargo test --all-features --test pty_smoke -q`
- `cargo +1.88.0 check --locked --workspace --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --workspace --all-features --no-deps`
- `cargo run --locked --example demo -- check`
- `python3 scripts/validate_okf.py knowledge --strict --check-links`
- `python3 scripts/test_validate_okf.py`
- `python3 scripts/test_publish_order.py`
- Real-terminal `highlight_file` smoke: wheel down/up, drag selection, OSC 52 emission, clean quit.

## Follow-ups

No follow-ups.
