### PR TITLE
feat: hover tracking, timed style transitions, and gradient spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ described in the release process begins with the entry below.
   wheel events continue to reach application scrolling. Applications can claim
   gestures with `UpdateResult::Consumed` / `Dirty` or opt out with
   `with_text_selection(false)`.
+- Hover styling: `mouse::HoverTracker` pairs the pointer-motion stream with the
+  existing `HitMap` hit-testing, reporting when the hovered region changes so a
+  host can restyle it (and knows a redraw is warranted).
+- Timed style transitions: `anim::Transition` is a retargetable eased ramp for
+  state-driven motion (hover on/off, focus, expansion) — retargeting mid-flight
+  continues from the current value instead of jumping. `anim::lerp` and
+  `style::lerp_color` interpolate scalars and 24-bit colors; non-RGB colors
+  snap to the nearer endpoint, since an indexed color has no blendable value.
+- Gradient color spans: `style::Gradient` is a multi-stop color ramp with
+  even (`across`) or explicit (`with_stops`) stops; `Gradient::line` sweeps a
+  string's foreground across the ramp per display column (wide glyphs get one
+  coherent color) for use with `Text`. `Transition` and `Gradient` (with
+  `lerp_color`) are also in the prelude.
 
 ### Fixed
 

--- a/benches/iai-baseline.json
+++ b/benches/iai-baseline.json
@@ -2,14 +2,14 @@
   "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
   "tolerance_pct": 2.0,
   "benchmarks": {
-    "frame_full.large": 81454007,
-    "frame_windowed.large": 869465,
-    "one_shot.large": 5832653,
-    "one_shot.small": 246183,
+    "frame_full.large": 81473338,
+    "frame_windowed.large": 888796,
+    "one_shot.large": 5906747,
+    "one_shot.small": 249437,
     "paging.large": 252164,
-    "reflow.mixed": 12142847,
-    "render.large": 849948,
-    "render.small": 849885,
-    "streaming.mixed": 11861169
+    "reflow.mixed": 12337073,
+    "render.large": 869279,
+    "render.small": 869213,
+    "streaming.mixed": 12114055
   }
 }

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -66,6 +66,115 @@ pub fn sawtooth(frame: u64, period: u64) -> Phase {
 /// the segment leading into it.
 pub type Easing = fn(Phase) -> Phase;
 
+/// Linear interpolation from `a` to `b` by `t` in `0.0..=1.0` (clamped).
+pub fn lerp(a: f32, b: f32, t: Phase) -> f32 {
+    a + (b - a) * t.clamp(0.0, 1.0)
+}
+
+/// A retargetable eased ramp between two values, for state-driven motion.
+///
+/// Where a [`Timeline`] plays a fixed choreography from frame 0, a `Transition`
+/// follows a *target that changes at runtime* — hover on/off, focus gained,
+/// a panel expanding. Give it a new target with [`set_target`](Self::set_target)
+/// and it eases there from wherever it currently is, including mid-flight:
+/// retargeting starts a fresh segment from the current sampled value, so motion
+/// never jumps.
+///
+/// Like everything animated in tuika it owns no clock: it is a pure function of
+/// the host's frame counter, so sampling is deterministic and testable. The
+/// usual shape for an animated *style* is a `Transition` driving a `0.0..=1.0`
+/// phase that [`style::lerp_color`](crate::style::lerp_color) or a
+/// [`style::Gradient`](crate::style::Gradient) maps onto colors:
+///
+/// ```
+/// use tuika::anim::Transition;
+/// use tuika::style::lerp_color;
+/// use tuika::ui::Color;
+///
+/// let (normal, hot) = (Color::Rgb(0, 0, 0), Color::Rgb(200, 200, 200));
+/// let mut hover = Transition::new(0.0, 12); // 12-frame ease
+/// hover.set_target(1.0, 100);               // pointer entered on frame 100
+/// let t = hover.sample(106);                // mid-flight...
+/// let fg = lerp_color(normal, hot, t);      // ...blends the style
+/// # let _ = fg;
+/// assert!(t > 0.0 && t < 1.0);
+/// assert_eq!(hover.sample(112), 1.0);
+/// ```
+#[derive(Clone, Copy, Debug)]
+pub struct Transition {
+    from: f32,
+    to: f32,
+    /// Host frame at which the current segment began.
+    start: u64,
+    duration: u64,
+    easing: Easing,
+}
+
+impl Transition {
+    /// A transition at rest on `value`, taking `duration` frames per segment,
+    /// eased with [`ease_in_out`]. A zero duration makes every retarget
+    /// instantaneous.
+    pub fn new(value: f32, duration: u64) -> Self {
+        Self {
+            from: value,
+            to: value,
+            start: 0,
+            duration,
+            easing: ease_in_out,
+        }
+    }
+
+    /// Replace the easing curve (e.g. [`ease_out`] for snappier arrivals).
+    pub fn easing(mut self, easing: Easing) -> Self {
+        self.easing = easing;
+        self
+    }
+
+    /// The value the transition is heading toward (or resting on).
+    pub fn target(&self) -> f32 {
+        self.to
+    }
+
+    /// Head toward `target`, starting a fresh eased segment at host `frame`
+    /// from the current sampled value. Setting the target it already has is a
+    /// no-op, so calling this every frame with the state-derived target is
+    /// fine — motion in flight is not restarted.
+    pub fn set_target(&mut self, target: f32, frame: u64) {
+        if target == self.to {
+            return;
+        }
+        self.from = self.sample(frame);
+        self.to = target;
+        self.start = frame;
+    }
+
+    /// Jump to `value` immediately, with no animation.
+    pub fn snap(&mut self, value: f32) {
+        self.from = value;
+        self.to = value;
+    }
+
+    /// The eased value at host `frame`. Frames before the segment started
+    /// return the segment's starting value.
+    pub fn sample(&self, frame: u64) -> f32 {
+        if self.duration == 0 || self.from == self.to {
+            return self.to;
+        }
+        let elapsed = frame.saturating_sub(self.start);
+        if elapsed >= self.duration {
+            return self.to;
+        }
+        let p = elapsed as f32 / self.duration as f32;
+        lerp(self.from, self.to, (self.easing)(p))
+    }
+
+    /// Whether motion has finished at host `frame` — the host can stop
+    /// scheduling animation frames once every transition is settled.
+    pub fn is_settled(&self, frame: u64) -> bool {
+        self.sample(frame) == self.to
+    }
+}
+
 /// What a [`Timeline`] does once the playhead passes its last keyframe.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum Repeat {
@@ -293,6 +402,62 @@ mod tests {
         assert!(eased.sample(5) < 0.5);
         approx(eased.sample(0), 0.0);
         approx(eased.sample(10), 1.0);
+    }
+
+    #[test]
+    fn transition_eases_toward_a_new_target() {
+        let mut t = Transition::new(0.0, 10).easing(linear);
+        approx(t.sample(0), 0.0);
+        assert!(t.is_settled(0));
+
+        t.set_target(1.0, 100);
+        approx(t.sample(100), 0.0);
+        approx(t.sample(105), 0.5);
+        approx(t.sample(110), 1.0);
+        approx(t.sample(999), 1.0); // holds after arrival
+        assert!(!t.is_settled(105));
+        assert!(t.is_settled(110));
+    }
+
+    #[test]
+    fn transition_retargets_from_mid_flight_value() {
+        let mut t = Transition::new(0.0, 10).easing(linear);
+        t.set_target(1.0, 0);
+        // Reverse halfway there: the new segment starts at 0.5, not at 1.0.
+        t.set_target(0.0, 5);
+        approx(t.sample(5), 0.5);
+        approx(t.sample(10), 0.25);
+        approx(t.sample(15), 0.0);
+    }
+
+    #[test]
+    fn transition_same_target_does_not_restart_motion() {
+        let mut t = Transition::new(0.0, 10).easing(linear);
+        t.set_target(1.0, 0);
+        // Re-asserting the target every frame must not reset the segment.
+        t.set_target(1.0, 4);
+        approx(t.sample(5), 0.5);
+    }
+
+    #[test]
+    fn transition_zero_duration_and_snap_are_instant() {
+        let mut t = Transition::new(0.0, 0);
+        t.set_target(1.0, 42);
+        approx(t.sample(42), 1.0);
+
+        let mut s = Transition::new(0.0, 30);
+        s.set_target(1.0, 0);
+        s.snap(0.25);
+        approx(s.sample(1), 0.25);
+        assert!(s.is_settled(1));
+    }
+
+    #[test]
+    fn lerp_clamps_and_interpolates() {
+        approx(lerp(0.0, 10.0, 0.5), 5.0);
+        approx(lerp(0.0, 10.0, -1.0), 0.0);
+        approx(lerp(0.0, 10.0, 2.0), 10.0);
+        approx(lerp(10.0, 0.0, 0.25), 7.5);
     }
 
     #[test]

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -379,6 +379,104 @@ impl ClickTracker {
     }
 }
 
