### PR TITLE
feat(text): link URLs in paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@ described in the release process begins with the entry below.
 
 ### Changed
 
+- `Paragraph` now treats its input as human-facing prose: bare `http(s)` URLs
+  use the stylesheet's link role and carry OSC 8 targets through wrapping by
+  default. `Paragraph::link_policy(LinkPolicy::NONE)` restores literal,
+  single-style rendering; `Text`, `Wrap`, `CodeBlock`, and `Console` remain
+  inert.
 - **Breaking**: `UpdateResult::Clean` now means an input was unhandled and may
   receive runner default behavior; return the new `UpdateResult::Consumed` for
   a handled input that does not need a repaint. Exhaustive matches over

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ component. Linked names below jump straight to their demo.
 
 | Component | Purpose |
 | --- | --- |
-| [`Text`](docs/components/text.md#text) / `Paragraph` | Styled lines / word-wrapped plain text |
+| [`Text`](docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
 | `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
 | [`Markdown`](docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](docs/markdown.md) |
 | [`CodeBlock`](docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -13,9 +13,14 @@ sidebar:
 ### `Text`
 
 A block of pre-styled [`Line`](https://docs.rs/ratatui)s drawn top-down and
-clipped. `Paragraph` word-wraps plain text in one style; `Wrap` word-wraps
-pre-styled lines while preserving per-span styles.
-[API](https://docs.rs/tuika/latest/tuika/components/text/struct.Text.html)
+clipped. `Paragraph` word-wraps plain prose from a base style and turns bare
+`http(s)` URLs into styled OSC 8 hyperlinks by default; `Wrap` word-wraps
+pre-styled lines while preserving per-span styles. Use
+`Paragraph::link_policy(LinkPolicy::NONE)` when URLs must remain literal, or
+`LinkPolicy::WEB.with_mailto()` to also link `mailto:` targets. `Text` and
+`Wrap` never infer links from their content.
+[Text API](https://docs.rs/tuika/latest/tuika/components/text/struct.Text.html) ·
+[Paragraph API](https://docs.rs/tuika/latest/tuika/components/text/struct.Paragraph.html)
 
 Horizontal alignment is honored. `Text` and `Wrap` read each `Line`'s
 `alignment` (unset = flush-left), so centered titles, right-aligned totals, and
@@ -28,6 +33,7 @@ intended; `Wrap` carries a line's alignment onto every reflowed row.
 ```rust
 use ratatui::layout::Alignment;
 use ratatui::text::Line;
+use tuika::term::hyperlink::LinkPolicy;
 use tuika::prelude::*;
 view! {
     col(gap = 1) {
@@ -37,8 +43,11 @@ view! {
             Line::from("centered").centered(),
             Line::from("flush right").right_aligned(),
         ]))
-        // One alignment for a wrapped plain-text block.
-        node(Paragraph::new("word-wrapped prose", style).alignment(Alignment::Center))
+        // Wrapped prose links bare web URLs without a special backend.
+        node(Paragraph::new("Read https://docs.rs/tuika", style)
+            .alignment(Alignment::Center))
+        node(Paragraph::new("literal https://tuika.dev", style)
+            .link_policy(LinkPolicy::NONE))
     }
 }
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -176,13 +176,18 @@ Turn a bare `http(s)` URL — or a markdown `[label](url)` whose visible text is
 not the URL — into a real clickable link, without changing the visible text. A
 cell buffer can't carry a link target — a `ratatui::Cell` is one grapheme plus a
 style — so tuika emits the link by writing the OSC 8 sequence around the run
-(either via [`HyperlinkBackend`] scanning bare URLs, or via
-[`apply_buffer_links`] for explicit destinations from the markdown renderer).
+(via [`HyperlinkBackend`] scanning arbitrary rendered output, or
+[`apply_buffer_links`] for destinations retained by `Paragraph` and the
+markdown renderer).
 [API](https://docs.rs/tuika/latest/tuika/term/hyperlink/index.html)
 
 <img src="demos/hyperlink.png" width="880" alt="Hyperlink demo: a transcript line with 'https://docs.rs/tuika' and a markdown link label both shown in an underlined link color; unsupported terminals would render the same text without the link.">
 
-There are two entry points:
+The entry points cover both components and lower-level output:
+
+- `Paragraph` — wrapped plain prose links bare web URLs by default, including
+  URLs split across rows. Configure it with `Paragraph::link_policy`; `Text`,
+  `Wrap`, `CodeBlock`, and `Console` stay literal.
 
 - `hyperlink::encode(url, text)` — the pure encoder. Returns `text` wrapped in the OSC 8
   sequence, or `text` unchanged when `url` isn't a safe web URL. No I/O.
@@ -196,12 +201,13 @@ There are two entry points:
   preserves `[label](url)` destinations as [`BufferLink`]s through wrapping;
   after painting the lines, `apply_buffer_links` embeds OSC 8 into the boundary
   cells (ForcedWidth) so a label that is not itself a URL stays clickable with
-  the terminal's native modifier. Configure schemes with `LinkPolicy` (and
-  `Markdown::link_policy`).
+  the terminal's native modifier. `Paragraph` uses the same buffer-link path
+  for bare URLs. Configure schemes with `LinkPolicy`, `Markdown::link_policy`,
+  or `Paragraph::link_policy`.
 
-Each of the first three has a policy-aware sibling — `encode_with`, `write_line_with`, and
-`HyperlinkBackend::with_policy` — taking a `LinkPolicy` so the host chooses which
-schemes are linked. The default (`LinkPolicy::WEB`) is `http(s)`-only;
+The three lower-level emitters have policy-aware forms — `encode_with`,
+`write_line_with`, and `HyperlinkBackend::with_policy` — taking a `LinkPolicy`
+so the host chooses which schemes are linked. The default (`LinkPolicy::WEB`) is `http(s)`-only;
 `LinkPolicy::WEB.with_mailto()` also links `mailto:` addresses.
 `LinkPolicy::NONE` skips emission entirely.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -11,6 +11,14 @@
   - Async hosts can deliver typed producer messages through the runner's event
     wait, so data arrival itself wakes the UI without shared mutation or polling.
 
+- **Prose owns hyperlinks; literal text does not**
+  - `Paragraph`, like `Markdown`, retains complete bare-URL targets before
+    wrapping and emits them through the buffer-link path under a web-only
+    default policy.
+  - `Text`, `Wrap`, `CodeBlock`, and `Console` remain literal. Backend-wide URL
+    inference remains an explicit host choice because it cannot distinguish
+    prose from logs, source code, or diagnostics.
+
 ## 2026-08-10
 
 - **Mouse capture does not remove basic text selection from runner apps**

--- a/knowledge/specs/out-of-band.md
+++ b/knowledge/specs/out-of-band.md
@@ -24,7 +24,7 @@ Six out-of-band capabilities, in three families:
 
 | Capability | Sequence | Module | Emission point |
 | --- | --- | --- | --- |
-| Hyperlinks | OSC 8 | `term::hyperlink` | spliced into the drawn cell run by `HyperlinkBackend` |
+| Hyperlinks | OSC 8 | `term::hyperlink` | embedded by semantic prose components or spliced into arbitrary drawn runs by `HyperlinkBackend` |
 | Clipboard | OSC 52 | `term::clipboard` | host- or runner-initiated, any time |
 | Native progress | OSC 9;4 | `term::progress` | host-initiated, any time |
 | Pointer shape | OSC 22 | `term::pointer` | host-initiated, any time |
@@ -105,6 +105,14 @@ wrapping. Hosts are expected to keep it behind a switch until they have walked
 the terminal matrix for their own UI, and the repository's own PTY smoke asserts
 both that the escape is emitted and that the footer text around it survives
 intact.
+
+That opt-in applies to backend-wide inference. Components that own prose can
+retain link destinations before painting and emit them without reconstructing
+meaning from ratatui's incremental draw runs. `Markdown` does this for explicit
+and bare links; `Paragraph` does it for bare URLs, under `LinkPolicy::WEB` by
+default. Literal components (`Text`, `Wrap`, `CodeBlock`, `Console`) do not infer
+links. `HyperlinkBackend` remains the host-controlled escape hatch for arbitrary
+rendered content.
 
 ### Encoders live in tuika, payloads come from the host
 

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -1,10 +1,11 @@
 //! Text and paragraph components.
 //!
 //! [`Text`] draws pre-styled ratatui [`Line`]s faithfully (`Line::style` under
-//! each `Span::style`), clipping to its area. [`Paragraph`] takes a plain string
-//! plus one style and word-wraps it to the available width. [`Wrap`] is the
-//! styled counterpart to `Paragraph`: it word-wraps pre-styled `Line`s while
-//! preserving each span's style across the reflow (see [`wrap_lines`]).
+//! each `Span::style`), clipping to its area. [`Paragraph`] takes plain prose
+//! plus a base style, word-wraps it to the available width, and links bare web
+//! URLs. [`Wrap`] is the styled counterpart to `Paragraph`: it word-wraps
+//! pre-styled `Line`s while preserving each span's style across the reflow (see
+//! [`wrap_lines`]).
 //!
 //! Horizontal alignment is honored throughout. [`Text`] and [`Wrap`] read each
 //! [`Line::alignment`] (unset = flush-left), so centered titles, right-aligned