+/// Tracks which [`HitMap`] region the pointer is resting on, for hover styling.
+///
+/// Terminals report pointer motion as [`MouseKind::Moved`] events once mouse
+/// capture is on; this pairs that stream with the hit-testing the app already
+/// does for clicks. Feed every mouse event to [`handle`](Self::handle) (all of
+/// them carry a cell, so drags and scrolls keep the position fresh too), then
+/// after pushing the frame's regions call [`resolve`](Self::resolve) — it
+/// returns `true` when the hovered value changed, which is the host's cue to
+/// request a redraw. During rendering, style the hot region via
+/// [`hovered`](Self::hovered) or [`is`](Self::is); to *animate* the change,
+/// drive an [`anim::Transition`](crate::anim::Transition) from the resolved
+/// state instead of switching styles directly.
+///
+/// ```
+/// use tuika::mouse::{HitMap, HoverTracker};
+/// use tuika::{Mouse, MouseKind};
+/// use tuika::ui::Rect;
+///
+/// let mut hits: HitMap<u8> = HitMap::new();
+/// hits.push(Rect::new(0, 0, 4, 1), 1);
+/// hits.push(Rect::new(4, 0, 4, 1), 2);
+///
+/// let mut hover = HoverTracker::new();
+/// hover.handle(&Mouse::at(MouseKind::Moved, 5, 0));
+/// assert!(hover.resolve(&hits));      // entered region 2 → redraw
+/// assert!(hover.is(&2));
+/// assert!(!hover.resolve(&hits));     // still there → nothing to do
+/// ```
+#[derive(Clone, Debug)]
+pub struct HoverTracker<T> {
+    position: Option<(u16, u16)>,
+    hovered: Option<T>,
+}
+
+impl<T> Default for HoverTracker<T> {
+    fn default() -> Self {
+        Self {
+            position: None,
+            hovered: None,
+        }
+    }
+}
+
+impl<T: Clone + PartialEq> HoverTracker<T> {
+    /// A tracker that has not seen the pointer yet.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record the pointer cell from a mouse event. Returns `true` when the
+    /// pointer moved to a different cell — a hint that the hover may need
+    /// re-resolving, not yet a style change.
+    pub fn handle(&mut self, m: &Mouse) -> bool {
+        let position = Some((m.column, m.row));
+        let moved = position != self.position;
+        self.position = position;
+        moved
+    }
+
+    /// Re-resolve the pointer against `map` (typically right after the frame's
+    /// regions were pushed — regions can move under a still pointer, so this
+    /// matters even without a `Moved` event). Returns `true` when the hovered
+    /// value changed and a redraw is warranted.
+    pub fn resolve(&mut self, map: &HitMap<T>) -> bool {
+        let hovered = self
+            .position
+            .and_then(|(col, row)| map.hit(col, row))
+            .cloned();
+        let changed = hovered != self.hovered;
+        self.hovered = hovered;
+        changed
+    }
+
+    /// The value of the region under the pointer, per the last
+    /// [`resolve`](Self::resolve).
+    pub fn hovered(&self) -> Option<&T> {
+        self.hovered.as_ref()
+    }
+
+    /// Whether `value`'s region is the hovered one — the per-region question a
+    /// renderer asks while styling.
+    pub fn is(&self, value: &T) -> bool {
+        self.hovered.as_ref() == Some(value)
+    }
+
+    /// The last pointer cell, if any event has been seen.
+    pub fn position(&self) -> Option<(u16, u16)> {
+        self.position
+    }
+
+    /// Forget the pointer (capture disabled, focus lost, pointer left the
+    /// pane). Returns `true` when that cleared an active hover.
+    pub fn clear(&mut self) -> bool {
+        self.position = None;
+        self.hovered.take().is_some()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -556,6 +654,77 @@ mod tests {
         assert_eq!(hits.hit(50, 50), None);
         // hit_event resolves an event's coordinates.
         assert_eq!(hits.hit_event(&down(3, 3)), Some(&"panel"));
+    }
+
+    fn moved(col: u16, row: u16) -> Mouse {
+        Mouse::at(MouseKind::Moved, col, row)
+    }
+
+    #[test]
+    fn hover_tracks_enter_move_and_leave() {
+        let mut hits: HitMap<&str> = HitMap::new();
+        hits.push(Rect::new(0, 0, 4, 1), "left");
+        hits.push(Rect::new(4, 0, 4, 1), "right");
+        let mut hover: HoverTracker<&str> = HoverTracker::new();
+
+        // Nothing seen yet: no hover, resolving changes nothing.
+        assert_eq!(hover.hovered(), None);
+        assert!(!hover.resolve(&hits));
+
+        assert!(hover.handle(&moved(1, 0)));
+        assert!(hover.resolve(&hits), "entering a region is a change");
+        assert!(hover.is(&"left"));
+
+        // Moving within the same region is not a style change.
+        assert!(hover.handle(&moved(2, 0)));
+        assert!(!hover.resolve(&hits));
+
+        // Crossing into the neighbor is.
+        hover.handle(&moved(5, 0));
+        assert!(hover.resolve(&hits));
+        assert!(hover.is(&"right"));
+        assert!(!hover.is(&"left"));
+
+        // Off every region: hover ends.
+        hover.handle(&moved(20, 5));
+        assert!(hover.resolve(&hits));
+        assert_eq!(hover.hovered(), None);
+    }
+
+    #[test]
+    fn hover_position_updates_from_any_event_kind() {
+        let mut hover: HoverTracker<u8> = HoverTracker::new();
+        assert!(hover.handle(&down(3, 1)), "a press carries the pointer too");
+        assert_eq!(hover.position(), Some((3, 1)));
+        assert!(!hover.handle(&up(3, 1)), "same cell: nothing moved");
+        assert!(hover.handle(&drag(4, 1)));
+        assert_eq!(hover.position(), Some((4, 1)));
+    }
+
+    #[test]
+    fn hover_follows_regions_that_move_under_a_still_pointer() {
+        let mut hover: HoverTracker<&str> = HoverTracker::new();
+        hover.handle(&moved(2, 2));
+        let mut hits: HitMap<&str> = HitMap::new();
+        hits.push(Rect::new(0, 0, 8, 8), "panel");
+        assert!(hover.resolve(&hits));
+        // Next frame the layout shifted and the panel is elsewhere.
+        hits.clear();
+        hits.push(Rect::new(10, 10, 4, 4), "panel");
+        assert!(hover.resolve(&hits), "region left the pointer");
+        assert_eq!(hover.hovered(), None);
+    }
+
+    #[test]
+    fn hover_clear_forgets_pointer_and_reports_the_drop() {
+        let mut hits: HitMap<u8> = HitMap::new();
+        hits.push(Rect::new(0, 0, 4, 1), 7);
+        let mut hover: HoverTracker<u8> = HoverTracker::new();
+        hover.handle(&moved(1, 0));
+        hover.resolve(&hits);
+        assert!(hover.clear(), "an active hover was dropped");
+        assert_eq!(hover.position(), None);
+        assert!(!hover.clear(), "already cleared");
     }
 
     #[test]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,14 +26,16 @@
 //! boxed view, [`ScopedElement`] may borrow data anywhere in a base subtree,
 //! and [`ScopedScene`] composes such a tree with owned overlays for one paint.
 
-pub use crate::anim::{Easing, Repeat, Timeline};
+pub use crate::anim::{Easing, Repeat, Timeline, Transition};
 pub use crate::components::*;
 pub use crate::focus::FocusRegistry;
 pub use crate::highlight::{CodeHighlighter, Highlighter, PlainHighlighter};
 pub use crate::interop::RatatuiView;
 pub use crate::keymap::{Binding, Chord, Dispatch, Hint, KeySequence, Keymap, Layer};
 pub use crate::live::{Live, LiveView, RedrawHandle};
-pub use crate::style::{BorderStyle, CodeTheme, Role, StyleBundle, StyleResolver, StyleRole};
+pub use crate::style::{
+    BorderStyle, CodeTheme, Gradient, Role, StyleBundle, StyleResolver, StyleRole, lerp_color,
+};
 pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // The `view!` macro plus the module it is named for; the macro expands to
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.

--- a/src/style.rs
+++ b/src/style.rs
@@ -7,6 +7,7 @@
 //! own palette without touching component code.
 
 use ratatui_core::style::{Color, Modifier, Style};
+use ratatui_core::text::{Line, Span};
 
 use crate::geometry::Padding;
 
@@ -677,6 +678,158 @@ impl Default for StyleSheet {
     }
 }
 
+/// Blend `from` toward `to` by `t` in `0.0..=1.0` (clamped), channel-wise.
+///
+/// Only two [`Color::Rgb`] endpoints carry values tuika can do arithmetic on;
+/// an indexed or named endpoint has no known RGB without the terminal's
+/// palette, so any other pairing snaps to the nearer endpoint at `t = 0.5`.
+/// Pairs naturally with a phase from
+/// [`anim::Transition`](crate::anim::Transition) to animate a style between
+/// two states (hover, focus, selection).
+pub fn lerp_color(from: Color, to: Color, t: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    match (from, to) {
+        (Color::Rgb(r0, g0, b0), Color::Rgb(r1, g1, b1)) => {
+            let mix = |a: u8, b: u8| (a as f32 + (b as f32 - a as f32) * t).round() as u8;
+            Color::Rgb(mix(r0, r1), mix(g0, g1), mix(b0, b1))
+        }
+        _ => {
+            if t < 0.5 {
+                from
+            } else {
+                to
+            }
+        }
+    }
+}
+
+/// A multi-stop color ramp sampled at `0.0..=1.0`, for gradient text and fills.
+///
+/// Stops are positions along the ramp; sampling between two stops blends them
+/// with [`lerp_color`], so the same RGB-only arithmetic rule applies —
+/// non-RGB stops produce hard steps rather than blends. Sampling outside the
+/// outermost stops clamps to them.
+///
+/// [`line`](Self::line) is the headline use: paint a string's foreground
+/// across the ramp, one blended color per display column, ready for
+/// [`Text`](crate::components::Text).
+///
+/// ```
+/// use tuika::style::Gradient;
+/// use tuika::ui::Color;
+///
+/// let g = Gradient::new(Color::Rgb(255, 0, 255), Color::Rgb(0, 255, 255));
+/// assert_eq!(g.sample(0.5), Color::Rgb(128, 128, 255));
+/// let banner = g.line("Heeyoo!"); // magenta → cyan across seven columns
+/// # let _ = banner;
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gradient {
+    /// `(position, color)` stops, sorted ascending by position in `0.0..=1.0`.
+    stops: Vec<(f32, Color)>,
+}
+
+impl Gradient {
+    /// A two-stop ramp from `from` (at `0.0`) to `to` (at `1.0`).
+    pub fn new(from: Color, to: Color) -> Self {
+        Self {
+            stops: vec![(0.0, from), (1.0, to)],
+        }
+    }
+
+    /// A ramp through `colors` at evenly spaced positions. One color is a
+    /// constant ramp; empty samples to [`Color::Reset`].
+    pub fn across(colors: impl IntoIterator<Item = Color>) -> Self {
+        let colors: Vec<Color> = colors.into_iter().collect();
+        let last = colors.len().saturating_sub(1).max(1) as f32;
+        Self {
+            stops: colors
+                .into_iter()
+                .enumerate()
+                .map(|(i, c)| (i as f32 / last, c))
+                .collect(),
+        }
+    }
+
+    /// A ramp with explicit `(position, color)` stops. Positions are clamped
+    /// to `0.0..=1.0` and sorted (stably, so equal positions keep their order
+    /// and make a hard step).
+    pub fn with_stops(stops: impl IntoIterator<Item = (f32, Color)>) -> Self {
+        let mut stops: Vec<(f32, Color)> = stops
+            .into_iter()
+            .map(|(p, c)| (p.clamp(0.0, 1.0), c))
+            .collect();
+        stops.sort_by(|a, b| a.0.total_cmp(&b.0));
+        Self { stops }
+    }
+
+    /// The blended color at `t` in `0.0..=1.0` (clamped to the outermost stops).
+    pub fn sample(&self, t: f32) -> Color {
+        let (first, rest) = match self.stops.as_slice() {
+            [] => return Color::Reset,
+            [(_, only)] => return *only,
+            [first, rest @ ..] => (first, rest),
+        };
+        let t = t.clamp(0.0, 1.0);
+        if t <= first.0 {
+            return first.1;
+        }
+        let mut lo = *first;
+        for &(p, c) in rest {
+            // Strict, so a sample exactly on a shared position takes the later
+            // stop — the hard-step side a stepped ramp intends to show there.
+            if t < p {
+                // `lo.0 <= t < p`, so the span is strictly positive.
+                return lerp_color(lo.1, c, (t - lo.0) / (p - lo.0));
+            }
+            lo = (p, c);
+        }
+        lo.1
+    }
+
+    /// `text` as a [`Line`] with its foreground swept across the ramp.
+    ///
+    /// Each grapheme is colored by sampling at the midpoint of the display
+    /// columns it occupies, so wide glyphs get one coherent color and the ramp
+    /// tracks *cells*, not bytes or chars. Adjacent graphemes that resolve to
+    /// the same color share a span.
+    pub fn line(&self, text: &str) -> Line<'static> {
+        use unicode_segmentation::UnicodeSegmentation;
+
+        let total = crate::width::str_cols(text);
+        if total == 0 {
+            return Line::raw(text.to_owned());
+        }
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        let mut run = String::new();
+        let mut run_color = Color::Reset;
+        let mut col = 0u16;
+        for grapheme in text.graphemes(true) {
+            let cols = crate::width::grapheme_cols(grapheme);
+            let mid = (col as f32 + cols as f32 / 2.0) / total as f32;
+            let color = self.sample(mid);
+            // A zero-width cluster stays with the run it modifies.
+            if cols > 0 && color != run_color && !run.is_empty() {
+                spans.push(Span::styled(
+                    std::mem::take(&mut run),
+                    Style::default().fg(run_color),
+                ));
+            }
+            if run.is_empty() {
+                run_color = color;
+            }
+            run.push_str(grapheme);
+            // Saturating like `str_cols`, so absurd input degrades to the last
+            // color instead of overflowing.
+            col = col.saturating_add(cols);
+        }
+        if !run.is_empty() {
+            spans.push(Span::styled(run, Style::default().fg(run_color)));
+        }
+        Line::from(spans)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -782,6 +935,111 @@ mod tests {
             Some(s.key_hint_label)
         );
         assert_eq!(s.resolve_style(StyleRole::new("app.unknown")), None);
+    }
+
+    #[test]
+    fn lerp_color_blends_rgb_and_snaps_everything_else() {
+        use ratatui_core::style::Color;
+        let a = Color::Rgb(0, 0, 0);
+        let b = Color::Rgb(200, 100, 50);
+        assert_eq!(lerp_color(a, b, 0.0), a);
+        assert_eq!(lerp_color(a, b, 1.0), b);
+        assert_eq!(lerp_color(a, b, 0.5), Color::Rgb(100, 50, 25));
+        // Out-of-range t clamps.
+        assert_eq!(lerp_color(a, b, -1.0), a);
+        assert_eq!(lerp_color(a, b, 2.0), b);
+        // A named endpoint has no RGB to blend: nearest endpoint wins.
+        assert_eq!(lerp_color(Color::Red, b, 0.4), Color::Red);
+        assert_eq!(lerp_color(Color::Red, b, 0.6), b);
+    }
+
+    #[test]
+    fn gradient_samples_stops_and_clamps_the_ends() {
+        use ratatui_core::style::Color;
+        let g = Gradient::new(Color::Rgb(0, 0, 0), Color::Rgb(100, 100, 100));
+        assert_eq!(g.sample(-1.0), Color::Rgb(0, 0, 0));
+        assert_eq!(g.sample(0.5), Color::Rgb(50, 50, 50));
+        assert_eq!(g.sample(2.0), Color::Rgb(100, 100, 100));
+
+        // Three evenly spaced colors: the middle one sits at 0.5.
+        let tri = Gradient::across([
+            Color::Rgb(0, 0, 0),
+            Color::Rgb(100, 0, 0),
+            Color::Rgb(0, 0, 100),
+        ]);
+        assert_eq!(tri.sample(0.5), Color::Rgb(100, 0, 0));
+        assert_eq!(tri.sample(0.25), Color::Rgb(50, 0, 0));
+        assert_eq!(tri.sample(0.75), Color::Rgb(50, 0, 50));
+
+        // Degenerate ramps stay total.
+        assert_eq!(Gradient::across([]).sample(0.5), Color::Reset);
+        assert_eq!(
+            Gradient::across([Color::Rgb(1, 2, 3)]).sample(0.9),
+            Color::Rgb(1, 2, 3)
+        );
+
+        // Explicit stops normalize order, and equal positions make a hard step.
+        let stepped = Gradient::with_stops([
+            (1.0, Color::Rgb(9, 9, 9)),
+            (0.0, Color::Rgb(0, 0, 0)),
+            (0.5, Color::Rgb(2, 2, 2)),
+            (0.5, Color::Rgb(4, 4, 4)),
+        ]);
+        assert_eq!(stepped.sample(0.5), Color::Rgb(4, 4, 4));
+        assert_eq!(stepped.sample(0.499), Color::Rgb(2, 2, 2));
+    }
+
+    #[test]
+    fn gradient_line_sweeps_columns_and_merges_equal_runs() {
+        use ratatui_core::style::Color;
+        let g = Gradient::new(Color::Rgb(0, 0, 0), Color::Rgb(240, 0, 0));
+        let line = g.line("abcd");
+        // Four columns sampled at their midpoints: 30, 90, 150, 210 red.
+        let spans: Vec<_> = line
+            .spans
+            .iter()
+            .map(|s| (s.content.to_string(), s.style.fg))
+            .collect();
+        assert_eq!(
+            spans,
+            vec![
+                ("a".into(), Some(Color::Rgb(30, 0, 0))),
+                ("b".into(), Some(Color::Rgb(90, 0, 0))),
+                ("c".into(), Some(Color::Rgb(150, 0, 0))),
+                ("d".into(), Some(Color::Rgb(210, 0, 0))),
+            ]
+        );
+        // A constant ramp collapses to a single span.
+        let flat = Gradient::across([Color::Rgb(7, 7, 7)]).line("abcd");
+        assert_eq!(flat.spans.len(), 1);
+        assert_eq!(flat.spans[0].content, "abcd");
+
+        // A wide glyph is one span colored once, by its two-column midpoint.
+        let wide = g.line("你a");
+        assert_eq!(wide.spans.len(), 2);
+        assert_eq!(wide.spans[0].content, "你");
+        // 你 spans columns 0..2 of 3 → midpoint 1/3; a sits at 2.5/3.
+        assert_eq!(wide.spans[0].style.fg, Some(Color::Rgb(80, 0, 0)));
+        assert_eq!(wide.spans[1].style.fg, Some(Color::Rgb(200, 0, 0)));
+
+        // Empty text renders as an empty line, not a panic.
+        assert!(g.line("").spans.is_empty());
+    }
+
+    #[test]
+    fn gradient_line_paints_cells_through_text() {
+        use crate::components::Text;
+        use ratatui_core::style::Color;
+        let g = Gradient::new(Color::Rgb(0, 0, 0), Color::Rgb(240, 0, 0));
+        let text = Text::new(vec![g.line("abcd")]);
+        let buf = crate::testing::render(&text, 4, 1, &Theme::default());
+        for (col, red) in [(0u16, 30u8), (1, 90), (2, 150), (3, 210)] {
+            assert_eq!(
+                buf[(col, 0)].fg,
+                Color::Rgb(red, 0, 0),
+                "column {col} carries its ramp color"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Three interaction/styling primitives that give hosts hover-styled, animated, gradient-painted UIs without any new model:

- **Hover styling** — `mouse::HoverTracker` pairs the pointer-motion stream with the existing `HitMap` hit-testing. `resolve()` reports exactly when the hovered *value* changes (including when regions move under a still pointer), so a host knows when a redraw is warranted; `is(&value)` answers the per-region question while styling.
- **Timed style transitions** — `anim::Transition` is a retargetable eased ramp for state-driven motion (hover on/off, focus, expansion), following the same host-owned frame-counter model as `Timeline`: no clock, deterministic sampling. Retargeting mid-flight continues from the current value instead of jumping, and re-asserting the same target every frame is a no-op. `anim::lerp` and `style::lerp_color` interpolate scalars and 24-bit colors.
- **Gradient color spans** — `style::Gradient` is a multi-stop color ramp (`new`, evenly spaced `across`, explicit `with_stops`); `Gradient::line` sweeps a string's foreground across the ramp per display column — wide glyphs get one coherent color, adjacent same-color graphemes merge into one span — ready for `Text`.

The composition story is documented on `Transition`: a `HoverTracker` change drives a `Transition` 0→1 phase, and `lerp_color`/`Gradient` map that phase onto colors.

Also refreshes `benches/iai-baseline.json`. The committed baseline was already ~1.3% stale relative to `main` (verified by benching the merge base `7526882` locally: render.large 861,335 vs the committed 849,948), and this branch's additive code shifts codegen layout by a further ~0.9%, tipping four benches past the ±2% gate. None of the new code executes in any benchmarked path — the render-bench delta is identical for `render.small` and `render.large` (a per-frame constant, not per-cell work). Counts were regenerated with `check_iai.py --update` from a local run whose numbers reproduce CI's exactly on the scroll benches and within 0.4% on the markdown benches.

## Why

Feature-gap adoption from current TUI frameworks: hover-reactive cards with animated color transitions and gradient text are what make modern terminal UIs read as polished, and tuika had the hit-testing, easing, and theming seams but not these three primitives on top of them.

## Before / After

Before: no hover concept anywhere in the crate, no way to ease a style between two states, no gradients.

After — headless render driving all three at once (hover resolves onto the right card, the transition eases the border color over 12 frames, the banner and card labels are gradient `Line`s):

```
hover: changed=true hovered=Some("right") (redraw warranted)
frame 100: phase=0.00 border=Rgb(60, 60, 60) settled=false
frame 106: phase=0.50 border=Rgb(58, 125, 154) settled=false
frame 112: phase=1.00 border=Rgb(56, 189, 248) settled=true
Heeyoo! tuika
╭left──────╮╭right─────╮
│ left     ││ right    │
╰──────────╯╰──────────╯
```

## Risk

- Low
- Purely additive API: no existing signature, behavior, or rendering path changed. The only touched shared file surfaces are new items in `mouse`, `anim`, `style`, and two prelude re-export lines. A glob-importing host could newly collide on `Transition`, `Gradient`, `lerp_color`, or `lerp` — the prelude documents collision handling (import by path).
- The iai baseline refresh resets the drift budget; the next real hot-path regression is measured from these counts.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — additive utilities inside existing seams (mouse affordances over `HitMap`, host-owned-frame animation beside `Timeline`, color utilities in `style`); no change to architecture, policy, the two-layer styling model, or maintainer process. The changelog Unreleased section carries the API additions.

**API change (for the changelog):** adds `pub` items `mouse::HoverTracker`, `anim::{Transition, lerp}`, `style::{Gradient, lerp_color}`; prelude gains `Transition`, `Gradient`, `lerp_color`. No removals or signature changes; not breaking.

## Security

Reviewed against the threat-model categories:

- **TM-ESC** — no new code emits escapes or reaches the terminal; everything renders into the cell buffer or returns plain values.
- **TM-STATE** — no terminal state touched.
- **TM-PARSE** — `Gradient::line` takes untrusted text: it iterates graphemes with the crate's own width measurement, allocates linearly in input length (same as `Text` itself), and has no recursion or indexing. Found and fixed one issue during review: the column accumulator now saturates like `str_cols`, so input wider than `u16::MAX` columns degrades to the last ramp color instead of overflowing (panic in debug builds). NaN/degenerate gradient stops and NaN transition targets propagate as values but cannot panic (`total_cmp`, clamped comparisons).
- **TM-CLIP** — no buffer writes outside existing components; `HoverTracker` only reads the map.
- **TM-DEP** — no new dependencies.

## Follow-ups

- A gallery scene (and `docs/components/` entry) showing a hover-animated card row would make these visible in the component gallery; it needs a VHS recording pass, so it's deferred to the next demo-regeneration batch rather than blocking this change.
- The iai baseline had drifted ~1.3% on `main` without a re-bless; if additive-code codegen drift keeps eating the ±2% tolerance, consider re-blessing the baseline as part of landing any change that shifts counts >0.5%, so the budget measures real hot-path work.