@@ -19,7 +20,9 @@ use ratatui_core::text::{Line, Span};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::geometry::Size;
+use crate::style::Role;
 use crate::surface::Surface;
+use crate::term::hyperlink::{BufferLink, LinkPolicy, apply_buffer_links, find_links};
 use crate::view::{RenderCtx, View};
 use crate::width::{grapheme_cols, str_cols};
 
@@ -117,20 +120,40 @@ impl View for Text {
     }
 }
 
-/// Plain text word-wrapped to the render width in one style.
+/// Plain prose word-wrapped to the render width from one base style.
+///
+/// Bare `http(s)` URLs are styled with the active [`Role::Link`] and emitted as
+/// OSC 8 hyperlinks by default. Because this component owns the complete source
+/// text, links remain intact across wrapping without requiring a
+/// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend). Use
+/// [`link_policy`](Self::link_policy) to opt out or enable another supported
+/// scheme.
 pub struct Paragraph {
     text: String,
     style: Style,
     align: Alignment,
+    link_policy: LinkPolicy,
+}
+
+struct ParagraphLine {
+    text: String,
+    links: Vec<ParagraphLink>,
+}
+
+struct ParagraphLink {
+    start: usize,
+    end: usize,
+    url: String,
 }
 
 impl Paragraph {
-    /// A paragraph that wraps `text` in a single `style`, flush-left.
+    /// A paragraph that wraps `text` from one base `style`, flush-left.
     pub fn new(text: impl Into<String>, style: Style) -> Self {
         Self {
             text: text.into(),
             style,
             align: Alignment::Left,
+            link_policy: LinkPolicy::default(),
         }
     }
 
@@ -142,19 +165,62 @@ impl Paragraph {
         self
     }
 
-    fn wrap(&self, width: u16) -> Vec<String> {
+    /// Configure which bare-URL schemes become styled OSC 8 hyperlinks.
+    ///
+    /// The default ([`LinkPolicy::WEB`]) links `http(s)` only. Pass
+    /// [`LinkPolicy::NONE`] to keep URLs literal and in the paragraph's base
+    /// style.
+    pub fn link_policy(mut self, policy: LinkPolicy) -> Self {
+        self.link_policy = policy;
+        self
+    }
+
+    fn wrap(&self, width: u16, link_policy: LinkPolicy) -> Vec<ParagraphLine> {
         if width == 0 {
             return Vec::new();
         }
         self.text
             .split('\n')
             .flat_map(|para| {
+                let links = find_links(para, link_policy);
                 let wrapped = textwrap::wrap(para, width as usize);
-                if wrapped.is_empty() {
-                    vec![String::new()]
-                } else {
-                    wrapped.into_iter().map(|c| c.into_owned()).collect()
-                }
+                let mut cursor = 0usize;
+                wrapped.into_iter().map(move |line| {
+                    let text = line.into_owned();
+                    if links.is_empty() {
+                        return ParagraphLine {
+                            text,
+                            links: Vec::new(),
+                        };
+                    }
+                    // textwrap removes boundary whitespace. Searching forward
+                    // maps even repeated words to their source occurrence.
+                    let Some(relative) = para[cursor..].find(text.as_str()) else {
+                        // If the wrapping implementation ever synthesizes text,
+                        // keep rendering but stop inferring source metadata.
+                        cursor = para.len();
+                        return ParagraphLine {
+                            text,
+                            links: Vec::new(),
+                        };
+                    };
+                    let start = cursor + relative;
+                    let end = start.saturating_add(text.len()).min(para.len());
+                    cursor = end;
+                    let links = links
+                        .iter()
+                        .filter_map(|&(link_start, link_end)| {
+                            let visible_start = link_start.max(start);
+                            let visible_end = link_end.min(end);
+                            (visible_start < visible_end).then(|| ParagraphLink {
+                                start: visible_start - start,
+                                end: visible_end - start,
+                                url: para[link_start..link_end].to_string(),
+                            })
+                        })
+                        .collect();
+                    ParagraphLine { text, links }
+                })
             })
             .collect()
     }
@@ -162,24 +228,57 @@ impl Paragraph {
 
 impl View for Paragraph {
     fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
-        let lines = self.wrap(available.width);
+        // Hyperlink metadata and styling never affect paragraph geometry.
+        let lines = self.wrap(available.width, LinkPolicy::NONE);
         let width = lines
             .iter()
-            .map(|l| str_cols(l.as_str()))
+            .map(|line| str_cols(line.text.as_str()))
             .max()
             .unwrap_or(0);
         Size::new(width, lines.len() as u16)
     }
 
-    fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
-        for (row, line) in self.wrap(area.width).into_iter().enumerate() {
+    fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        let mut buffer_links = Vec::new();
+        let link_style = ctx.sheet.resolve(Role::Link).apply(self.style);
+        for (row, line) in self
+            .wrap(area.width, self.link_policy)
+            .into_iter()
+            .enumerate()
+        {
             let y = area.y.saturating_add(row as u16);
             if y >= area.bottom() {
                 break;
             }
-            let x = aligned_x(self.align, str_cols(line.as_str()), area);
-            surface.set_string(x, y, &line, self.style);
+            let x = aligned_x(self.align, str_cols(line.text.as_str()), area);
+            let mut byte = 0usize;
+            let mut col = x;
+            for link in line.links {
+                col = surface.set_string(col, y, &line.text[byte..link.start], self.style);
+                let start_col = col.saturating_sub(area.x);
+                col = surface.set_string(col, y, &line.text[link.start..link.end], link_style);
+                let end_col = col.saturating_sub(area.x);
+                if end_col > start_col {
+                    buffer_links.push(BufferLink {
+                        line: row.min(u16::MAX as usize) as u16,
+                        start_col,
+                        end_col,
+                        url: link.url,
+                    });
+                }
+                byte = link.end;
+            }
+            surface.set_string(col, y, &line.text[byte..], self.style);
         }
+        apply_buffer_links(
+            surface.buffer_mut(),
+            ratatui_core::layout::Position {
+                x: area.x,
+                y: area.y,
+            },
+            &buffer_links,
+            self.link_policy,
+        );
     }
 }
 
@@ -355,15 +454,28 @@ impl View for Wrap {
 mod tests {
     use super::*;
     use crate::style::Theme;
+    use crate::term::hyperlink::ctrl_click_url;
     use crate::tests::support::{buffer, row};
     use crate::view::{RenderCtx, View};
-    use crate::{Size, Surface};
+    use crate::{Mouse, MouseButton, MouseKind, Size, Surface};
+    use ratatui_core::layout::Rect;
     use ratatui_core::style::{Color, Modifier, Style};
     use ratatui_core::text::{Line, Span};
 
     /// Concatenated text of a line's spans.
     fn line_text(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn link_at(
+        buffer: &ratatui_core::buffer::Buffer,
+        area: Rect,
+        col: u16,
+        row: u16,
+    ) -> Option<String> {
+        let mut event = Mouse::at(MouseKind::Up(MouseButton::Left), col, row);
+        event.ctrl = true;
+        ctrl_click_url(&event, buffer, area)
     }
 
     #[test]
@@ -401,6 +513,88 @@ mod tests {
         let size = p.measure(Size::new(10, 10), &RenderCtx::new(&theme));
         assert!(size.height >= 2, "expected wrap, got {size:?}");
         assert!(size.width <= 10);
+    }
+
+    #[test]
+    fn paragraph_links_web_urls_by_default() {
+        let theme = Theme::default();
+        let buf = crate::testing::render(
+            &Paragraph::new("see https://a.dev now", Style::default()),
+            24,
+            1,
+            &theme,
+        );
+        assert_eq!(
+            link_at(&buf, Rect::new(0, 0, 24, 1), 6, 0).as_deref(),
+            Some("https://a.dev")
+        );
+        let linked_cell = &buf[(4, 0)];
+        assert_eq!(linked_cell.fg, theme.code.link);
+        assert!(linked_cell.modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn paragraph_link_policy_none_keeps_urls_literal() {
+        let buf = crate::testing::render(
+            &Paragraph::new("https://a.dev", Style::default())
+                .link_policy(crate::term::hyperlink::LinkPolicy::NONE),
+            20,
+            1,
+            &Theme::default(),
+        );
+        assert!(
+            buf.content
+                .iter()
+                .all(|cell| !cell.symbol().contains("\x1b]8;;"))
+        );
+        assert!(!buf[(0, 0)].modifier.contains(Modifier::UNDERLINED));
+    }
+
+    #[test]
+    fn paragraph_keeps_full_link_target_across_hard_wraps() {
+        let url = "https://example.com/very-long-path";
+        let buf = crate::testing::render(
+            &Paragraph::new(url, Style::default()),
+            10,
+            4,
+            &Theme::default(),
+        );
+        for row in 0..4 {
+            assert_eq!(
+                link_at(&buf, Rect::new(0, 0, 10, 4), 1, row).as_deref(),
+                Some(url),
+                "wrapped row {row} should resolve the complete URL"
+            );
+        }
+    }
+
+    #[test]
+    fn paragraph_aligns_link_metadata_with_visible_text() {
+        let url = "https://a.dev";
+        let buf = crate::testing::render(
+            &Paragraph::new(url, Style::default()).alignment(Alignment::Center),
+            20,
+            1,
+            &Theme::default(),
+        );
+        assert_eq!(
+            link_at(&buf, Rect::new(0, 0, 20, 1), 3, 0).as_deref(),
+            Some(url)
+        );
+        assert_eq!(link_at(&buf, Rect::new(0, 0, 20, 1), 0, 0), None);
+    }
+
+    #[test]
+    fn paragraph_links_survive_degenerate_sizes() {
+        let paragraph = Paragraph::new(
+            "read https://example.com/a-very-long-path",
+            Style::default(),
+        );
+        let sizes = (0..=20).flat_map(|width| (0..=4).map(move |height| (width, height)));
+        assert_eq!(
+            crate::testing::render_sizes(&paragraph, sizes, &Theme::default()).len(),
+            105
+        );
     }
 
     #[test]

--- a/src/term/hyperlink.rs
+++ b/src/term/hyperlink.rs
@@ -374,7 +374,7 @@ fn osc8_url_at(buffer: &Buffer, area: Rect, col: u16, row: u16) -> Option<String
 /// sentence punctuation trimmed, matching how the host styles links; a
 /// `mailto:` match also stops at its query `?` so the pre-fill params are
 /// neither shown nor linked.
-fn find_links(s: &str, policy: LinkPolicy) -> Vec<(usize, usize)> {
+pub(crate) fn find_links(s: &str, policy: LinkPolicy) -> Vec<(usize, usize)> {
     const TRAILING: &[char] = &['.', ',', ';', ':', '!', '?', ')', ']', '}', '\'', '"'];
     let mut ranges = Vec::new();
     if !policy.links_any() {


### PR DESCRIPTION
## What changed

`Paragraph` now treats bare web URLs as semantic links by default: it applies the active link role and retains complete OSC 8 targets across wrapping and alignment. `Paragraph::link_policy` lets callers disable links or opt into the supported `mailto:` policy. Literal components (`Text`, `Wrap`, `CodeBlock`, and `Console`) remain inert.

## Why

Human-facing plain prose should provide the same safe link behavior as `Markdown` without requiring backend-wide URL inference, which cannot distinguish prose from logs, code, or diagnostics.

## Before / After

- Before: a URL rendered by `Paragraph` kept the paragraph's base style and had no OSC 8 target unless the host wrapped all rendering in `HyperlinkBackend`.
- After: `Paragraph` links `http(s)` by default through the existing buffer-link encoder; `LinkPolicy::NONE` restores literal rendering. A real-terminal smoke rendered a long URL through the ordinary `Runner`, emitted one underlined OSC 8 target, and restored terminal state cleanly on exit.

## API

Non-breaking public API addition: `Paragraph::link_policy(LinkPolicy)`.

## Risk

- Medium: existing paragraphs containing web URLs become styled and clickable by default.
- Wrapping geometry is unchanged; tests cover opt-out, alignment, hard-wrapped targets, theme cells, click resolution, and 105 degenerate geometries.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo +1.88 check -p tuika --all-targets`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `cargo run --example demo -- check`
- `python3 scripts/validate_okf.py knowledge --strict --check-links`
- Real-terminal `Paragraph` smoke through the ordinary runner

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated `knowledge/specs/out-of-band.md` and `knowledge/log.md` to record the semantic-prose versus literal-text boundary.

## Security

- **TM-ESC:** targets still pass through tuika's existing web-only policy and control-byte sanitizer; no caller text is interpolated as an escape sequence.
- **TM-STATE:** no lifecycle code changed; the real-terminal smoke confirmed cursor, mouse, keyboard, and alternate-screen restoration.
- **TM-PARSE:** source-to-wrap mapping degrades to inert text instead of panicking if wrapping ever synthesizes content.
- **TM-CLIP:** link metadata is applied through the clipped `Surface`; hard wraps, alignment, and degenerate dimensions are directly tested.
- **TM-DEP:** no dependency changes.

## Follow-ups

No follow-ups.
