### PR TITLE
feat(runner)!: one frame source, one signal, four run methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ described in the release process begins with the entry below.
 - `AsyncRunner::{run_with_messages, run_with_events_and_messages}` delivers a
   typed application stream through `AsyncSignal<M>`, including deterministic
   completion/error/redraw/exit behavior without shared mutable state or polling.
+- `AsyncApplication` is the borrowed-view application seam for the async runner,
+  the counterpart to `Application`. It is generic over its signal type, so an
+  application that also consumes a message stream implements
+  `AsyncApplication<AsyncSignal<M>>` rather than a second trait. Driven by
+  `AsyncRunner::{run_app, run_app_with_messages, run_app_with_backend,
+  run_app_with_events, run_app_with_events_and_messages}`, which complete the
+  application row of the runner's `run*` axes — previously a frame could borrow
+  application state only on the synchronous runner.
+- `AsyncRunner::redraw_handle` matches `Runner::redraw_handle`, so a `Live`
+  value (or any background producer) can mark the next frame stale on either
+  runner. `RedrawHandle` now registers the waiting task's waker, so the async
+  loop is woken by a request instead of only noticing one on its next tick;
+  bursts still coalesce into a single repaint.
 
 - `Runner` and `AsyncRunner` restore drag-to-select behavior by default when
   their terminal session captures the mouse. Selection is painted over the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,17 +25,17 @@ described in the release process begins with the entry below.
   scrolling, branch rendering, and a scrollbar over host-provided tree rows.
 - `FocusRegistry::focus(id)` lets a `HitMap` focus a registered pane while
   rejecting unknown ids and requests blocked by overlay input ownership.
-- `AsyncRunner::{run_with_messages, run_with_events_and_messages}` delivers a
-  typed application stream through `AsyncSignal<M>`, including deterministic
-  completion/error/redraw/exit behavior without shared mutable state or polling.
+- `AsyncRunner::run_with_messages` delivers a typed application stream beside
+  terminal events and ticks, with deterministic completion/error/redraw/exit
+  behavior and no shared mutable state or polling.
 - `AsyncApplication` is the borrowed-view application seam for the async runner,
-  the counterpart to `Application`. It is generic over its signal type, so an
-  application that also consumes a message stream implements
-  `AsyncApplication<AsyncSignal<M>>` rather than a second trait. Driven by
-  `AsyncRunner::{run_app, run_app_with_messages, run_app_with_backend,
-  run_app_with_events, run_app_with_events_and_messages}`, which complete the
-  application row of the runner's `run*` axes — previously a frame could borrow
-  application state only on the synchronous runner.
+  the counterpart to `Application`: previously a frame could borrow application
+  state only on the synchronous runner, so a Tokio host had to clone into an
+  owned tree or share through `Rc<RefCell<_>>`.
+- `FrameSource` / `AsyncFrameSource` is the single seam every run method now
+  takes, with exactly two implementors: `&mut app` for an `Application`, and
+  `from_fn(&mut state, view, update)` (`async_from_fn` for the async runner) for
+  the closure form. `no_messages()` is the empty application-message stream.
 - `AsyncRunner::redraw_handle` matches `Runner::redraw_handle`, so a `Live`
   value (or any background producer) can mark the next frame stale on either
   runner. `RedrawHandle` now registers the waiting task's waker, so the async
@@ -75,6 +75,35 @@ described in the release process begins with the entry below.
   around the layout engine stays.
 
 ### Changed
+
+**Breaking: the runner's `run*` surface is one seam plus two axes.** The methods
+were a cross product of frame source, runtime, terminal ownership, and extra
+input, encoded as names — ten of them on `AsyncRunner` — with arbitrary holes in
+the product. The frame source is now a `FrameSource` argument rather than a
+name, and messages ride the existing `Signal`, which leaves only *where the
+terminal and the input come from* in the names.
+
+`Signal` gained a message type parameter, `Signal<M = Infallible>`. Because the
+default is uninhabited, an existing `match signal { Signal::Tick => …,
+Signal::Event(e) => … }` **still compiles and stays exhaustive**. A `match` on a
+*reference* (`match &signal`) does need a `_` arm added. `AsyncSignal<M>` is now
+a deprecated alias for `Signal<M>`.
+
+| Before | After |
+| --- | --- |
+| `Runner::run(theme, state, view, update)` | `Runner::run(theme, from_fn(state, view, update))` |
+| `Runner::run_app(theme, app)` | `Runner::run(theme, app)` *(shim, deprecated)* |
+| `Runner::run_with_backend(theme, backend, state, view, update)` | `Runner::run_with_backend(theme, backend, from_fn(state, view, update))` |
+| `Runner::run_app_with_backend(theme, backend, app)` | `Runner::run_with_backend(theme, backend, app)` *(shim, deprecated)* |
+| `AsyncRunner::run(theme, state, view, update)` | `AsyncRunner::run(theme, async_from_fn(state, view, update))` |
+| `AsyncRunner::run_with_messages(theme, state, messages, view, update)` | `AsyncRunner::run_with_messages(theme, async_from_fn(state, view, update), messages)` |
+| `AsyncRunner::run_with_backend(theme, backend, state, view, update)` | `AsyncRunner::run_with_backend(theme, backend, async_from_fn(state, view, update))` |
+| `AsyncRunner::run_with_events(terminal, theme, state, events, view, update)` | `AsyncRunner::run_driven_by(terminal, theme, async_from_fn(state, view, update), events, no_messages())` *(shim, deprecated)* |
+| `AsyncRunner::run_with_events_and_messages(terminal, theme, state, events, messages, view, update)` | `AsyncRunner::run_driven_by(terminal, theme, async_from_fn(state, view, update), events, messages)` *(shim, deprecated)* |
+
+Methods marked *shim* keep working with a deprecation warning. The rest changed
+shape under the same name, so they fail to compile rather than warn — the
+migration is mechanical and the table above is exhaustive.
 
 - `Paragraph` now treats its input as human-facing prose: bare `http(s)` URLs
   use the stylesheet's link role and carry OSC 8 targets through wrapping by

--- a/README.md
+++ b/README.md
@@ -747,15 +747,16 @@ impl Application for Stats {
 }
 
 let mut app = Stats::default();
-runner.run_app(&Theme::default(), &mut app)?;
+runner.run(&Theme::default(), &mut app)?;
 ```
 
 `UpdateResult::Clean` leaves an input available to runner defaults such as text
 selection. Return `Consumed` when the application handled it without changing
 the frame, `Dirty` when handling changed the frame, or `Exit` to stop.
 
-`Runner::run` and `run_with_backend` retain the separate state/view/update
-closure API for owned `Element` trees. The
+Every run method takes a `FrameSource`, and there are exactly two: `&mut app`
+for an `Application`, as above, or `from_fn(&mut state, view, update)` for the
+closure form over an owned `Element` tree. The
 [`borrowed_app`](examples/borrowed_app.rs) example implements a custom `View`
 that directly borrows a `String` from its application.
 
@@ -779,23 +780,22 @@ single event loop. Its update closure returns the same
 `UpdateResult::{Clean, Consumed, Dirty, Exit}` as `Runner`, so awaited work only
 rebuilds and repaints when it actually changes visible state. `AsyncApplication`
 is its `Application` twin — the same borrowed-view seam, with an awaiting
-`update` — driven by `run_app`.
+`update` — and `&mut app` is a `FrameSource` for it just as it is for `Runner`.
 
 `run_with_messages` adds a typed host stream beside terminal events and ticks.
-Its update callback receives `AsyncSignal::{Event, Tick, Message}`; a background
-producer can therefore wake and update the UI immediately without
-`Arc<Mutex<_>>`, fabricated keys, or a short polling interval. The lower-level
-`run_with_events_and_messages` accepts both streams and a caller-owned backend,
-which also makes completion and error behavior deterministic under `TestBackend`.
-An application consuming that stream implements `AsyncApplication<AsyncSignal<M>>`
-and runs through `run_app_with_messages`: the message axis changes the signal
-type, not the seam.
+Messages arrive as `Signal::Message`, so a background producer can wake and
+update the UI immediately without `Arc<Mutex<_>>`, fabricated keys, or a short
+polling interval — and the frame source is the same one `run` takes, at
+`Signal<M>` instead of the default. The lower-level `run_driven_by` accepts a
+caller-owned terminal and both streams, which also makes completion and error
+behavior deterministic under `TestBackend`.
 
-Both runners' `run` methods are named for the axes they depart from —
-`run[_app][_with_backend|_with_events][_and_messages]` — where `_app` selects
-the borrowed-view seam, the middle segment moves terminal ownership to the
-caller, and the last adds the message stream. The runtime is the runner type;
-everything else is `RunnerConfig` or a builder method.
+`Signal<M>` is that one signal type: `M` defaults to the uninhabited
+`Infallible`, so a loop with no message stream has no `Message` variant to
+handle and a two-arm `match` stays exhaustive. What is left in the method names
+is only where the terminal and the input come from — `run`, `run_with_backend`,
+`run_with_messages`, `run_driven_by`. The runtime is the runner type; everything
+else is `RunnerConfig` or a builder method.
 
 Enabling `async` adds Tokio (timer + `select!`) and crossterm's `event-stream`
 feature; it stays off by default so sync-only hosts pull in no runtime. The

--- a/README.md
+++ b/README.md
@@ -639,9 +639,10 @@ let layout = activity.resolve(Rect::new(0, 0, 120, 30), DockSpec::right(90, 40))
 
 `Live<T>` is shared application data with a narrow read/update API. `LiveView`
 derives a fresh view from its current value each frame. Connect it to
-`Runner::redraw_handle()` when background producers should invalidate the
-screen. Producers retain ownership of their threads, tasks, retries, and
-lifecycle.
+`Runner::redraw_handle()` — or `AsyncRunner::redraw_handle()`, which wakes a
+parked `select!` rather than waiting for its next tick — when background
+producers should invalidate the screen. Producers retain ownership of their
+threads, tasks, retries, and lifecycle.
 
 ## Screen modes, lifecycle, and runner
 
@@ -776,7 +777,9 @@ network or disk I/O — and lets its update closure `.await`. It ties
 `EventStream` and a tick timer in one `tokio::select!`, so the host keeps a
 single event loop. Its update closure returns the same
 `UpdateResult::{Clean, Consumed, Dirty, Exit}` as `Runner`, so awaited work only
-rebuilds and repaints when it actually changes visible state.
+rebuilds and repaints when it actually changes visible state. `AsyncApplication`
+is its `Application` twin — the same borrowed-view seam, with an awaiting
+`update` — driven by `run_app`.
 
 `run_with_messages` adds a typed host stream beside terminal events and ticks.
 Its update callback receives `AsyncSignal::{Event, Tick, Message}`; a background
@@ -784,6 +787,15 @@ producer can therefore wake and update the UI immediately without
 `Arc<Mutex<_>>`, fabricated keys, or a short polling interval. The lower-level
 `run_with_events_and_messages` accepts both streams and a caller-owned backend,
 which also makes completion and error behavior deterministic under `TestBackend`.
+An application consuming that stream implements `AsyncApplication<AsyncSignal<M>>`
+and runs through `run_app_with_messages`: the message axis changes the signal
+type, not the seam.
+
+Both runners' `run` methods are named for the axes they depart from —
+`run[_app][_with_backend|_with_events][_and_messages]` — where `_app` selects
+the borrowed-view seam, the middle segment moves terminal ownership to the
+caller, and the last adds the message stream. The runtime is the runner type;
+everything else is `RunnerConfig` or a builder method.
 
 Enabling `async` adds Tokio (timer + `select!`) and crossterm's `event-stream`
 feature; it stays off by default so sync-only hosts pull in no runtime. The

--- a/crates/tuika-charts/examples/charts.rs
+++ b/crates/tuika-charts/examples/charts.rs
@@ -158,5 +158,5 @@ fn main() -> io::Result<()> {
         return Ok(());
     }
 
-    Runner::new(RunnerConfig::default()).run_app(&theme, &mut gallery)
+    Runner::new(RunnerConfig::default()).run(&theme, &mut gallery)
 }

--- a/crates/tuika-codeformatters/examples/highlight_file.rs
+++ b/crates/tuika-codeformatters/examples/highlight_file.rs
@@ -179,7 +179,7 @@ fn invalid_usage(extra: Option<OsString>) -> io::Error {
 
 fn main() -> io::Result<()> {
     let mut viewer = FileViewer::open(input_path()?)?;
-    Runner::new(RunnerConfig::default()).run_app(&Theme::default(), &mut viewer)
+    Runner::new(RunnerConfig::default()).run(&Theme::default(), &mut viewer)
 }
 
 #[cfg(test)]

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -58,15 +58,17 @@ fn main() -> std::io::Result<()> {
     let runner = Runner::new(RunnerConfig::default());
     runner.run(
         &theme,
-        &mut (),
-        |(), _frame| scene(),
-        |(), signal| match signal {
-            Signal::Event(Event::Key(key))
-                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+        from_fn(
+            &mut (),
+            |(), _frame| scene(),
+            |(), signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     )
 }

--- a/crates/tuika-html/examples/html_view/main.rs
+++ b/crates/tuika-html/examples/html_view/main.rs
@@ -41,15 +41,17 @@ fn main() -> std::io::Result<()> {
     let runner = Runner::new(RunnerConfig::default());
     runner.run(
         &theme,
-        &mut (),
-        |(), _frame| scene(),
-        |(), signal| match signal {
-            Signal::Event(Event::Key(key))
-                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+        from_fn(
+            &mut (),
+            |(), _frame| scene(),
+            |(), signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     )
 }

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -40,7 +40,7 @@ let chart = Chart::new()
 // Return `chart` from Application::view. Runner supplies graphics when the
 // terminal supports them and otherwise leaves Chart on its cell path.
 Runner::new(RunnerConfig::default())
-    .run_app(&Theme::default(), &mut app)?;
+    .run(&Theme::default(), &mut app)?;
 ```
 
 Direct calls to `paint` use cells by default, making in-memory tests stable.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,28 +31,30 @@ fn main() -> io::Result<()> {
 
     runner.run(
         &theme,
-        &mut (),
-        |_state, _frame| {
-            view! {
-                col(padding = Padding::all(1)) {
-                    fixed(3) {
-                        boxed(title = " tuika ") {
-                            text("Hello from the terminal")
+        from_fn(
+            &mut (),
+            |_state, _frame| {
+                view! {
+                    col(padding = Padding::all(1)) {
+                        fixed(3) {
+                            boxed(title = " tuika ") {
+                                text("Hello from the terminal")
+                            }
                         }
+                        grow(1) { spacer() }
+                        fixed(1) { text("q or esc to quit") }
                     }
-                    grow(1) { spacer() }
-                    fixed(1) { text("q or esc to quit") }
                 }
-            }
-        },
-        |_state, signal| match signal {
-            Signal::Event(Event::Key(key))
-                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+            },
+            |_state, signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     )
 }
 ```

--- a/examples/async_dashboard.rs
+++ b/examples/async_dashboard.rs
@@ -112,24 +112,26 @@ async fn main() -> std::io::Result<()> {
     runner
         .run_with_messages(
             &Theme::default(),
-            &mut metrics,
-            UnboundedReceiverStream::new(receive),
-            |metrics, _frame| dashboard(metrics),
-            async |metrics, signal| match signal {
-                AsyncSignal::Message(requests) => {
-                    metrics.ingest(requests);
-                    UpdateResult::Dirty
-                }
-                AsyncSignal::Event(Event::Key(key)) if key.plain() => match key.code {
-                    KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
-                    KeyCode::Char('r') => {
-                        metrics.ingest(fetch_stats(metrics.requests).await);
+            async_from_fn(
+                &mut metrics,
+                |metrics, _frame| dashboard(metrics),
+                async |metrics, signal| match signal {
+                    Signal::Message(requests) => {
+                        metrics.ingest(requests);
                         UpdateResult::Dirty
                     }
-                    _ => UpdateResult::Clean,
+                    Signal::Event(Event::Key(key)) if key.plain() => match key.code {
+                        KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
+                        KeyCode::Char('r') => {
+                            metrics.ingest(fetch_stats(metrics.requests).await);
+                            UpdateResult::Dirty
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                    Signal::Tick | Signal::Event(_) => UpdateResult::Clean,
                 },
-                AsyncSignal::Tick | AsyncSignal::Event(_) => UpdateResult::Clean,
-            },
+            ),
+            UnboundedReceiverStream::new(receive),
         )
         .await
 }

--- a/examples/borrowed_app.rs
+++ b/examples/borrowed_app.rs
@@ -60,5 +60,5 @@ fn main() -> io::Result<()> {
         title: "Borrowed application state".into(),
         count: 0,
     };
-    Runner::new(RunnerConfig::default()).run_app(&Theme::default(), &mut app)
+    Runner::new(RunnerConfig::default()).run(&Theme::default(), &mut app)
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -12,27 +12,29 @@ fn main() -> io::Result<()> {
 
     runner.run(
         &theme,
-        &mut (),
-        |_state, _frame| {
-            view! {
-                col(padding = Padding::all(1)) {
-                    fixed(3) {
-                        boxed(title = " tuika ") {
-                            text("Hello from the terminal")
+        from_fn(
+            &mut (),
+            |_state, _frame| {
+                view! {
+                    col(padding = Padding::all(1)) {
+                        fixed(3) {
+                            boxed(title = " tuika ") {
+                                text("Hello from the terminal")
+                            }
                         }
+                        grow(1) { spacer() }
+                        fixed(1) { text("q or esc to quit") }
                     }
-                    grow(1) { spacer() }
-                    fixed(1) { text("q or esc to quit") }
                 }
-            }
-        },
-        |_state, signal| match signal {
-            Signal::Event(Event::Key(key))
-                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+            },
+            |_state, signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     )
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -42,41 +42,43 @@ fn main() -> io::Result<()> {
 
     Runner::new(RunnerConfig::default()).run(
         &theme,
-        &mut state,
-        move |_state, _frame| {
-            let image = Image::new(data.clone(), COLS, ROWS).alt("a red/green gradient");
-            let status = match support {
-                ImageSupport::Kitty => " graphics: Kitty protocol detected ",
-                ImageSupport::ITerm2 => " graphics: iTerm2 protocol detected ",
-                ImageSupport::Sixel => " graphics: Sixel protocol detected ",
-                ImageSupport::None => " graphics: none — showing text fallback ",
-            };
-            let bar = StatusBar::new()
-                .left(vec![Span::styled(status, theme.selection_style())])
-                .right(vec![Span::styled(" q quit ", theme.muted_style())])
-                .background(Style::default().bg(theme.surface));
-            view! {
-                col(padding = Padding::all(1), gap = 1) {
-                    grow(1) { node(Spacer) }
-                    fixed(ROWS) {
-                        row {
-                            grow(1) { node(Spacer) }
-                            fixed(COLS) { node(image) }
-                            grow(1) { node(Spacer) }
+        from_fn(
+            &mut state,
+            move |_state, _frame| {
+                let image = Image::new(data.clone(), COLS, ROWS).alt("a red/green gradient");
+                let status = match support {
+                    ImageSupport::Kitty => " graphics: Kitty protocol detected ",
+                    ImageSupport::ITerm2 => " graphics: iTerm2 protocol detected ",
+                    ImageSupport::Sixel => " graphics: Sixel protocol detected ",
+                    ImageSupport::None => " graphics: none — showing text fallback ",
+                };
+                let bar = StatusBar::new()
+                    .left(vec![Span::styled(status, theme.selection_style())])
+                    .right(vec![Span::styled(" q quit ", theme.muted_style())])
+                    .background(Style::default().bg(theme.surface));
+                view! {
+                    col(padding = Padding::all(1), gap = 1) {
+                        grow(1) { node(Spacer) }
+                        fixed(ROWS) {
+                            row {
+                                grow(1) { node(Spacer) }
+                                fixed(COLS) { node(image) }
+                                grow(1) { node(Spacer) }
+                            }
                         }
+                        grow(1) { node(Spacer) }
+                        fixed(1) { node(bar) }
                     }
-                    grow(1) { node(Spacer) }
-                    fixed(1) { node(bar) }
                 }
-            }
-        },
-        |_state, signal| match signal {
-            Signal::Event(Event::Key(key))
-                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+            },
+            |_state, signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     )
 }

--- a/examples/inherit.rs
+++ b/examples/inherit.rs
@@ -33,7 +33,8 @@ use ratatui::text::{Line, Span};
 use tuika::components::{Flex, Rule, Text};
 use tuika::term::capabilities::Capabilities;
 use tuika::{
-    Event, KeyCode, Padding, Runner, RunnerConfig, Signal, Theme, UpdateResult, themes, view,
+    Event, KeyCode, Padding, Runner, RunnerConfig, Signal, Theme, UpdateResult, from_fn, themes,
+    view,
 };
 
 /// How long to wait for the terminal to answer. A real tty replies to the
@@ -162,15 +163,17 @@ fn main() -> io::Result<()> {
     let runner = Runner::new(RunnerConfig::default());
     runner.run(
         &theme,
-        &mut (),
-        |(), _frame| build(&theme, source),
-        |(), signal| match signal {
-            Signal::Event(Event::Key(key))
-                if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+        from_fn(
+            &mut (),
+            |(), _frame| build(&theme, source),
+            |(), signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     )
 }

--- a/examples/ratatui_dashboard.rs
+++ b/examples/ratatui_dashboard.rs
@@ -116,16 +116,18 @@ fn main() -> std::io::Result<()> {
     let live_view = metrics.clone();
     let result = runner.run(
         &Theme::default(),
-        &mut (),
-        move |(), _frame| element(LiveView::new(live_view.clone(), dashboard)),
-        |(), signal| match signal {
-            Signal::Event(Event::Key(key))
-                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-            {
-                UpdateResult::Exit
-            }
-            _ => UpdateResult::Clean,
-        },
+        from_fn(
+            &mut (),
+            move |(), _frame| element(LiveView::new(live_view.clone(), dashboard)),
+            |(), signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
     );
 
     stop.store(true, Ordering::Release);

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -119,12 +119,14 @@ fn main() -> io::Result<()> {
     let mut state = PickerState::new();
     runner.run(
         &theme,
-        &mut state,
-        |state, _frame| scene(state, &theme),
-        |state, signal| match signal {
-            Signal::Event(event) => update(state, &event),
-            Signal::Tick => UpdateResult::Clean,
-        },
+        from_fn(
+            &mut state,
+            |state, _frame| scene(state, &theme),
+            |state, signal| match signal {
+                Signal::Event(event) => update(state, &event),
+                Signal::Tick => UpdateResult::Clean,
+            },
+        ),
     )
 }
 

--- a/examples/split_footer.rs
+++ b/examples/split_footer.rs
@@ -136,28 +136,30 @@ fn main() -> std::io::Result<()> {
     let mut state = ();
     let result = runner.run(
         &theme,
-        &mut state,
-        move |(), frame| {
-            element(LiveView::new(view_status.clone(), move |status| {
-                footer(status, frame, &theme)
-            }))
-        },
-        |(), signal| match signal {
-            Signal::Event(Event::Key(key)) if key.plain() => match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
-                KeyCode::Char('p') => {
-                    status.update(|status| status.paused = !status.paused);
-                    UpdateResult::Clean
-                }
-                KeyCode::Char(' ') | KeyCode::Enter => {
-                    publish(&scrollback, seq.fetch_add(1, Ordering::AcqRel), &theme);
-                    status.update(|status| status.published += 1);
-                    UpdateResult::Clean
-                }
+        from_fn(
+            &mut state,
+            move |(), frame| {
+                element(LiveView::new(view_status.clone(), move |status| {
+                    footer(status, frame, &theme)
+                }))
+            },
+            |(), signal| match signal {
+                Signal::Event(Event::Key(key)) if key.plain() => match key.code {
+                    KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
+                    KeyCode::Char('p') => {
+                        status.update(|status| status.paused = !status.paused);
+                        UpdateResult::Clean
+                    }
+                    KeyCode::Char(' ') | KeyCode::Enter => {
+                        publish(&scrollback, seq.fetch_add(1, Ordering::AcqRel), &theme);
+                        status.update(|status| status.published += 1);
+                        UpdateResult::Clean
+                    }
+                    _ => UpdateResult::Clean,
+                },
                 _ => UpdateResult::Clean,
             },
-            _ => UpdateResult::Clean,
-        },
+        ),
     );
 
     stop.store(true, Ordering::Release);

--- a/examples/tree_list.rs
+++ b/examples/tree_list.rs
@@ -146,7 +146,7 @@ impl Application for TreeApp {
 }
 
 fn main() -> io::Result<()> {
-    Runner::new(RunnerConfig::default()).run_app(&Theme::default(), &mut TreeApp::new())
+    Runner::new(RunnerConfig::default()).run(&Theme::default(), &mut TreeApp::new())
 }
 
 #[cfg(test)]

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,15 @@
 
 ## 2026-08-14
 
+- **One seam, named axes only for what the names must carry**
+  - `FrameSource` makes the frame source an argument, and a message type
+    parameter on `Signal` makes the message stream a type rather than a method
+    name. The `run*` surface collapses to terminal ownership plus the presence
+    of a stream, and the combinations that were missing cannot recur.
+  - An uninhabited default message type is what keeps that unification cheap for
+    callers: existing matches stay exhaustive, so the generalization is a
+    compile-time no-op unless a host actually wants messages.
+
 - **The application seam is a runner axis, not a synchronous privilege**
   - `AsyncApplication` gives the async runner the borrowed-view seam the sync
     runner already had, and carries its signal type as a parameter so a
@@ -11,8 +20,6 @@
     general in what a frame returns and states render purity in its receiver,
     while the closure seam's `FnMut` view is the more permissive in what it
     captures. Neither is legacy.
-  - Run methods are named by the axes they depart from, so a capability added
-    at one point of the product belongs across its row.
 
 - **A redraw request must reach a parked loop**
   - `RedrawHandle` registers the waiting task's waker, making it a runner-neutral

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,25 @@
 # Knowledge Log
 
+## 2026-08-14
+
+- **The application seam is a runner axis, not a synchronous privilege**
+  - `AsyncApplication` gives the async runner the borrowed-view seam the sync
+    runner already had, and carries its signal type as a parameter so a
+    message-consuming application is the same seam with a different signal
+    rather than a third trait.
+  - Both frame sources are kept deliberately: the application seam is the more
+    general in what a frame returns and states render purity in its receiver,
+    while the closure seam's `FnMut` view is the more permissive in what it
+    captures. Neither is legacy.
+  - Run methods are named by the axes they depart from, so a capability added
+    at one point of the product belongs across its row.
+
+- **A redraw request must reach a parked loop**
+  - `RedrawHandle` registers the waiting task's waker, making it a runner-neutral
+    wakeup rather than a flag only a polling loop can notice, and both runners
+    expose one. It stays executor-agnostic: the wait is a plain `poll_fn`, not a
+    Tokio primitive.
+
 ## 2026-08-11
 
 - **Collection interaction state owns the window hosts need to preserve**

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`view_fn`/`Element`/`ScopedElement`/`RenderCtx`, `Application`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`view_fn`/`Element`/`ScopedElement`/`RenderCtx`, `Application`/`AsyncApplication`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -137,13 +137,16 @@ rather than beside it.
   synchronous loop has nothing to select with — so a background producer's
   runner-neutral option stays the redraw handle, which both runners expose and
   which wakes a parked async loop rather than waiting for its next tick.
-- **A run method names the axes it departs from, not a variant.** The seam
-  (closure or application), terminal ownership (runner, caller's backend, or
-  caller's terminal and event stream), and extra input (a message stream)
-  compose as `run[_app][_with_backend|_with_events][_and_messages]`; the runtime
-  is the runner type, and everything else is `RunnerConfig` or a builder. Adding
-  a capability to one point of that product means adding it to the whole row,
-  otherwise the surface stops being predictable.
+- **The frame source is an argument, not a method name.** `FrameSource` has two
+  implementors — `&mut app` for an `Application`, and `from_fn` over a state
+  value and closures — so a run method never has to name which one it takes.
+  Messages ride the same `Signal<M>`, whose default message type is
+  uninhabited, so a loop without a stream has no variant to handle and existing
+  two-arm matches stay exhaustive. What remains in the names is only terminal
+  ownership and whether there is a message stream; the runtime is the runner
+  type, and everything else is `RunnerConfig` or a builder. A capability added
+  at one point of that surface belongs across it — a cross product encoded as
+  names grows holes, which is what the pre-0.9 `run*`/`run_app*` matrix did.
 
 `measure` and `render` are the two halves of every view, and both receive the
 same `RenderCtx`: `measure` reports a size in whole cells so the solver can

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -114,12 +114,16 @@ rather than beside it.
   52 on release. Wheel input still routes to the application. A handled gesture
   returns `UpdateResult::Consumed` or `Dirty`; custom-loop hosts keep using the
   public selection primitives directly.
-- **Runners own application state directly**: `Application` receives signals
-  through `&mut self` and builds a `ScopedElement<'_>` through `&self`, so a
-  frame can borrow application data without shared interior mutability. The
-  compatible closure seam renders an owned `Element` from `&State` and updates
-  through `&mut State`. Repaint is an explicit dirty result (or, synchronously,
-  an external redraw request); terminal resize is the exception because layout
+- **Runners own application state directly**: `Application` (and its awaiting
+  counterpart `AsyncApplication`) receives signals through `&mut self` and
+  builds a `ScopedElement<'_>` through `&self`, so a frame can borrow
+  application data without shared interior mutability. The compatible closure
+  seam renders an owned `Element` from `&State` and updates through
+  `&mut State`. Both seams are kept: the application seam is more general in
+  what a frame may *return* (`Element` is `ScopedElement<'static>`) and states
+  render purity in its receiver, while the closure seam's `FnMut` view is more
+  permissive in what it may *capture*. Repaint is an explicit dirty result or an
+  external redraw request; terminal resize is the exception because layout
   must be repainted even when application state is unchanged. Rendering stays
   pure, and idle ticks do not churn the terminal. The
   synchronous runner's monotonic clock defaults to the process clock and is
@@ -129,7 +133,17 @@ rather than beside it.
   remain outside it.
   The async shell may additionally select over a typed application stream;
   messages use the same dirty/exit contract as events and ticks, and completion
-  disables only that source.
+  disables only that source. That stream is the async shell's alone — a
+  synchronous loop has nothing to select with — so a background producer's
+  runner-neutral option stays the redraw handle, which both runners expose and
+  which wakes a parked async loop rather than waiting for its next tick.
+- **A run method names the axes it departs from, not a variant.** The seam
+  (closure or application), terminal ownership (runner, caller's backend, or
+  caller's terminal and event stream), and extra input (a message stream)
+  compose as `run[_app][_with_backend|_with_events][_and_messages]`; the runtime
+  is the runner type, and everything else is `RunnerConfig` or a builder. Adding
+  a capability to one point of that product means adding it to the whole row,
+  otherwise the surface stops being predictable.
 
 `measure` and `render` are the two halves of every view, and both receive the
 same `RenderCtx`: `measure` reports a size in whole cells so the solver can

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,11 +139,15 @@ pub use layout::{
 };
 pub use output::{OneShotOptions, render_once, write_once};
 pub use overlay::{Overlay, OverlaySpec, TargetAlign, TargetPlacement, TargetSide};
+#[cfg(feature = "async")]
+#[allow(deprecated)]
+pub use runner::AsyncSignal;
 pub use runner::{
-    Application, Runner, RunnerAction, RunnerConfig, RunnerCore, Signal, UpdateResult,
+    Application, FrameSource, Runner, RunnerAction, RunnerConfig, RunnerCore, Signal, UpdateResult,
+    from_fn,
 };
 #[cfg(feature = "async")]
-pub use runner::{AsyncApplication, AsyncRunner, AsyncSignal};
+pub use runner::{AsyncApplication, AsyncFrameSource, AsyncRunner, async_from_fn, no_messages};
 pub use scene::{Backdrop, Scene, SceneOverlay, ScopedScene};
 pub use screen::{ScreenMode, Scrollback};
 pub use style::{SemanticRole, StyleResolver, StyleRole, StyleSheet, Theme};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ pub use runner::{
     Application, Runner, RunnerAction, RunnerConfig, RunnerCore, Signal, UpdateResult,
 };
 #[cfg(feature = "async")]
-pub use runner::{AsyncRunner, AsyncSignal};
+pub use runner::{AsyncApplication, AsyncRunner, AsyncSignal};
 pub use scene::{Backdrop, Scene, SceneOverlay, ScopedScene};
 pub use screen::{ScreenMode, Scrollback};
 pub use style::{SemanticRole, StyleResolver, StyleRole, StyleSheet, Theme};

--- a/src/live.rs
+++ b/src/live.rs
@@ -2,29 +2,85 @@
 //!
 //! `Live` is not a reconciler and does not spawn work. Producers own their
 //! threads or async tasks; updating a value requests a redraw from a connected
-//! [`Runner`](crate::Runner), and views read the latest value each frame.
+//! runner ([`Runner`](crate::Runner) or
+//! [`AsyncRunner`](crate::runner::AsyncRunner)), and views read the latest value
+//! each frame.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
+use std::task::Waker;
+#[cfg(feature = "async")]
+use std::task::{Context, Poll};
 
 use ratatui_core::layout::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 
+#[derive(Default)]
+struct RedrawSignal {
+    requested: AtomicBool,
+    // The synchronous runner discovers a request by checking the flag once per
+    // loop iteration; an async runner has no such iteration to check from and
+    // must be woken. Registering the waiting task's waker here keeps that
+    // wakeup executor-neutral — the async runner is Tokio-shaped, but nothing
+    // in this handle needs to be.
+    waker: Mutex<Option<Waker>>,
+}
+
 /// A thread-safe request for the terminal runner to redraw.
 #[derive(Clone, Default)]
 pub struct RedrawHandle {
-    requested: Arc<AtomicBool>,
+    signal: Arc<RedrawSignal>,
 }
 
 impl RedrawHandle {
     /// Mark the connected runner dirty.
     pub fn request(&self) {
-        self.requested.store(true, Ordering::Release);
+        self.signal.requested.store(true, Ordering::Release);
+        let waker = self
+            .signal
+            .waker
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .take();
+        if let Some(waker) = waker {
+            waker.wake();
+        }
     }
 
     pub(crate) fn take(&self) -> bool {
-        self.requested.swap(false, Ordering::AcqRel)
+        self.signal.requested.swap(false, Ordering::AcqRel)
+    }
+
+    /// Poll for a pending request, registering `cx`'s waker when there is none.
+    ///
+    /// Cancelling a wait leaves at most a stale waker behind, which costs one
+    /// spurious wakeup and never a lost one: the flag is re-checked after
+    /// registration, so a request racing with it is still observed.
+    #[cfg(feature = "async")]
+    pub(crate) fn poll_take(&self, cx: &Context<'_>) -> Poll<()> {
+        if self.take() {
+            return Poll::Ready(());
+        }
+        {
+            let mut waker = self
+                .signal
+                .waker
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            *waker = Some(cx.waker().clone());
+        }
+        if self.take() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+
+    /// Wait until a redraw is requested, consuming the request.
+    #[cfg(feature = "async")]
+    pub(crate) async fn requested(&self) {
+        std::future::poll_fn(|cx| self.poll_take(cx)).await;
     }
 }
 
@@ -128,6 +184,38 @@ mod tests {
     use crate::style::Theme;
     use crate::tests::support::row;
     use crate::view::element;
+
+    // A waiter that registers before any request must still be woken, and a
+    // request that lands first must not be lost. Polled by hand so the
+    // guarantee is checked without an executor.
+    #[cfg(feature = "async")]
+    #[test]
+    fn a_waiter_observes_requests_made_before_and_after_it_parks() {
+        let handle = RedrawHandle::default();
+        let waker = Waker::noop();
+        let context = Context::from_waker(waker);
+
+        assert_eq!(handle.poll_take(&context), Poll::Pending, "no request yet");
+        handle.request();
+        assert_eq!(
+            handle.poll_take(&context),
+            Poll::Ready(()),
+            "a request made while parked is observed"
+        );
+        assert_eq!(
+            handle.poll_take(&context),
+            Poll::Pending,
+            "the request was consumed"
+        );
+
+        let requested = RedrawHandle::default();
+        requested.request();
+        assert_eq!(
+            requested.poll_take(&context),
+            Poll::Ready(()),
+            "a request made before the first poll is not lost"
+        );
+    }
 
     #[test]
     fn live_view_reads_updated_data_without_reconstruction() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -53,4 +53,4 @@ pub use crate::{
 };
 
 #[cfg(feature = "async")]
-pub use crate::{AsyncRunner, AsyncSignal};
+pub use crate::{AsyncApplication, AsyncRunner, AsyncSignal};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -43,14 +43,14 @@ pub use crate::view;
 pub use crate::{
     Align, AlignContent, Application, AvailableSpace, Backdrop, Clock, Dimension, Direction,
     DockEdge, DockLayout, DockPlacement, DockSpec, DockState, Element, Event, EventFlow,
-    FlexItemStyle, FlexWrap, InputOutcome, Justify, Key, KeyCode, LayoutStyle, MeasureRequest,
-    Mouse, MouseButton, MouseCapture, MouseKind, OneShotOptions, Overlay, OverlaySpec, Padding,
-    RenderCtx, Runner, RunnerAction, RunnerConfig, RunnerCore, Scene, SceneOverlay, ScopedElement,
-    ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal, Size, StyleSheet, Surface,
-    SystemClock, TargetAlign, TargetPlacement, TargetSide, TerminalSession, TerminalSessionConfig,
-    Theme, UpdateResult, View, element, paint, paint_scene, paint_with_context, paint_with_sheet,
-    render_once, translate_event, view_fn, write_once,
+    FlexItemStyle, FlexWrap, FrameSource, InputOutcome, Justify, Key, KeyCode, LayoutStyle,
+    MeasureRequest, Mouse, MouseButton, MouseCapture, MouseKind, OneShotOptions, Overlay,
+    OverlaySpec, Padding, RenderCtx, Runner, RunnerAction, RunnerConfig, RunnerCore, Scene,
+    SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal, Size,
+    StyleSheet, Surface, SystemClock, TargetAlign, TargetPlacement, TargetSide, TerminalSession,
+    TerminalSessionConfig, Theme, UpdateResult, View, element, from_fn, paint, paint_scene,
+    paint_with_context, paint_with_sheet, render_once, translate_event, view_fn, write_once,
 };
 
 #[cfg(feature = "async")]
-pub use crate::{AsyncApplication, AsyncRunner, AsyncSignal};
+pub use crate::{AsyncApplication, AsyncFrameSource, AsyncRunner, async_from_fn, no_messages};

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -66,10 +66,12 @@ use tokio::time::{Instant as TokioInstant, MissedTickBehavior, interval, sleep_u
 use tokio_stream::{Stream, StreamExt};
 
 use super::{
-    FrameGraphics, FrameGraphicsCleanup, RESIZE_FRAME_INTERVAL, RunnerAction, RunnerCore,
-    RunnerSelection, Signal,
+    FrameGraphics, FrameGraphicsCleanup, PaintRoot, RESIZE_FRAME_INTERVAL, RunnerAction,
+    RunnerCore, RunnerSelection, Signal,
 };
+use crate::live::RedrawHandle;
 use crate::screen::{Scrollback, close_footer, pin_footer};
+use crate::view::ScopedElement;
 use crate::{
     Element, Event, RenderCtx, RunnerConfig, SystemClock, TerminalSession, Theme, UpdateResult,
     paint_with_context, translate_event,
@@ -93,16 +95,79 @@ impl<M> AsyncSignal<M> {
     }
 }
 
+/// A data-driven asynchronous terminal application.
+///
+/// The asynchronous counterpart to [`Application`](crate::runner::Application),
+/// with the same contract: the runner mutably borrows the application to deliver
+/// a signal, then immutably borrows it to build the next frame, so a frame can
+/// read application data directly instead of cloning it into an owned
+/// [`Element`] or sharing it through `Rc<RefCell<_>>`. Only `update` may
+/// `.await`; rendering stays pure and synchronous.
+///
+/// The signal type is a parameter so the same seam serves both input shapes: it
+/// defaults to [`Signal`] for [`run_app`](AsyncRunner::run_app), and an
+/// application that also consumes a message stream implements
+/// `AsyncApplication<AsyncSignal<M>>` for
+/// [`run_app_with_messages`](AsyncRunner::run_app_with_messages). Adding a
+/// stream therefore changes one type parameter rather than the seam.
+///
+/// ```no_run
+/// use tuika::prelude::*;
+/// use tuika::runner::AsyncApplication;
+///
+/// struct Counter {
+///     hits: Vec<String>,
+/// }
+///
+/// impl AsyncApplication for Counter {
+///     async fn update(&mut self, signal: Signal) -> UpdateResult {
+///         match signal {
+///             Signal::Event(Event::Key(key)) if key.code == KeyCode::Esc => UpdateResult::Exit,
+///             Signal::Event(Event::Key(_)) => {
+///                 self.hits.push("hit".into());
+///                 UpdateResult::Dirty
+///             }
+///             _ => UpdateResult::Clean,
+///         }
+///     }
+///
+///     // The frame borrows `self.hits` — no clone, no `'static` bound.
+///     fn view(&self, _frame: u64) -> ScopedElement<'_> {
+///         element(Text::raw(format!("{} hits", self.hits.len())))
+///     }
+/// }
+/// ```
+pub trait AsyncApplication<Sig = Signal> {
+    /// Update application state in response to a signal, possibly awaiting.
+    fn update(&mut self, signal: Sig) -> impl Future<Output = UpdateResult>;
+
+    /// Build the ephemeral view tree for one numbered frame.
+    fn view(&self, frame: u64) -> ScopedElement<'_>;
+}
+
+/// Adapt an [`AsyncApplication`] to the loop's view callback.
+fn app_view<A, Sig>() -> impl FnMut(&A, u64, PaintRoot<'_>)
+where
+    A: AsyncApplication<Sig>,
+{
+    |app, frame, paint_root| paint_root(app.view(frame).as_ref())
+}
+
 /// An asynchronous Crossterm event and rendering loop.
 ///
-/// See the [module documentation](crate::runner) for the full picture. Construct one with
-/// a [`RunnerConfig`], then drive it with [`run`](Self::run) (real terminal),
-/// [`run_with_backend`](Self::run_with_backend) (caller-supplied backend, such as
-/// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend)), or
-/// [`run_with_events`](Self::run_with_events) (caller-supplied backend *and*
-/// event stream, for tests and hosts that own the terminal lifecycle).
+/// See the [module documentation](crate::runner) for the full picture,
+/// including how the `run*` names are composed from the loop's axes. Construct
+/// one with a [`RunnerConfig`], then pick a method by what you are departing
+/// from the default on: `_app` for an [`AsyncApplication`] whose frame borrows
+/// itself instead of a view closure returning an owned tree,
+/// `_with_backend` for a caller-supplied backend (such as
+/// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend)),
+/// `_with_events` for a caller-owned terminal *and* event stream (tests and
+/// hosts that own the terminal lifecycle), and `_with_messages` /
+/// `_and_messages` to select over a typed application stream as well.
 pub struct AsyncRunner {
     config: RunnerConfig,
+    redraw: RedrawHandle,
     scrollback: Scrollback,
     session_config: Option<crate::TerminalSessionConfig>,
     text_selection: bool,
@@ -117,10 +182,22 @@ impl AsyncRunner {
         config.tick_rate = config.tick_rate.max(Duration::from_millis(1));
         Self {
             config,
+            redraw: RedrawHandle::default(),
             scrollback: Scrollback::new(),
             session_config: None,
             text_selection: true,
         }
+    }
+
+    /// Return a handle that background producers can use to request redraws.
+    ///
+    /// The counterpart to [`Runner::redraw_handle`](crate::Runner::redraw_handle),
+    /// so a [`Live`](crate::live::Live) value works the same on either runner. A
+    /// producer that owns domain data it wants delivered *into* `update` should
+    /// prefer a message stream ([`run_with_messages`](Self::run_with_messages));
+    /// a redraw request only says the next frame is stale.
+    pub fn redraw_handle(&self) -> RedrawHandle {
+        self.redraw.clone()
     }
 
     /// Override terminal lifecycle policy while retaining the async loop.
@@ -177,7 +254,7 @@ impl AsyncRunner {
             theme,
             CrosstermBackend::new(io::stdout()),
             state,
-            view,
+            owned_view(view),
             update,
             Some(&graphics),
         )
@@ -203,6 +280,23 @@ impl AsyncRunner {
     where
         MS: Stream<Item = io::Result<M>> + Unpin,
         V: FnMut(&S, u64) -> Element,
+        U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
+    {
+        self.run_with_messages_inner(theme, state, messages, owned_view(view), update)
+            .await
+    }
+
+    async fn run_with_messages_inner<S, M, V, U, MS>(
+        &self,
+        theme: &Theme,
+        state: &mut S,
+        messages: MS,
+        view: V,
+        update: U,
+    ) -> io::Result<()>
+    where
+        MS: Stream<Item = io::Result<M>> + Unpin,
+        V: FnMut(&S, u64, PaintRoot<'_>),
         U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
     {
         let graphics = FrameGraphics::detected();
@@ -250,6 +344,141 @@ impl AsyncRunner {
         result
     }
 
+    /// Run a data-driven [`AsyncApplication`] on the real terminal.
+    ///
+    /// The borrowed-view counterpart to [`run`](Self::run), and the async
+    /// counterpart to [`Runner::run_app`](crate::Runner::run_app). It uses the
+    /// same terminal lifecycle, scheduling, redraw, and split-footer behavior.
+    pub async fn run_app<A: AsyncApplication>(&self, theme: &Theme, app: &mut A) -> io::Result<()> {
+        let graphics = FrameGraphics::detected();
+        self.run_with_backend_inner(
+            theme,
+            CrosstermBackend::new(io::stdout()),
+            app,
+            app_view(),
+            async |app: &mut A, signal| app.update(signal).await,
+            Some(&graphics),
+        )
+        .await
+    }
+
+    /// Run a data-driven [`AsyncApplication`] that also receives typed
+    /// application `messages`.
+    ///
+    /// The borrowed-view counterpart to
+    /// [`run_with_messages`](Self::run_with_messages). The application
+    /// implements `AsyncApplication<AsyncSignal<M>>`, so ticks, terminal
+    /// events, and messages all arrive through the one `update`.
+    pub async fn run_app_with_messages<A, M, MS>(
+        &self,
+        theme: &Theme,
+        app: &mut A,
+        messages: MS,
+    ) -> io::Result<()>
+    where
+        A: AsyncApplication<AsyncSignal<M>>,
+        MS: Stream<Item = io::Result<M>> + Unpin,
+    {
+        self.run_with_messages_inner(
+            theme,
+            app,
+            messages,
+            app_view(),
+            async |app: &mut A, signal| app.update(signal).await,
+        )
+        .await
+    }
+
+    /// Run a data-driven [`AsyncApplication`] against a caller-owned terminal
+    /// and event stream.
+    ///
+    /// The borrowed-view counterpart to
+    /// [`run_with_events`](Self::run_with_events), with the same contract: no
+    /// terminal lifecycle, and the backend and stream share the run's error
+    /// type `Er`.
+    pub async fn run_app_with_events<A, B, E, Er>(
+        &self,
+        terminal: &mut Terminal<B>,
+        theme: &Theme,
+        app: &mut A,
+        events: E,
+    ) -> Result<(), Er>
+    where
+        A: AsyncApplication,
+        B: Backend<Error = Er>,
+        E: Stream<Item = Result<Event, Er>> + Unpin,
+    {
+        self.run_with_events_inner(
+            terminal,
+            theme,
+            app,
+            events,
+            app_view(),
+            async |app: &mut A, signal| app.update(signal).await,
+            None,
+            |_| Ok(()),
+        )
+        .await
+    }
+
+    /// Run a data-driven [`AsyncApplication`] with a caller-provided backend.
+    ///
+    /// The borrowed-view counterpart to
+    /// [`run_with_backend`](Self::run_with_backend).
+    pub async fn run_app_with_backend<A, B>(
+        &self,
+        theme: &Theme,
+        backend: B,
+        app: &mut A,
+    ) -> io::Result<()>
+    where
+        A: AsyncApplication,
+        B: Backend<Error = io::Error>,
+    {
+        self.run_with_backend_inner(
+            theme,
+            backend,
+            app,
+            app_view(),
+            async |app: &mut A, signal| app.update(signal).await,
+            None,
+        )
+        .await
+    }
+
+    /// Run a data-driven [`AsyncApplication`] against a caller-owned terminal,
+    /// event stream, and message stream.
+    ///
+    /// The borrowed-view counterpart to
+    /// [`run_with_events_and_messages`](Self::run_with_events_and_messages).
+    pub async fn run_app_with_events_and_messages<A, M, B, E, MS, Er>(
+        &self,
+        terminal: &mut Terminal<B>,
+        theme: &Theme,
+        app: &mut A,
+        events: E,
+        messages: MS,
+    ) -> Result<(), Er>
+    where
+        A: AsyncApplication<AsyncSignal<M>>,
+        B: Backend<Error = Er>,
+        E: Stream<Item = Result<Event, Er>> + Unpin,
+        MS: Stream<Item = Result<M, Er>> + Unpin,
+    {
+        self.run_with_events_and_messages_inner(
+            terminal,
+            theme,
+            app,
+            events,
+            messages,
+            app_view(),
+            async |app: &mut A, signal| app.update(signal).await,
+            None,
+            |_| Ok(()),
+        )
+        .await
+    }
+
     /// Run with a caller-provided backend, such as
     /// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend). Otherwise identical to
     /// [`run`](Self::run): it owns the [`TerminalSession`] and the
@@ -267,7 +496,7 @@ impl AsyncRunner {
         V: FnMut(&S, u64) -> Element,
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
-        self.run_with_backend_inner(theme, backend, state, view, update, None)
+        self.run_with_backend_inner(theme, backend, state, owned_view(view), update, None)
             .await
     }
 
@@ -282,7 +511,7 @@ impl AsyncRunner {
     ) -> io::Result<()>
     where
         B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64) -> Element,
+        V: FnMut(&S, u64, PaintRoot<'_>),
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
         let mode = self.config.screen_mode;
@@ -370,9 +599,16 @@ impl AsyncRunner {
         V: FnMut(&S, u64) -> Element,
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
-        self.run_with_events_inner(terminal, theme, state, events, view, update, None, |_| {
-            Ok(())
-        })
+        self.run_with_events_inner(
+            terminal,
+            theme,
+            state,
+            events,
+            owned_view(view),
+            update,
+            None,
+            |_| Ok(()),
+        )
         .await
     }
 
@@ -407,7 +643,7 @@ impl AsyncRunner {
             state,
             events,
             messages,
-            view,
+            owned_view(view),
             update,
             None,
             |_| Ok(()),
@@ -432,7 +668,7 @@ impl AsyncRunner {
         B: Backend<Error = Er>,
         E: Stream<Item = Result<Event, Er>> + Unpin,
         MS: Stream<Item = Result<M, Er>> + Unpin,
-        V: FnMut(&S, u64) -> Element,
+        V: FnMut(&S, u64, PaintRoot<'_>),
         U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
         F: FnMut(Option<&str>) -> Result<(), Er>,
     {
@@ -467,12 +703,17 @@ impl AsyncRunner {
                 Tick,
                 Event(Event),
                 Message(M),
+                /// A scheduled repaint deadline came due.
                 Redraw,
+                /// A background producer asked for one through a
+                /// [`RedrawHandle`].
+                Requested,
             }
 
             let deadline = redraw_at.unwrap_or_else(TokioInstant::now);
             let wake = tokio::select! {
                 _ = sleep_until(deadline), if redraw_at.is_some() => Wake::Redraw,
+                () = self.redraw.requested() => Wake::Requested,
                 _ = ticker.tick() => Wake::Tick,
                 item = events.next(), if !events_done => match item {
                     Some(Ok(event)) => Wake::Event(event),
@@ -491,6 +732,16 @@ impl AsyncRunner {
                     }
                 },
             };
+
+            // An external request only marks the frame stale; the repaint
+            // itself goes through the same deadline path as every other one, so
+            // a burst of requests still coalesces into one frame.
+            if matches!(&wake, Wake::Requested) {
+                core.request_redraw();
+                let now = TokioInstant::now();
+                redraw_at = Some(redraw_at.map_or(now, |current: TokioInstant| current.min(now)));
+                continue;
+            }
 
             if matches!(&wake, Wake::Redraw) {
                 if let RunnerAction::Render(frame) = core.next_action() {
@@ -521,7 +772,7 @@ impl AsyncRunner {
                     (AsyncSignal::Event(event), selection)
                 }
                 Wake::Message(message) => (AsyncSignal::Message(message), None),
-                Wake::Redraw => unreachable!(),
+                Wake::Redraw | Wake::Requested => unreachable!("handled above"),
             };
             let requires_redraw = signal.requires_redraw();
             let result = update(state, signal).await;
@@ -591,7 +842,7 @@ impl AsyncRunner {
     where
         B: Backend<Error = Er>,
         E: Stream<Item = Result<Event, Er>> + Unpin,
-        V: FnMut(&S, u64) -> Element,
+        V: FnMut(&S, u64, PaintRoot<'_>),
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
         F: FnMut(Option<&str>) -> Result<(), Er>,
     {
@@ -615,6 +866,10 @@ impl AsyncRunner {
 }
 
 /// Paint one numbered frame from the current `state`.
+///
+/// `view` hands its root to a painting callback rather than returning it, which
+/// is what lets the same loop serve an owned [`Element`] and a frame-borrowed
+/// [`ScopedElement`]: the borrow only has to outlive the call, not the return.
 fn draw<S, B, V, Er>(
     terminal: &mut Terminal<B>,
     theme: &Theme,
@@ -626,17 +881,29 @@ fn draw<S, B, V, Er>(
 ) -> Result<Option<String>, Er>
 where
     B: Backend<Error = Er>,
-    V: FnMut(&S, u64) -> Element,
+    V: FnMut(&S, u64, PaintRoot<'_>),
 {
     let mut copied = None;
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
-        let root = view(state, frame);
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
-        paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root.as_ref(), &[]);
+        view(state, frame, &mut |root| {
+            paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root, &[]);
+        });
         copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);
     })?;
     Ok(copied)
+}
+
+/// Adapt an owned-`Element` view closure to the painting-callback form.
+fn owned_view<S, V>(mut view: V) -> impl FnMut(&S, u64, PaintRoot<'_>)
+where
+    V: FnMut(&S, u64) -> Element,
+{
+    move |state, frame, paint_root| {
+        let root = view(state, frame);
+        paint_root(root.as_ref());
+    }
 }
 
 #[cfg(test)]
@@ -648,6 +915,11 @@ mod tests {
     use crate::event::{Key, KeyCode, Mouse, MouseButton, MouseKind};
     use crate::view::element;
     use ratatui_core::backend::TestBackend;
+    use ratatui_core::layout::Rect;
+
+    use crate::View;
+    use crate::geometry::Size;
+    use crate::surface::Surface;
 
     /// A key event as the infallible-stream item the `TestBackend` tests use.
     fn key(code: KeyCode) -> Result<Event, Infallible> {
@@ -1349,8 +1621,6 @@ mod tests {
 
     #[tokio::test]
     async fn message_stream_error_propagates() {
-        use ratatui_core::layout::Rect;
-
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
             ..RunnerConfig::default()
@@ -1380,6 +1650,191 @@ mod tests {
         assert_eq!(
             result.expect_err("message error").to_string(),
             "message boom"
+        );
+    }
+
+    /// An application whose frame borrows its own data, used to prove the
+    /// borrowed seam reaches the async loop unchanged.
+    struct Notes {
+        title: String,
+        hits: Vec<char>,
+    }
+
+    struct NotesView<'app> {
+        title: &'app str,
+        hits: &'app [char],
+    }
+
+    impl View for NotesView<'_> {
+        fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
+            Size::new(available.width, 1.min(available.height))
+        }
+
+        fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+            let line = format!("{}:{}", self.title, self.hits.iter().collect::<String>());
+            surface.set_string(area.x, area.y, &line, ctx.theme.text_style());
+        }
+    }
+
+    impl AsyncApplication for Notes {
+        async fn update(&mut self, signal: Signal) -> UpdateResult {
+            match signal {
+                Signal::Event(Event::Key(key)) if key.code == KeyCode::Esc => UpdateResult::Exit,
+                Signal::Event(Event::Key(Key {
+                    code: KeyCode::Char(c),
+                    ..
+                })) => {
+                    self.hits.push(c);
+                    UpdateResult::Dirty
+                }
+                _ => UpdateResult::Clean,
+            }
+        }
+
+        fn view(&self, _frame: u64) -> ScopedElement<'_> {
+            element(NotesView {
+                title: &self.title,
+                hits: &self.hits,
+            })
+        }
+    }
+
+    // The async runner drives the same `Application`-shaped seam the sync runner
+    // does: events mutate through `&mut self`, and the frame borrows `&self`
+    // without cloning into an owned tree.
+    #[tokio::test]
+    async fn run_app_paints_a_borrowed_view() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(12, 1);
+        let mut app = Notes {
+            title: "n".into(),
+            hits: Vec::new(),
+        };
+        let events = tokio_stream::iter([
+            key(KeyCode::Char('a')),
+            key(KeyCode::Char('b')),
+            key(KeyCode::Esc),
+        ]);
+
+        runner
+            .run_app_with_events(&mut terminal, &Theme::default(), &mut app, events)
+            .await
+            .expect("run");
+
+        assert_eq!(app.hits, vec!['a', 'b']);
+        assert!(
+            buffer_text(&terminal).contains("n:ab"),
+            "final frame borrows application data: {:?}",
+            buffer_text(&terminal)
+        );
+    }
+
+    /// The message-carrying twin of `Notes`: the same seam with a different
+    /// signal type rather than a different trait.
+    struct Feed {
+        items: Vec<u8>,
+    }
+
+    impl AsyncApplication<AsyncSignal<u8>> for Feed {
+        async fn update(&mut self, signal: AsyncSignal<u8>) -> UpdateResult {
+            match signal {
+                AsyncSignal::Message(0) => UpdateResult::Exit,
+                AsyncSignal::Message(item) => {
+                    self.items.push(item);
+                    UpdateResult::Dirty
+                }
+                _ => UpdateResult::Clean,
+            }
+        }
+
+        fn view(&self, _frame: u64) -> ScopedElement<'_> {
+            element(Text::raw(format!("items={}", self.items.len())))
+        }
+    }
+
+    #[tokio::test]
+    async fn run_app_receives_messages_through_the_same_seam() {
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(12, 1);
+        let mut app = Feed { items: Vec::new() };
+        let messages = tokio_stream::iter([Ok::<u8, Infallible>(7), Ok(9), Ok(0)]);
+
+        runner
+            .run_app_with_events_and_messages(
+                &mut terminal,
+                &Theme::default(),
+                &mut app,
+                tokio_stream::empty::<Result<Event, Infallible>>(),
+                messages,
+            )
+            .await
+            .expect("run");
+
+        assert_eq!(app.items, vec![7, 9]);
+        assert!(buffer_text(&terminal).contains("items=2"));
+    }
+
+    // A background producer that only owns a `RedrawHandle` — the `Live` case —
+    // must be able to wake the select loop, which has no polling iteration of
+    // its own to notice the flag from. Time is paused, so the producer's sleep
+    // cannot advance until the runner is parked again: the repaint is ordered
+    // before the quit key without a wall-clock race.
+    #[tokio::test(start_paused = true)]
+    async fn redraw_handle_wakes_the_loop_and_repaints() {
+        use tokio_stream::wrappers::ReceiverStream;
+
+        let runner = AsyncRunner::new(RunnerConfig {
+            tick_rate: Duration::from_secs(3600),
+            ..RunnerConfig::default()
+        });
+        let mut terminal = terminal(12, 1);
+        let redraw = runner.redraw_handle();
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let views = std::cell::Cell::new(0usize);
+        let (sender, receiver) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(4);
+
+        let producer = {
+            let counter = std::sync::Arc::clone(&counter);
+            tokio::spawn(async move {
+                counter.store(41, std::sync::atomic::Ordering::Release);
+                redraw.request();
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                sender.send(key(KeyCode::Esc)).await.expect("send quit");
+            })
+        };
+
+        let mut state = std::sync::Arc::clone(&counter);
+        runner
+            .run_with_events(
+                &mut terminal,
+                &Theme::default(),
+                &mut state,
+                ReceiverStream::new(receiver),
+                |state, _frame| {
+                    views.set(views.get() + 1);
+                    let value = state.load(std::sync::atomic::Ordering::Acquire);
+                    element(Text::raw(format!("value={value}")))
+                },
+                async |_state, signal| match signal {
+                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
+                    _ => UpdateResult::Clean,
+                },
+            )
+            .await
+            .expect("run");
+        producer.await.expect("producer");
+
+        assert_eq!(views.get(), 2, "initial frame plus the requested repaint");
+        assert!(
+            buffer_text(&terminal).contains("value=41"),
+            "the requested repaint shows the producer's data: {:?}",
+            buffer_text(&terminal)
         );
     }
 }

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -9,12 +9,12 @@
 //! owns — no `spawn_blocking`, no shared `RwLock`/`Notify`/stop flag bolted onto
 //! the synchronous [`Runner`](crate::Runner) just to feed it.
 //!
-//! The loop threads a single `state` value through two callbacks: `view` builds
-//! the frame from `&state`, and `update` mutates `&mut state` in response to a
-//! [`Signal`] (a tick or an input event) and may `.await` while doing so. Both
-//! borrow the same value at different times, which is why it is a runner
-//! argument rather than a capture — a closure cannot hold `&state` and
-//! `&mut state` at once.
+//! The loop pulls every frame and update decision from one
+//! [`AsyncFrameSource`]: either `&mut app` for an [`AsyncApplication`], or
+//! [`async_from_fn`] over a state value and a pair of closures. In the closure
+//! form `view` builds the frame from `&state` while `update` mutates
+//! `&mut state` and may `.await`; state is an argument rather than a capture
+//! because a closure cannot hold `&state` and `&mut state` at once.
 //!
 //! ```no_run
 //! use std::time::Duration;
@@ -32,29 +32,32 @@
 //!     runner
 //!         .run(
 //!             &Theme::default(),
-//!             &mut requests,
-//!             |requests, _frame| element(Text::raw(format!("requests: {requests}"))),
-//!             async |requests, signal| match signal {
-//!                 // Poll on every tick and on `r`; both may await.
-//!                 Signal::Tick => {
-//!                     *requests = fetch_stats().await.unwrap_or(*requests);
-//!                     UpdateResult::Dirty
-//!                 }
-//!                 Signal::Event(Event::Key(k)) if k.plain() => match k.code {
-//!                     KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
-//!                     KeyCode::Char('r') => {
+//!             async_from_fn(
+//!                 &mut requests,
+//!                 |requests, _frame| element(Text::raw(format!("requests: {requests}"))),
+//!                 async |requests, signal| match signal {
+//!                     // Poll on every tick and on `r`; both may await.
+//!                     Signal::Tick => {
 //!                         *requests = fetch_stats().await.unwrap_or(*requests);
 //!                         UpdateResult::Dirty
 //!                     }
+//!                     Signal::Event(Event::Key(k)) if k.plain() => match k.code {
+//!                         KeyCode::Char('q') | KeyCode::Esc => UpdateResult::Exit,
+//!                         KeyCode::Char('r') => {
+//!                             *requests = fetch_stats().await.unwrap_or(*requests);
+//!                             UpdateResult::Dirty
+//!                         }
+//!                         _ => UpdateResult::Clean,
+//!                     },
 //!                     _ => UpdateResult::Clean,
 //!                 },
-//!                 _ => UpdateResult::Clean,
-//!             },
+//!             ),
 //!         )
 //!         .await
 //! }
 //! ```
 
+use std::convert::Infallible;
 use std::io;
 use std::time::Duration;
 
@@ -77,23 +80,10 @@ use crate::{
     paint_with_context, translate_event,
 };
 
-/// A signal delivered by an [`AsyncRunner`] that also listens to a typed
+/// The signal type an [`AsyncRunner`] delivers when it also listens to a typed
 /// application message stream.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum AsyncSignal<M> {
-    /// The configured tick interval elapsed.
-    Tick,
-    /// A translated terminal input event arrived.
-    Event(Event),
-    /// A host or background producer sent an application message.
-    Message(M),
-}
-
-impl<M> AsyncSignal<M> {
-    fn requires_redraw(&self) -> bool {
-        matches!(self, Self::Event(Event::Resize { .. }))
-    }
-}
+#[deprecated(since = "0.9.0", note = "use `Signal<M>`, which now carries messages")]
+pub type AsyncSignal<M> = Signal<M>;
 
 /// A data-driven asynchronous terminal application.
 ///
@@ -104,16 +94,12 @@ impl<M> AsyncSignal<M> {
 /// [`Element`] or sharing it through `Rc<RefCell<_>>`. Only `update` may
 /// `.await`; rendering stays pure and synchronous.
 ///
-/// The signal type is a parameter so the same seam serves both input shapes: it
-/// defaults to [`Signal`] for [`run_app`](AsyncRunner::run_app), and an
-/// application that also consumes a message stream implements
-/// `AsyncApplication<AsyncSignal<M>>` for
-/// [`run_app_with_messages`](AsyncRunner::run_app_with_messages). Adding a
-/// stream therefore changes one type parameter rather than the seam.
+/// `M` is the application-message type, and defaults to the uninhabited
+/// [`Infallible`] — so an application that consumes a message stream is this
+/// same trait at `AsyncApplication<MyMessage>`, not a different one.
 ///
 /// ```no_run
 /// use tuika::prelude::*;
-/// use tuika::runner::AsyncApplication;
 ///
 /// struct Counter {
 ///     hits: Vec<String>,
@@ -137,20 +123,75 @@ impl<M> AsyncSignal<M> {
 ///     }
 /// }
 /// ```
-pub trait AsyncApplication<Sig = Signal> {
+pub trait AsyncApplication<M = Infallible> {
     /// Update application state in response to a signal, possibly awaiting.
-    fn update(&mut self, signal: Sig) -> impl Future<Output = UpdateResult>;
+    fn update(&mut self, signal: Signal<M>) -> impl Future<Output = UpdateResult>;
 
     /// Build the ephemeral view tree for one numbered frame.
     fn view(&self, frame: u64) -> ScopedElement<'_>;
 }
 
-/// Adapt an [`AsyncApplication`] to the loop's view callback.
-fn app_view<A, Sig>() -> impl FnMut(&A, u64, PaintRoot<'_>)
+/// What an [`AsyncRunner`] pulls frames and update decisions from.
+///
+/// The asynchronous [`FrameSource`](crate::runner::FrameSource): `&mut app` for
+/// an [`AsyncApplication`], or [`async_from_fn`] for the closure form.
+/// Implement [`AsyncApplication`] rather than this trait.
+pub trait AsyncFrameSource<M = Infallible> {
+    /// Deliver one signal, possibly awaiting.
+    fn update(&mut self, signal: Signal<M>) -> impl Future<Output = UpdateResult>;
+
+    /// Build one numbered frame and hand its root to `paint`.
+    fn frame(&mut self, frame: u64, paint: PaintRoot<'_>);
+}
+
+impl<M, A: AsyncApplication<M>> AsyncFrameSource<M> for &mut A {
+    async fn update(&mut self, signal: Signal<M>) -> UpdateResult {
+        AsyncApplication::update(*self, signal).await
+    }
+
+    fn frame(&mut self, frame: u64, paint: PaintRoot<'_>) {
+        paint(AsyncApplication::view(*self, frame).as_ref());
+    }
+}
+
+/// An [`AsyncFrameSource`] built from a state value and a pair of closures.
+///
+/// Returned by [`async_from_fn`].
+pub struct AsyncFromFn<'state, S, V, U> {
+    state: &'state mut S,
+    view: V,
+    update: U,
+}
+
+/// Build an [`AsyncFrameSource`] from `state` and closures over it.
+///
+/// The asynchronous [`from_fn`](crate::runner::from_fn): `view` stays a
+/// synchronous `FnMut` returning an owned [`Element`], while `update` may
+/// `.await`.
+pub fn async_from_fn<S, V, U, M>(state: &mut S, view: V, update: U) -> AsyncFromFn<'_, S, V, U>
 where
-    A: AsyncApplication<Sig>,
+    V: FnMut(&S, u64) -> Element,
+    U: AsyncFnMut(&mut S, Signal<M>) -> UpdateResult,
 {
-    |app, frame, paint_root| paint_root(app.view(frame).as_ref())
+    AsyncFromFn {
+        state,
+        view,
+        update,
+    }
+}
+
+impl<M, S, V, U> AsyncFrameSource<M> for AsyncFromFn<'_, S, V, U>
+where
+    V: FnMut(&S, u64) -> Element,
+    U: AsyncFnMut(&mut S, Signal<M>) -> UpdateResult,
+{
+    async fn update(&mut self, signal: Signal<M>) -> UpdateResult {
+        (self.update)(&mut *self.state, signal).await
+    }
+
+    fn frame(&mut self, frame: u64, paint: PaintRoot<'_>) {
+        paint((self.view)(self.state, frame).as_ref());
+    }
 }
 
 /// An asynchronous Crossterm event and rendering loop.
@@ -233,32 +274,15 @@ impl AsyncRunner {
         self.scrollback.clone()
     }
 
-    /// Run on the real terminal until `update` returns [`UpdateResult::Exit`].
+    /// Run on the real terminal until the frame source returns
+    /// [`UpdateResult::Exit`].
     ///
-    /// Enters a [`TerminalSession`] (restored on return, including on error or
-    /// panic) and reads input from crossterm's async
-    /// [`EventStream`].
-    pub async fn run<S, V, U>(
-        &self,
-        theme: &Theme,
-        state: &mut S,
-        view: V,
-        update: U,
-    ) -> io::Result<()>
-    where
-        V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
-    {
-        let graphics = FrameGraphics::detected();
-        self.run_with_backend_inner(
-            theme,
-            CrosstermBackend::new(io::stdout()),
-            state,
-            owned_view(view),
-            update,
-            Some(&graphics),
-        )
-        .await
+    /// `frames` is either `&mut app` for an [`AsyncApplication`] or
+    /// [`async_from_fn`] over a state value and closures. Enters a
+    /// [`TerminalSession`] (restored on return, including on error or panic) and
+    /// reads input from crossterm's async [`EventStream`].
+    pub async fn run<F: AsyncFrameSource>(&self, theme: &Theme, frames: F) -> io::Result<()> {
+        self.run_with_messages(theme, frames, no_messages()).await
     }
 
     /// Run on the real terminal while also receiving typed application
@@ -266,38 +290,20 @@ impl AsyncRunner {
     ///
     /// A background producer can send domain values through any Tokio
     /// [`Stream`] without shared mutable state, synthetic terminal events, or
-    /// polling ticks. A completed message stream disables only that input;
+    /// polling ticks. They arrive as [`Signal::Message`], so the frame source is
+    /// the same one [`run`](Self::run) takes, at `M` instead of the default
+    /// [`Infallible`]. A completed message stream disables only that input;
     /// terminal events and ticks continue. Stream errors are propagated after
     /// terminal cleanup.
-    pub async fn run_with_messages<S, M, V, U, MS>(
+    pub async fn run_with_messages<M, F, MS>(
         &self,
         theme: &Theme,
-        state: &mut S,
+        mut frames: F,
         messages: MS,
-        view: V,
-        update: U,
     ) -> io::Result<()>
     where
+        F: AsyncFrameSource<M>,
         MS: Stream<Item = io::Result<M>> + Unpin,
-        V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
-    {
-        self.run_with_messages_inner(theme, state, messages, owned_view(view), update)
-            .await
-    }
-
-    async fn run_with_messages_inner<S, M, V, U, MS>(
-        &self,
-        theme: &Theme,
-        state: &mut S,
-        messages: MS,
-        view: V,
-        update: U,
-    ) -> io::Result<()>
-    where
-        MS: Stream<Item = io::Result<M>> + Unpin,
-        V: FnMut(&S, u64, PaintRoot<'_>),
-        U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
     {
         let graphics = FrameGraphics::detected();
         let mode = self.config.screen_mode;
@@ -318,234 +324,15 @@ impl AsyncRunner {
             Err(error) => Some(Err(error)),
         });
         let result = self
-            .run_with_events_and_messages_inner(
+            .run_inner(
                 &mut terminal,
                 theme,
-                state,
+                &mut frames,
                 events,
                 messages,
-                view,
-                update,
                 Some(&graphics),
                 |copied| {
                     graphics.finish_frame()?;
-                    if let Some(text) = copied {
-                        let _ = crate::term::clipboard::write(&mut io::stdout(), text)?;
-                    }
-                    Ok(())
-                },
-            )
-            .await;
-        if mode.is_alternate() {
-            let _ = terminal.clear();
-        } else {
-            let _ = close_footer(&mut terminal);
-        }
-        result
-    }
-
-    /// Run a data-driven [`AsyncApplication`] on the real terminal.
-    ///
-    /// The borrowed-view counterpart to [`run`](Self::run), and the async
-    /// counterpart to [`Runner::run_app`](crate::Runner::run_app). It uses the
-    /// same terminal lifecycle, scheduling, redraw, and split-footer behavior.
-    pub async fn run_app<A: AsyncApplication>(&self, theme: &Theme, app: &mut A) -> io::Result<()> {
-        let graphics = FrameGraphics::detected();
-        self.run_with_backend_inner(
-            theme,
-            CrosstermBackend::new(io::stdout()),
-            app,
-            app_view(),
-            async |app: &mut A, signal| app.update(signal).await,
-            Some(&graphics),
-        )
-        .await
-    }
-
-    /// Run a data-driven [`AsyncApplication`] that also receives typed
-    /// application `messages`.
-    ///
-    /// The borrowed-view counterpart to
-    /// [`run_with_messages`](Self::run_with_messages). The application
-    /// implements `AsyncApplication<AsyncSignal<M>>`, so ticks, terminal
-    /// events, and messages all arrive through the one `update`.
-    pub async fn run_app_with_messages<A, M, MS>(
-        &self,
-        theme: &Theme,
-        app: &mut A,
-        messages: MS,
-    ) -> io::Result<()>
-    where
-        A: AsyncApplication<AsyncSignal<M>>,
-        MS: Stream<Item = io::Result<M>> + Unpin,
-    {
-        self.run_with_messages_inner(
-            theme,
-            app,
-            messages,
-            app_view(),
-            async |app: &mut A, signal| app.update(signal).await,
-        )
-        .await
-    }
-
-    /// Run a data-driven [`AsyncApplication`] against a caller-owned terminal
-    /// and event stream.
-    ///
-    /// The borrowed-view counterpart to
-    /// [`run_with_events`](Self::run_with_events), with the same contract: no
-    /// terminal lifecycle, and the backend and stream share the run's error
-    /// type `Er`.
-    pub async fn run_app_with_events<A, B, E, Er>(
-        &self,
-        terminal: &mut Terminal<B>,
-        theme: &Theme,
-        app: &mut A,
-        events: E,
-    ) -> Result<(), Er>
-    where
-        A: AsyncApplication,
-        B: Backend<Error = Er>,
-        E: Stream<Item = Result<Event, Er>> + Unpin,
-    {
-        self.run_with_events_inner(
-            terminal,
-            theme,
-            app,
-            events,
-            app_view(),
-            async |app: &mut A, signal| app.update(signal).await,
-            None,
-            |_| Ok(()),
-        )
-        .await
-    }
-
-    /// Run a data-driven [`AsyncApplication`] with a caller-provided backend.
-    ///
-    /// The borrowed-view counterpart to
-    /// [`run_with_backend`](Self::run_with_backend).
-    pub async fn run_app_with_backend<A, B>(
-        &self,
-        theme: &Theme,
-        backend: B,
-        app: &mut A,
-    ) -> io::Result<()>
-    where
-        A: AsyncApplication,
-        B: Backend<Error = io::Error>,
-    {
-        self.run_with_backend_inner(
-            theme,
-            backend,
-            app,
-            app_view(),
-            async |app: &mut A, signal| app.update(signal).await,
-            None,
-        )
-        .await
-    }
-
-    /// Run a data-driven [`AsyncApplication`] against a caller-owned terminal,
-    /// event stream, and message stream.
-    ///
-    /// The borrowed-view counterpart to
-    /// [`run_with_events_and_messages`](Self::run_with_events_and_messages).
-    pub async fn run_app_with_events_and_messages<A, M, B, E, MS, Er>(
-        &self,
-        terminal: &mut Terminal<B>,
-        theme: &Theme,
-        app: &mut A,
-        events: E,
-        messages: MS,
-    ) -> Result<(), Er>
-    where
-        A: AsyncApplication<AsyncSignal<M>>,
-        B: Backend<Error = Er>,
-        E: Stream<Item = Result<Event, Er>> + Unpin,
-        MS: Stream<Item = Result<M, Er>> + Unpin,
-    {
-        self.run_with_events_and_messages_inner(
-            terminal,
-            theme,
-            app,
-            events,
-            messages,
-            app_view(),
-            async |app: &mut A, signal| app.update(signal).await,
-            None,
-            |_| Ok(()),
-        )
-        .await
-    }
-
-    /// Run with a caller-provided backend, such as
-    /// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend). Otherwise identical to
-    /// [`run`](Self::run): it owns the [`TerminalSession`] and the
-    /// [`EventStream`].
-    pub async fn run_with_backend<S, B, V, U>(
-        &self,
-        theme: &Theme,
-        backend: B,
-        state: &mut S,
-        view: V,
-        update: U,
-    ) -> io::Result<()>
-    where
-        B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
-    {
-        self.run_with_backend_inner(theme, backend, state, owned_view(view), update, None)
-            .await
-    }
-
-    async fn run_with_backend_inner<S, B, V, U>(
-        &self,
-        theme: &Theme,
-        backend: B,
-        state: &mut S,
-        view: V,
-        update: U,
-        graphics: Option<&FrameGraphics>,
-    ) -> io::Result<()>
-    where
-        B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64, PaintRoot<'_>),
-        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
-    {
-        let mode = self.config.screen_mode;
-        let _session = if let Some(config) = self.session_config {
-            TerminalSession::enter_config(config)?
-        } else {
-            TerminalSession::enter_with(mode)?
-        };
-        let mut terminal = Terminal::with_options(
-            backend,
-            TerminalOptions {
-                viewport: mode.viewport(),
-            },
-        )?;
-        let _graphics_cleanup = graphics.map(FrameGraphicsCleanup);
-        // Translate crossterm events to tuika events at the stream boundary,
-        // dropping the ones tuika does not model and surfacing read errors.
-        let events = EventStream::new().filter_map(|result| match result {
-            Ok(raw) => translate_event(raw).map(Ok),
-            Err(error) => Some(Err(error)),
-        });
-        let result = self
-            .run_with_events_inner(
-                &mut terminal,
-                theme,
-                state,
-                events,
-                view,
-                update,
-                graphics,
-                |copied| {
-                    if let Some(graphics) = graphics {
-                        graphics.finish_frame()?;
-                    }
                     if let Some(text) = copied {
                         let _ = crate::term::clipboard::write(&mut io::stdout(), text)?;
                     }
@@ -567,23 +354,100 @@ impl AsyncRunner {
         result
     }
 
-    /// The core loop: caller-owned `terminal` and `events`, no terminal
-    /// lifecycle. This is what [`run`](Self::run) builds on, and the seam tests
-    /// use to drive the runner against a
-    /// [`TestBackend`](ratatui_core::backend::TestBackend) with a scripted event
-    /// stream. Hosts that already own their terminal and event source (or want a
-    /// non-crossterm one) can call it directly.
+    /// Run with a caller-provided backend, such as
+    /// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend). Otherwise
+    /// identical to [`run`](Self::run): it owns the [`TerminalSession`] and the
+    /// [`EventStream`].
+    pub async fn run_with_backend<F, B>(
+        &self,
+        theme: &Theme,
+        backend: B,
+        mut frames: F,
+    ) -> io::Result<()>
+    where
+        F: AsyncFrameSource,
+        B: Backend<Error = io::Error>,
+    {
+        let mode = self.config.screen_mode;
+        let _session = if let Some(config) = self.session_config {
+            TerminalSession::enter_config(config)?
+        } else {
+            TerminalSession::enter_with(mode)?
+        };
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: mode.viewport(),
+            },
+        )?;
+        let events = EventStream::new().filter_map(|result| match result {
+            Ok(raw) => translate_event(raw).map(Ok),
+            Err(error) => Some(Err(error)),
+        });
+        let result = self
+            .run_inner(
+                &mut terminal,
+                theme,
+                &mut frames,
+                events,
+                no_messages(),
+                None,
+                |_| Ok(()),
+            )
+            .await;
+        if mode.is_alternate() {
+            let _ = terminal.clear();
+        } else {
+            let _ = close_footer(&mut terminal);
+        }
+        result
+    }
+
+    /// Run against a caller-owned terminal and input streams, with no terminal
+    /// lifecycle of the runner's own.
     ///
-    /// The backend error and the event-stream error share one type `Er`, which
-    /// is the run's error type: for the real terminal that is [`io::Error`], but
+    /// This is the loop itself, and what [`run`](Self::run) builds on. The seam
+    /// tests drive it against a
+    /// [`TestBackend`](ratatui_core::backend::TestBackend) with scripted
+    /// streams; hosts that already own their terminal and event source (or want
+    /// a non-crossterm one) can call it directly. Pass [`no_messages`] when
+    /// there is no application stream.
+    ///
+    /// The backend error and both stream errors share one type `Er`, which is
+    /// the run's error type: for the real terminal that is [`io::Error`], but
     /// leaving it generic lets an infallible backend
     /// ([`TestBackend`](ratatui_core::backend::TestBackend), whose error is
-    /// [`Infallible`](std::convert::Infallible)) pair with an infallible stream.
+    /// [`Infallible`]) pair with infallible streams.
     ///
-    /// `events` yields already-translated tuika [`Event`]s. An `Err` item ends
-    /// the run by propagating out; `None` (a finite stream running dry) stops
-    /// event delivery but leaves the tick timer running, so the loop still exits
-    /// only when `update` returns [`UpdateResult::Exit`].
+    /// `events` yields already-translated tuika [`Event`]s. An `Err` item from
+    /// either stream ends the run by propagating out; `None` (a finite stream
+    /// running dry) stops that source but leaves the tick timer running, so the
+    /// loop still exits only on [`UpdateResult::Exit`].
+    pub async fn run_driven_by<M, F, B, E, MS, Er>(
+        &self,
+        terminal: &mut Terminal<B>,
+        theme: &Theme,
+        mut frames: F,
+        events: E,
+        messages: MS,
+    ) -> Result<(), Er>
+    where
+        F: AsyncFrameSource<M>,
+        B: Backend<Error = Er>,
+        E: Stream<Item = Result<Event, Er>> + Unpin,
+        MS: Stream<Item = Result<M, Er>> + Unpin,
+    {
+        self.run_inner(terminal, theme, &mut frames, events, messages, None, |_| {
+            Ok(())
+        })
+        .await
+    }
+
+    /// Run with caller-owned terminal and event stream.
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `run_driven_by(terminal, theme, async_from_fn(state, view, update), events, no_messages())`"
+    )]
     pub async fn run_with_events<S, B, V, U, E, Er>(
         &self,
         terminal: &mut Terminal<B>,
@@ -599,26 +463,22 @@ impl AsyncRunner {
         V: FnMut(&S, u64) -> Element,
         U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
     {
-        self.run_with_events_inner(
+        self.run_driven_by(
             terminal,
             theme,
-            state,
+            async_from_fn(state, view, update),
             events,
-            owned_view(view),
-            update,
-            None,
-            |_| Ok(()),
+            no_messages(),
         )
         .await
     }
 
     /// Run with caller-owned terminal, terminal-event stream, and typed
     /// application-message stream.
-    ///
-    /// Both streams yield the backend's error type. Completion of either one
-    /// disables that source without busy-spinning; an error from either source
-    /// ends the run. Each delivered [`AsyncSignal`] independently controls
-    /// redraw and exit through [`UpdateResult`].
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `run_driven_by(terminal, theme, async_from_fn(state, view, update), events, messages)`"
+    )]
     #[allow(clippy::too_many_arguments)]
     pub async fn run_with_events_and_messages<S, M, B, V, U, E, MS, Er>(
         &self,
@@ -635,42 +495,35 @@ impl AsyncRunner {
         E: Stream<Item = Result<Event, Er>> + Unpin,
         MS: Stream<Item = Result<M, Er>> + Unpin,
         V: FnMut(&S, u64) -> Element,
-        U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
+        U: AsyncFnMut(&mut S, Signal<M>) -> UpdateResult,
     {
-        self.run_with_events_and_messages_inner(
+        self.run_driven_by(
             terminal,
             theme,
-            state,
+            async_from_fn(state, view, update),
             events,
             messages,
-            owned_view(view),
-            update,
-            None,
-            |_| Ok(()),
         )
         .await
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn run_with_events_and_messages_inner<S, M, B, V, U, E, MS, Er, F>(
+    async fn run_inner<M, S, B, E, MS, Er, Finish>(
         &self,
         terminal: &mut Terminal<B>,
         theme: &Theme,
-        state: &mut S,
+        frames: &mut S,
         mut events: E,
         mut messages: MS,
-        mut view: V,
-        mut update: U,
         graphics: Option<&FrameGraphics>,
-        mut finish_frame: F,
+        mut finish_frame: Finish,
     ) -> Result<(), Er>
     where
+        S: AsyncFrameSource<M>,
         B: Backend<Error = Er>,
         E: Stream<Item = Result<Event, Er>> + Unpin,
         MS: Stream<Item = Result<M, Er>> + Unpin,
-        V: FnMut(&S, u64, PaintRoot<'_>),
-        U: AsyncFnMut(&mut S, AsyncSignal<M>) -> UpdateResult,
-        F: FnMut(Option<&str>) -> Result<(), Er>,
+        Finish: FnMut(Option<&str>) -> Result<(), Er>,
     {
         let mut events_done = false;
         let mut messages_done = false;
@@ -684,15 +537,7 @@ impl AsyncRunner {
             pin_footer(terminal)?;
         }
         if let RunnerAction::Render(frame) = core.next_action() {
-            let copied = draw(
-                terminal,
-                theme,
-                &mut view,
-                state,
-                frame,
-                graphics,
-                &mut selection,
-            )?;
+            let copied = draw(terminal, theme, frames, frame, graphics, &mut selection)?;
             finish_frame(copied.as_deref())?;
         }
         let mut last_frame = TokioInstant::now();
@@ -749,15 +594,7 @@ impl AsyncRunner {
                         terminal.autoresize()?;
                         pin_footer(terminal)?;
                     }
-                    let copied = draw(
-                        terminal,
-                        theme,
-                        &mut view,
-                        state,
-                        frame,
-                        graphics,
-                        &mut selection,
-                    )?;
+                    let copied = draw(terminal, theme, frames, frame, graphics, &mut selection)?;
                     finish_frame(copied.as_deref())?;
                     last_frame = TokioInstant::now();
                 }
@@ -766,16 +603,16 @@ impl AsyncRunner {
             }
 
             let (signal, selection_event) = match wake {
-                Wake::Tick => (AsyncSignal::Tick, None),
+                Wake::Tick => (Signal::Tick, None),
                 Wake::Event(event) => {
                     let selection = Some(event.clone());
-                    (AsyncSignal::Event(event), selection)
+                    (Signal::Event(event), selection)
                 }
-                Wake::Message(message) => (AsyncSignal::Message(message), None),
+                Wake::Message(message) => (Signal::Message(message), None),
                 Wake::Redraw | Wake::Requested => unreachable!("handled above"),
             };
             let requires_redraw = signal.requires_redraw();
-            let result = update(state, signal).await;
+            let result = frames.update(signal).await;
             core.apply(result);
             if core.is_exited() {
                 break;
@@ -808,15 +645,7 @@ impl AsyncRunner {
                         terminal.autoresize()?;
                         pin_footer(terminal)?;
                     }
-                    let copied = draw(
-                        terminal,
-                        theme,
-                        &mut view,
-                        state,
-                        frame,
-                        graphics,
-                        &mut selection,
-                    )?;
+                    let copied = draw(terminal, theme, frames, frame, graphics, &mut selection)?;
                     finish_frame(copied.as_deref())?;
                     last_frame = TokioInstant::now();
                 }
@@ -826,68 +655,26 @@ impl AsyncRunner {
 
         Ok(())
     }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn run_with_events_inner<S, B, V, U, E, Er, F>(
-        &self,
-        terminal: &mut Terminal<B>,
-        theme: &Theme,
-        state: &mut S,
-        events: E,
-        view: V,
-        mut update: U,
-        graphics: Option<&FrameGraphics>,
-        finish_frame: F,
-    ) -> Result<(), Er>
-    where
-        B: Backend<Error = Er>,
-        E: Stream<Item = Result<Event, Er>> + Unpin,
-        V: FnMut(&S, u64, PaintRoot<'_>),
-        U: AsyncFnMut(&mut S, Signal) -> UpdateResult,
-        F: FnMut(Option<&str>) -> Result<(), Er>,
-    {
-        self.run_with_events_and_messages_inner(
-            terminal,
-            theme,
-            state,
-            events,
-            tokio_stream::empty::<Result<std::convert::Infallible, Er>>(),
-            view,
-            async move |state, signal| match signal {
-                AsyncSignal::Tick => update(state, Signal::Tick).await,
-                AsyncSignal::Event(event) => update(state, Signal::Event(event)).await,
-                AsyncSignal::Message(never) => match never {},
-            },
-            graphics,
-            finish_frame,
-        )
-        .await
-    }
 }
 
-/// Paint one numbered frame from the current `state`.
-///
-/// `view` hands its root to a painting callback rather than returning it, which
-/// is what lets the same loop serve an owned [`Element`] and a frame-borrowed
-/// [`ScopedElement`]: the borrow only has to outlive the call, not the return.
-fn draw<S, B, V, Er>(
+/// Paint one numbered frame from the current frame source.
+fn draw<M, S, B, Er>(
     terminal: &mut Terminal<B>,
     theme: &Theme,
-    view: &mut V,
-    state: &S,
+    frames: &mut S,
     frame: u64,
     graphics: Option<&FrameGraphics>,
     selection: &mut RunnerSelection,
 ) -> Result<Option<String>, Er>
 where
     B: Backend<Error = Er>,
-    V: FnMut(&S, u64, PaintRoot<'_>),
+    S: AsyncFrameSource<M>,
 {
     let mut copied = None;
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
-        view(state, frame, &mut |root| {
+        frames.frame(frame, &mut |root| {
             paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root, &[]);
         });
         copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);
@@ -895,15 +682,12 @@ where
     Ok(copied)
 }
 
-/// Adapt an owned-`Element` view closure to the painting-callback form.
-fn owned_view<S, V>(mut view: V) -> impl FnMut(&S, u64, PaintRoot<'_>)
-where
-    V: FnMut(&S, u64) -> Element,
-{
-    move |state, frame, paint_root| {
-        let root = view(state, frame);
-        paint_root(root.as_ref());
-    }
+/// An empty application-message stream, for a loop that has none.
+///
+/// The message type is [`Infallible`], so [`Signal::Message`] is uninhabited and
+/// an `update` that handles only ticks and events stays exhaustive.
+pub fn no_messages<Er>() -> impl Stream<Item = Result<Infallible, Er>> + Unpin {
+    tokio_stream::empty()
 }
 
 #[cfg(test)]
@@ -976,22 +760,25 @@ mod tests {
         ]);
 
         let result = runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut count,
+                async_from_fn(
+                    &mut count,
+                    |count, _frame| element(Text::raw(format!("count={count}"))),
+                    async |count, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
+                            UpdateResult::Exit
+                        }
+                        Signal::Event(Event::Key(_)) => {
+                            *count += 1;
+                            UpdateResult::Dirty
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |count, _frame| element(Text::raw(format!("count={count}"))),
-                async |count, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
-                        UpdateResult::Exit
-                    }
-                    Signal::Event(Event::Key(_)) => {
-                        *count += 1;
-                        UpdateResult::Dirty
-                    }
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await;
 
@@ -1016,19 +803,24 @@ mod tests {
         let events = tokio_stream::iter([key(KeyCode::Char('a')), key(KeyCode::Esc)]);
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |state, _frame| {
+                        views.set(views.get() + 1);
+                        element(Text::raw(format!("state={state}")))
+                    },
+                    async |_state, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
+                            UpdateResult::Exit
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |state, _frame| {
-                    views.set(views.get() + 1);
-                    element(Text::raw(format!("state={state}")))
-                },
-                async |_state, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1055,20 +847,25 @@ mod tests {
         ]);
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut mouse_events,
+                async_from_fn(
+                    &mut mouse_events,
+                    |_state, _frame| element(Text::raw("hello world")),
+                    async |mouse_events, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
+                            UpdateResult::Exit
+                        }
+                        Signal::Event(Event::Mouse(_)) => {
+                            *mouse_events += 1;
+                            UpdateResult::Clean
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |_state, _frame| element(Text::raw("hello world")),
-                async |mouse_events, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
-                    Signal::Event(Event::Mouse(_)) => {
-                        *mouse_events += 1;
-                        UpdateResult::Clean
-                    }
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1102,17 +899,22 @@ mod tests {
         ]);
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |_state, _frame| element(Text::raw("hello world")),
+                    async |_state, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
+                            UpdateResult::Exit
+                        }
+                        Signal::Event(Event::Mouse(_)) => UpdateResult::Consumed,
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |_state, _frame| element(Text::raw("hello world")),
-                async |_state, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
-                    Signal::Event(Event::Mouse(_)) => UpdateResult::Consumed,
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1135,25 +937,30 @@ mod tests {
         let events = tokio_stream::iter([mouse(MouseKind::ScrollDown, 0, 0), key(KeyCode::Esc)]);
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut scrolled,
+                async_from_fn(
+                    &mut scrolled,
+                    |scrolled, _frame| {
+                        element(Text::raw(if *scrolled { "line two" } else { "line one" }))
+                    },
+                    async |scrolled, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
+                            UpdateResult::Exit
+                        }
+                        Signal::Event(Event::Mouse(Mouse {
+                            kind: MouseKind::ScrollDown,
+                            ..
+                        })) => {
+                            *scrolled = true;
+                            UpdateResult::Dirty
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |scrolled, _frame| {
-                    element(Text::raw(if *scrolled { "line two" } else { "line one" }))
-                },
-                async |scrolled, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
-                    Signal::Event(Event::Mouse(Mouse {
-                        kind: MouseKind::ScrollDown,
-                        ..
-                    })) => {
-                        *scrolled = true;
-                        UpdateResult::Dirty
-                    }
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1178,19 +985,22 @@ mod tests {
         }));
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |_state, _frame| {
+                        views.set(views.get() + 1);
+                        element(Text::raw("frame"))
+                    },
+                    async |_state, signal| match signal {
+                        Signal::Tick if views.get() >= 2 => UpdateResult::Exit,
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |_state, _frame| {
-                    views.set(views.get() + 1);
-                    element(Text::raw("frame"))
-                },
-                async |_state, signal| match signal {
-                    Signal::Tick if views.get() >= 2 => UpdateResult::Exit,
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1212,13 +1022,16 @@ mod tests {
         let events = tokio_stream::iter([key(KeyCode::Esc)]);
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |state, _frame| element(Text::raw(*state)),
+                    async |_state, _signal| UpdateResult::Exit,
+                ),
                 events,
-                |state, _frame| element(Text::raw(*state)),
-                async |_state, _signal| UpdateResult::Exit,
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1241,24 +1054,27 @@ mod tests {
         let events = tokio_stream::iter(Vec::<Result<Event, Infallible>>::new());
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut ticks,
+                async_from_fn(
+                    &mut ticks,
+                    |ticks, _frame| element(Text::raw(format!("ticks={ticks}"))),
+                    async |ticks, signal| {
+                        if let Signal::Tick = signal {
+                            // Prove an await inside tick handling is fine.
+                            tokio::task::yield_now().await;
+                            *ticks += 1;
+                        }
+                        if *ticks >= 3 {
+                            UpdateResult::Exit
+                        } else {
+                            UpdateResult::Dirty
+                        }
+                    },
+                ),
                 events,
-                |ticks, _frame| element(Text::raw(format!("ticks={ticks}"))),
-                async |ticks, signal| {
-                    if let Signal::Tick = signal {
-                        // Prove an await inside tick handling is fine.
-                        tokio::task::yield_now().await;
-                        *ticks += 1;
-                    }
-                    if *ticks >= 3 {
-                        UpdateResult::Exit
-                    } else {
-                        UpdateResult::Dirty
-                    }
-                },
+                no_messages(),
             )
             .await
             .unwrap();
@@ -1302,27 +1118,30 @@ mod tests {
         let mut state = ();
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |_state, _frame| {
+                        element(Text::new(vec![
+                            ratatui_core::text::Line::from("FOOTER"),
+                            ratatui_core::text::Line::from("FOOTER"),
+                        ]))
+                    },
+                    async |_state, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
+                            UpdateResult::Exit
+                        }
+                        Signal::Event(_) => {
+                            scrollback.write(|_width| element(Text::raw("published")));
+                            UpdateResult::Dirty
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |_state, _frame| {
-                    element(Text::new(vec![
-                        ratatui_core::text::Line::from("FOOTER"),
-                        ratatui_core::text::Line::from("FOOTER"),
-                    ]))
-                },
-                async |_state, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Char('q') => {
-                        UpdateResult::Exit
-                    }
-                    Signal::Event(_) => {
-                        scrollback.write(|_width| element(Text::raw("published")));
-                        UpdateResult::Dirty
-                    }
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .expect("run");
@@ -1374,22 +1193,25 @@ mod tests {
 
         let mut ticks = 0u32;
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut ticks,
+                async_from_fn(
+                    &mut ticks,
+                    |_ticks, _frame| element(Text::raw("FOOTER")),
+                    async |ticks, _signal| {
+                        *ticks += 1;
+                        // Enough ticks for the spawned task to be polled and its
+                        // blocks flushed.
+                        if *ticks >= 8 {
+                            UpdateResult::Exit
+                        } else {
+                            UpdateResult::Clean
+                        }
+                    },
+                ),
                 tokio_stream::iter(Vec::<Result<Event, Infallible>>::new()),
-                |_ticks, _frame| element(Text::raw("FOOTER")),
-                async |ticks, _signal| {
-                    *ticks += 1;
-                    // Enough ticks for the spawned task to be polled and its
-                    // blocks flushed.
-                    if *ticks >= 8 {
-                        UpdateResult::Exit
-                    } else {
-                        UpdateResult::Clean
-                    }
-                },
+                no_messages(),
             )
             .await
             .expect("run");
@@ -1423,16 +1245,21 @@ mod tests {
         let mut state = ();
 
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |_state, _frame| element(Text::raw("frame")),
+                    async |_state, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
+                            UpdateResult::Exit
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 events,
-                |_state, _frame| element(Text::raw("frame")),
-                async |_state, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .expect("run");
@@ -1467,13 +1294,16 @@ mod tests {
         let events = tokio_stream::iter([Err::<Event, io::Error>(io::Error::other("boom"))]);
 
         let result = runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |_state, _frame| element(Text::raw("x")),
+                    async |_state, _signal| UpdateResult::Dirty,
+                ),
                 events,
-                |_state, _frame| element(Text::raw("x")),
-                async |_state, _signal| UpdateResult::Dirty,
+                no_messages(),
             )
             .await;
 
@@ -1500,25 +1330,27 @@ mod tests {
             tokio_stream::iter([Ok::<_, Infallible>(Message::Add(7)), Ok(Message::Exit)]);
 
         runner
-            .run_with_events_and_messages(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut count,
+                async_from_fn(
+                    &mut count,
+                    |count, _| element(Text::raw(format!("count={count}"))),
+                    async |count, signal| match signal {
+                        Signal::Event(Event::Key(_)) => {
+                            *count += 1;
+                            UpdateResult::Dirty
+                        }
+                        Signal::Message(Message::Add(value)) => {
+                            *count += value;
+                            UpdateResult::Dirty
+                        }
+                        Signal::Message(Message::Exit) => UpdateResult::Exit,
+                        Signal::Tick | Signal::Event(_) => UpdateResult::Clean,
+                    },
+                ),
                 events,
                 messages,
-                |count, _| element(Text::raw(format!("count={count}"))),
-                async |count, signal| match signal {
-                    AsyncSignal::Event(Event::Key(_)) => {
-                        *count += 1;
-                        UpdateResult::Dirty
-                    }
-                    AsyncSignal::Message(Message::Add(value)) => {
-                        *count += value;
-                        UpdateResult::Dirty
-                    }
-                    AsyncSignal::Message(Message::Exit) => UpdateResult::Exit,
-                    AsyncSignal::Tick | AsyncSignal::Event(_) => UpdateResult::Clean,
-                },
             )
             .await
             .unwrap();
@@ -1537,24 +1369,26 @@ mod tests {
         let mut ticks = 0u8;
 
         runner
-            .run_with_events_and_messages(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut ticks,
+                async_from_fn(
+                    &mut ticks,
+                    |ticks, _| element(Text::raw(format!("ticks={ticks}"))),
+                    async |ticks, signal| match signal {
+                        Signal::Tick => {
+                            *ticks += 1;
+                            if *ticks == 2 {
+                                UpdateResult::Exit
+                            } else {
+                                UpdateResult::Dirty
+                            }
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 tokio_stream::empty::<Result<Event, Infallible>>(),
                 tokio_stream::empty::<Result<(), Infallible>>(),
-                |ticks, _| element(Text::raw(format!("ticks={ticks}"))),
-                async |ticks, signal| match signal {
-                    AsyncSignal::Tick => {
-                        *ticks += 1;
-                        if *ticks == 2 {
-                            UpdateResult::Exit
-                        } else {
-                            UpdateResult::Dirty
-                        }
-                    }
-                    _ => UpdateResult::Clean,
-                },
             )
             .await
             .unwrap();
@@ -1585,31 +1419,33 @@ mod tests {
         ]);
 
         runner
-            .run_with_events_and_messages(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |state, _| {
+                        views.set(views.get() + 1);
+                        element(Text::raw(format!("state={state}")))
+                    },
+                    async |state, signal| match signal {
+                        Signal::Message(Message::Clean) => {
+                            *state = 1;
+                            UpdateResult::Clean
+                        }
+                        Signal::Message(Message::Dirty) => {
+                            *state = 2;
+                            UpdateResult::Dirty
+                        }
+                        Signal::Message(Message::Exit) => {
+                            *state = 3;
+                            UpdateResult::Exit
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 tokio_stream::empty::<Result<Event, Infallible>>(),
                 messages,
-                |state, _| {
-                    views.set(views.get() + 1);
-                    element(Text::raw(format!("state={state}")))
-                },
-                async |state, signal| match signal {
-                    AsyncSignal::Message(Message::Clean) => {
-                        *state = 1;
-                        UpdateResult::Clean
-                    }
-                    AsyncSignal::Message(Message::Dirty) => {
-                        *state = 2;
-                        UpdateResult::Dirty
-                    }
-                    AsyncSignal::Message(Message::Exit) => {
-                        *state = 3;
-                        UpdateResult::Exit
-                    }
-                    _ => UpdateResult::Clean,
-                },
             )
             .await
             .unwrap();
@@ -1636,14 +1472,16 @@ mod tests {
         let messages = tokio_stream::iter([Err::<(), io::Error>(io::Error::other("message boom"))]);
 
         let result = runner
-            .run_with_events_and_messages(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |_state, _| element(Text::raw("x")),
+                    async |_state, _signal| UpdateResult::Clean,
+                ),
                 tokio_stream::empty::<Result<Event, io::Error>>(),
                 messages,
-                |_state, _| element(Text::raw("x")),
-                async |_state, _signal| UpdateResult::Clean,
             )
             .await;
 
@@ -1703,7 +1541,7 @@ mod tests {
     // does: events mutate through `&mut self`, and the frame borrows `&self`
     // without cloning into an owned tree.
     #[tokio::test]
-    async fn run_app_paints_a_borrowed_view() {
+    async fn an_application_paints_a_borrowed_view() {
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
             ..RunnerConfig::default()
@@ -1720,7 +1558,13 @@ mod tests {
         ]);
 
         runner
-            .run_app_with_events(&mut terminal, &Theme::default(), &mut app, events)
+            .run_driven_by(
+                &mut terminal,
+                &Theme::default(),
+                &mut app,
+                events,
+                no_messages(),
+            )
             .await
             .expect("run");
 
@@ -1738,11 +1582,11 @@ mod tests {
         items: Vec<u8>,
     }
 
-    impl AsyncApplication<AsyncSignal<u8>> for Feed {
-        async fn update(&mut self, signal: AsyncSignal<u8>) -> UpdateResult {
+    impl AsyncApplication<u8> for Feed {
+        async fn update(&mut self, signal: Signal<u8>) -> UpdateResult {
             match signal {
-                AsyncSignal::Message(0) => UpdateResult::Exit,
-                AsyncSignal::Message(item) => {
+                Signal::Message(0) => UpdateResult::Exit,
+                Signal::Message(item) => {
                     self.items.push(item);
                     UpdateResult::Dirty
                 }
@@ -1756,7 +1600,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn run_app_receives_messages_through_the_same_seam() {
+    async fn an_application_receives_messages_through_the_same_seam() {
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
             ..RunnerConfig::default()
@@ -1766,7 +1610,7 @@ mod tests {
         let messages = tokio_stream::iter([Ok::<u8, Infallible>(7), Ok(9), Ok(0)]);
 
         runner
-            .run_app_with_events_and_messages(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
                 &mut app,
@@ -1811,20 +1655,25 @@ mod tests {
 
         let mut state = std::sync::Arc::clone(&counter);
         runner
-            .run_with_events(
+            .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
-                &mut state,
+                async_from_fn(
+                    &mut state,
+                    |state, _frame| {
+                        views.set(views.get() + 1);
+                        let value = state.load(std::sync::atomic::Ordering::Acquire);
+                        element(Text::raw(format!("value={value}")))
+                    },
+                    async |_state, signal| match signal {
+                        Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => {
+                            UpdateResult::Exit
+                        }
+                        _ => UpdateResult::Clean,
+                    },
+                ),
                 ReceiverStream::new(receiver),
-                |state, _frame| {
-                    views.set(views.get() + 1);
-                    let value = state.load(std::sync::atomic::Ordering::Acquire);
-                    element(Text::raw(format!("value={value}")))
-                },
-                async |_state, signal| match signal {
-                    Signal::Event(Event::Key(k)) if k.code == KeyCode::Esc => UpdateResult::Exit,
-                    _ => UpdateResult::Clean,
-                },
+                no_messages(),
             )
             .await
             .expect("run");

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -233,10 +233,15 @@ impl AsyncRunner {
     /// Return a handle that background producers can use to request redraws.
     ///
     /// The counterpart to [`Runner::redraw_handle`](crate::Runner::redraw_handle),
-    /// so a [`Live`](crate::live::Live) value works the same on either runner. A
-    /// producer that owns domain data it wants delivered *into* `update` should
-    /// prefer a message stream ([`run_with_messages`](Self::run_with_messages));
-    /// a redraw request only says the next frame is stale.
+    /// so a [`Live`](crate::live::Live) value works the same on either runner —
+    /// here it wakes the parked `select!` rather than waiting for the next tick.
+    ///
+    /// A request says only *the next frame is stale*, and requests coalesce: the
+    /// handle is a flag, so a burst produces one repaint. That is the right
+    /// primitive when the producer owns data the view re-reads each frame. When
+    /// each arrival instead needs `update` to decide something — mutate specific
+    /// state, open a dialog, exit — send it as a message and let the runner
+    /// deliver it: see [`run_with_messages`](Self::run_with_messages).
     pub fn redraw_handle(&self) -> RedrawHandle {
         self.redraw.clone()
     }
@@ -285,16 +290,82 @@ impl AsyncRunner {
         self.run_with_messages(theme, frames, no_messages()).await
     }
 
-    /// Run on the real terminal while also receiving typed application
-    /// `messages`.
+    /// Run on the real terminal, waking on values from the host's own program
+    /// as well as on input.
     ///
-    /// A background producer can send domain values through any Tokio
-    /// [`Stream`] without shared mutable state, synthetic terminal events, or
-    /// polling ticks. They arrive as [`Signal::Message`], so the frame source is
-    /// the same one [`run`](Self::run) takes, at `M` instead of the default
-    /// [`Infallible`]. A completed message stream disables only that input;
-    /// terminal events and ticks continue. Stream errors are propagated after
+    /// # When to use this
+    ///
+    /// Ask one question: **does `update` need to decide something about each
+    /// arrival, or does the frame just need to re-read the newest value?**
+    ///
+    /// - *Re-read* — the producer owns a value the view reads every frame (a
+    ///   gauge, a cached snapshot). Keep it in a [`Live`](crate::live::Live)
+    ///   and mark the frame stale with [`redraw_handle`](Self::redraw_handle).
+    /// - *Decide* — reach for this. Each item becomes one
+    ///   [`Signal::Message`] and one `update` call, so it can mutate specific
+    ///   state, open a dialog, or return [`UpdateResult::Exit`].
+    ///
+    /// The sharp difference: **redraw requests coalesce, messages do not.** A
+    /// [`RedrawHandle`] is a flag, so five requests between frames make one
+    /// repaint. Every message gets its own `update`, which is what lets each
+    /// arrival mean something different.
+    ///
+    /// Typical producers:
+    ///
+    /// - a child process's stdout, where each line appends to a transcript and
+    ///   some lines also change state
+    /// - a model or agent token stream, where tokens feed a
+    ///   [`MarkdownState`](crate::components::markdown::MarkdownState) and a
+    ///   final `Done` re-enables input
+    /// - a websocket or SSE feed — CI results, prices, chat
+    /// - a worker reporting `Progress` / `Failed` / `Finished`, the last of
+    ///   which may end the run
+    /// - another task asking the UI to do something ("open settings", "quit"),
+    ///   which is otherwise faked with a synthetic key event
+    ///
+    /// Do *not* use it to poll on a schedule; that is what [`Signal::Tick`] is
+    /// for.
+    ///
+    /// # Mechanics
+    ///
+    /// The producer sends through any Tokio [`Stream`], so no shared mutable
+    /// state, synthetic terminal events, or short polling interval is needed.
+    /// The frame source is the one [`run`](Self::run) takes, at `M` instead of
+    /// the default [`Infallible`]. A completed message stream disables only
+    /// that input — ticks and terminal events continue, so a finite producer
+    /// does not end the UI. A stream error ends the run and is propagated after
     /// terminal cleanup.
+    ///
+    /// ```no_run
+    /// # use tuika::prelude::*;
+    /// # use tokio_stream::wrappers::ReceiverStream;
+    /// # struct Tail { lines: Vec<String>, failed: bool }
+    /// impl AsyncApplication<String> for Tail {
+    ///     async fn update(&mut self, signal: Signal<String>) -> UpdateResult {
+    ///         match signal {
+    ///             // Every line is seen, and one of them means more than "repaint".
+    ///             Signal::Message(line) => {
+    ///                 self.failed |= line.starts_with("error:");
+    ///                 self.lines.push(line);
+    ///                 UpdateResult::Dirty
+    ///             }
+    ///             Signal::Event(Event::Key(key)) if key.code == KeyCode::Esc => UpdateResult::Exit,
+    ///             _ => UpdateResult::Clean,
+    ///         }
+    ///     }
+    ///
+    ///     fn view(&self, _frame: u64) -> ScopedElement<'_> {
+    ///         element(Text::raw(format!("{} lines", self.lines.len())))
+    ///     }
+    /// }
+    ///
+    /// # async fn run(runner: AsyncRunner, mut app: Tail,
+    /// #     rx: tokio::sync::mpsc::Receiver<std::io::Result<String>>) -> std::io::Result<()> {
+    /// runner
+    ///     .run_with_messages(&Theme::default(), &mut app, ReceiverStream::new(rx))
+    ///     .await
+    /// # }
+    /// ```
     pub async fn run_with_messages<M, F, MS>(
         &self,
         theme: &Theme,

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -177,12 +177,13 @@ impl Default for RunnerConfig {
     }
 }
 
-/// A signal delivered to a runner update function.
+/// Why a runner is calling `update`: a tick, terminal input, or a value the
+/// host's own program produced.
 ///
-/// `M` is the host's application-message type, for a loop that also selects
-/// over a message stream. It defaults to [`Infallible`], the uninhabited type:
-/// a plain `Signal` therefore *has* no `Message` variant to construct or match,
-/// and code that handles only ticks and events stays exhaustive.
+/// `M` is that last one's type, for a loop that also selects over a message
+/// stream. It defaults to [`Infallible`], the uninhabited type: a plain
+/// `Signal` therefore *has* no [`Message`](Self::Message) variant to construct
+/// or match, and code that handles only ticks and events stays exhaustive.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Signal<M = Infallible> {
     /// The configured tick interval elapsed.
@@ -190,8 +191,15 @@ pub enum Signal<M = Infallible> {
     /// A translated terminal input event arrived. Resize events force a redraw
     /// after the update unless it exits, even when the update is clean.
     Event(Event),
-    /// A host or background producer sent an application message. Unreachable
-    /// unless the runner was given a message stream.
+    /// A value from the host's own program — a background task, a worker, a
+    /// feed — delivered through the runner's message stream. Unreachable unless
+    /// the runner was given one.
+    ///
+    /// **This is not the Elm/Iced `Msg`.** There, one message type carries
+    /// *everything* that reaches `update`, key presses included. Here a key
+    /// press is [`Event`](Self::Event) and the clock is [`Tick`](Self::Tick);
+    /// this variant is only for what the terminal did not produce. See
+    /// [`AsyncRunner::run_with_messages`] for when to reach for it.
     Message(M),
 }
 
@@ -464,6 +472,19 @@ impl Runner {
     }
 
     /// Return a handle that background producers can use to request redraws.
+    ///
+    /// A request says only *the next frame is stale*, and requests coalesce: the
+    /// handle is a flag, so a burst produces one repaint. Pair it with a
+    /// [`Live`](crate::live::Live) (or any shared value) the view re-reads each
+    /// frame.
+    ///
+    /// When each arrival instead needs `update` to decide something, an
+    /// [`AsyncRunner`] can deliver it as a [`Signal::Message`] through
+    /// [`run_with_messages`](AsyncRunner::run_with_messages). The synchronous
+    /// loop has no equivalent: it blocks in `crossterm::event::poll`, which a
+    /// channel send cannot wake, so a message would arrive no sooner than the
+    /// next tick. A synchronous host wanting that shape drives its own loop with
+    /// [`crate::paint`].
     pub fn redraw_handle(&self) -> RedrawHandle {
         self.redraw.clone()
     }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -23,54 +23,63 @@
 //!
 //! # Choosing a `run` method
 //!
-//! There is one loop; the `run*` methods are its **axes**, not variants. Each
-//! name is built from the axes it departs from the default on:
+//! There is one loop and one seam, so the surface is small. Every run method
+//! takes a [`FrameSource`] — `&mut app` for an [`Application`], or [`from_fn`]
+//! for the closure form — and the remaining names say only where the terminal
+//! and the input come from:
 //!
-//! `run` `[_app]` `[_with_backend | _with_events]` `[_and_messages]`
-//!
-//! | Axis | Default | Alternative |
+//! | Method | Terminal | Input |
 //! | --- | --- | --- |
-//! | Frame source | closure pair over `&State` | `_app`: an [`Application`] that borrows itself |
-//! | Terminal | the runner enters a [`TerminalSession`] | `_with_backend`: caller's backend; `_with_events`: caller's terminal *and* event stream |
-//! | Input | terminal events and ticks | `_and_messages` / `_with_messages`: a typed application stream |
+//! | [`Runner::run`] / [`AsyncRunner::run`] | the runner enters a [`TerminalSession`] | terminal events and ticks |
+//! | [`Runner::run_with_backend`] / [`AsyncRunner::run_with_backend`] | the runner enters a session over your backend | terminal events and ticks |
+//! | [`AsyncRunner::run_with_messages`] | the runner enters a session | plus a typed application stream |
+//! | [`AsyncRunner::run_driven_by`] | yours, no lifecycle | your event and message streams |
 //!
 //! The runtime axis is the runner you construct, and everything else — screen
 //! mode, tick rate, session policy, text selection — is [`RunnerConfig`] or a
 //! builder method rather than another name.
 //!
-//! The message axis is [`AsyncRunner`]-only: it needs a [`Stream`] to select
-//! over, and a synchronous loop has nothing to select with. A synchronous host
-//! whose background work produces data keeps that data behind a
-//! [`Live`](crate::live::Live) (or any shared value) and marks the frame stale
-//! through [`Runner::redraw_handle`]; both runners expose that handle.
+//! Messages ride the same [`Signal`] the loop always delivered:
+//! `Signal<M>::Message` carries them, and `M` defaults to the uninhabited
+//! [`Infallible`], so a source that never sees a message stream has no variant
+//! to handle. That is also why the message axis is [`AsyncRunner`]-only — it
+//! needs a Tokio `Stream` to select over, and a synchronous loop has nothing to
+//! select with. A synchronous host whose background work produces data keeps
+//! that data behind a [`Live`](crate::live::Live) (or any shared value) and
+//! marks the frame stale through [`Runner::redraw_handle`]; both runners expose
+//! that handle.
 //!
 //! # The two frame sources
 //!
-//! Both describe the same thing and neither is legacy:
+//! [`FrameSource`] has exactly two implementors, and neither is legacy:
 //!
-//! - **Closures** (`run`): `view: FnMut(&State, u64) -> Element` beside
-//!   `update: FnMut(&mut State, Signal)`. State is the runner's argument
-//!   because a closure cannot hold `&state` and `&mut state` at once. The view
-//!   closure is `FnMut`, so it may carry scratch state of its own, and it
-//!   returns an *owned* tree.
-//! - **An application** (`run_app`): [`Application`] (or [`AsyncApplication`]).
-//!   `view(&self)` returns a [`ScopedElement<'_>`](crate::ScopedElement) — a
-//!   tree that borrows the application for the frame — so a large transcript,
+//! - **An application** — [`Application`] (or [`AsyncApplication`]), passed as
+//!   `&mut app`. `view(&self)` returns a [`ScopedElement<'_>`](crate::ScopedElement):
+//!   a tree that borrows the application for the frame, so a large transcript,
 //!   table, or log is painted in place instead of being cloned into an owned
 //!   tree or shared through `Rc<RefCell<_>>`. The `&self` receiver also states
 //!   the contract the closure form only documents: rendering is pure.
+//! - **Closures** — [`from_fn`]`(&mut state, view, update)`. It renders an
+//!   *owned* [`Element`], but the view closure is `FnMut`, so it may keep
+//!   scratch state of its own.
 //!
-//! Since `Element` is `ScopedElement<'static>`, the application seam is the more
-//! general of the two in what it can *return*; the closure seam is the more
-//! permissive in how the view may *capture*. Start with closures, move to
+//! Since `Element` is `ScopedElement<'static>`, the application form is the more
+//! general of the two in what it can *return*; the closure form is the more
+//! permissive in how the view may *capture*. Start with closures, implement
 //! [`Application`] when a frame wants to borrow host data.
 
 #[cfg(feature = "async")]
 mod asynchronous;
 
 #[cfg(feature = "async")]
-pub use asynchronous::{AsyncApplication, AsyncRunner, AsyncSignal};
+#[allow(deprecated)]
+pub use asynchronous::AsyncSignal;
+#[cfg(feature = "async")]
+pub use asynchronous::{
+    AsyncApplication, AsyncFrameSource, AsyncFromFn, AsyncRunner, async_from_fn, no_messages,
+};
 
+use std::convert::Infallible;
 use std::io::{self, Write};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -169,16 +178,24 @@ impl Default for RunnerConfig {
 }
 
 /// A signal delivered to a runner update function.
+///
+/// `M` is the host's application-message type, for a loop that also selects
+/// over a message stream. It defaults to [`Infallible`], the uninhabited type:
+/// a plain `Signal` therefore *has* no `Message` variant to construct or match,
+/// and code that handles only ticks and events stays exhaustive.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Signal {
+pub enum Signal<M = Infallible> {
     /// The configured tick interval elapsed.
     Tick,
     /// A translated terminal input event arrived. Resize events force a redraw
     /// after the update unless it exits, even when the update is clean.
     Event(Event),
+    /// A host or background producer sent an application message. Unreachable
+    /// unless the runner was given a message stream.
+    Message(M),
 }
 
-impl Signal {
+impl<M> Signal<M> {
     fn requires_redraw(&self) -> bool {
         matches!(self, Self::Event(Event::Resize { .. }))
     }
@@ -201,7 +218,7 @@ pub enum UpdateResult {
     Exit,
 }
 
-/// A data-driven terminal application, driven by [`Runner::run_app`].
+/// A data-driven terminal application: what [`Runner::run`] drives.
 ///
 /// [`AsyncApplication`] is the same seam for a host whose `update` awaits;
 /// the split exists because only the runtime differs, not the contract.
@@ -214,14 +231,116 @@ pub enum UpdateResult {
 ///
 /// Rendering should be pure: persistent UI and domain state belongs on the
 /// application and changes only in [`update`](Self::update).
-pub trait Application {
-    /// Update application state in response to a tick or terminal event. Return
-    /// [`UpdateResult::Clean`] only when the signal was unhandled, or
-    /// [`UpdateResult::Consumed`] when it was handled without a repaint.
-    fn update(&mut self, signal: Signal) -> UpdateResult;
+pub trait Application<M = Infallible> {
+    /// Update application state in response to a tick, terminal event, or
+    /// message. Return [`UpdateResult::Clean`] only when the signal was
+    /// unhandled, or [`UpdateResult::Consumed`] when it was handled without a
+    /// repaint.
+    fn update(&mut self, signal: Signal<M>) -> UpdateResult;
 
     /// Build the ephemeral view tree for one numbered frame.
     fn view(&self, frame: u64) -> ScopedElement<'_>;
+}
+
+/// What a run loop pulls frames and update decisions from.
+///
+/// This is the runner's single seam, and the reason there is no separate `run`
+/// method per frame source. Two things implement it:
+///
+/// - `&mut A` where `A: Application` — the borrowed-view seam. Its `view(&self)`
+///   may return a tree that borrows the application for the frame.
+/// - [`from_fn`] — a `state` value beside `view`/`update` closures, for a host
+///   that would rather not name a type.
+///
+/// The painting callback is what unifies them: a source hands its root to the
+/// runner instead of returning it, so a borrowed tree only has to outlive the
+/// call. Implement [`Application`] rather than this trait; this one exists to
+/// be *dispatched* on.
+pub trait FrameSource<M = Infallible> {
+    /// Deliver one signal.
+    fn update(&mut self, signal: Signal<M>) -> UpdateResult;
+
+    /// Build one numbered frame and hand its root to `paint`.
+    fn frame(&mut self, frame: u64, paint: PaintRoot<'_>);
+}
+
+impl<M, A: Application<M>> FrameSource<M> for &mut A {
+    fn update(&mut self, signal: Signal<M>) -> UpdateResult {
+        Application::update(*self, signal)
+    }
+
+    fn frame(&mut self, frame: u64, paint: PaintRoot<'_>) {
+        paint(Application::view(*self, frame).as_ref());
+    }
+}
+
+/// A [`FrameSource`] built from a state value and a pair of closures.
+///
+/// Returned by [`from_fn`]; see it for the trade against implementing
+/// [`Application`].
+pub struct FromFn<'state, S, V, U> {
+    state: &'state mut S,
+    view: V,
+    update: U,
+}
+
+/// Build a [`FrameSource`] from `state` and closures over it.
+///
+/// The closure form of the seam. State is a separate argument rather than a
+/// capture because one closure needs `&state` while the other needs
+/// `&mut state`, and a single closure cannot hold both.
+///
+/// It renders an *owned* [`Element`], so a frame that wants to borrow host data
+/// wants [`Application`] instead. In exchange the view closure is `FnMut`, so
+/// it may keep scratch state of its own.
+///
+/// ```no_run
+/// use tuika::prelude::*;
+/// use tuika::runner::from_fn;
+///
+/// # fn main() -> std::io::Result<()> {
+/// let mut count = 0u32;
+/// Runner::new(RunnerConfig::default()).run(
+///     &Theme::default(),
+///     from_fn(
+///         &mut count,
+///         |count, _frame| element(Text::raw(format!("count: {count}"))),
+///         |count, signal| match signal {
+///             Signal::Event(Event::Key(key)) if key.code == KeyCode::Esc => UpdateResult::Exit,
+///             Signal::Event(Event::Key(_)) => {
+///                 *count += 1;
+///                 UpdateResult::Dirty
+///             }
+///             _ => UpdateResult::Clean,
+///         },
+///     ),
+/// )
+/// # }
+/// ```
+pub fn from_fn<S, V, U, M>(state: &mut S, view: V, update: U) -> FromFn<'_, S, V, U>
+where
+    V: FnMut(&S, u64) -> Element,
+    U: FnMut(&mut S, Signal<M>) -> UpdateResult,
+{
+    FromFn {
+        state,
+        view,
+        update,
+    }
+}
+
+impl<M, S, V, U> FrameSource<M> for FromFn<'_, S, V, U>
+where
+    V: FnMut(&S, u64) -> Element,
+    U: FnMut(&mut S, Signal<M>) -> UpdateResult,
+{
+    fn update(&mut self, signal: Signal<M>) -> UpdateResult {
+        (self.update)(self.state, signal)
+    }
+
+    fn frame(&mut self, frame: u64, paint: PaintRoot<'_>) {
+        paint((self.view)(self.state, frame).as_ref());
+    }
 }
 
 /// Runtime-neutral decision produced by [`RunnerCore`].
@@ -373,84 +492,45 @@ impl Runner {
             )
     }
 
-    /// Run until `update` returns [`UpdateResult::Exit`].
+    /// Run until the frame source returns [`UpdateResult::Exit`].
+    ///
+    /// `frames` is either `&mut app` for an [`Application`] or [`from_fn`] over
+    /// a state value and closures — see [`FrameSource`].
     ///
     /// The runner paints once initially. It then delivers input and periodic
-    /// [`Signal::Tick`] values to `update`, repainting only when `update`
-    /// returns [`UpdateResult::Dirty`] or a [`RedrawHandle`] requests it.
-    pub fn run<S, V, U>(
-        &self,
-        theme: &Theme,
-        state: &mut S,
-        mut view: V,
-        update: U,
-    ) -> io::Result<()>
-    where
-        V: FnMut(&S, u64) -> Element,
-        U: FnMut(&mut S, Signal) -> UpdateResult,
-    {
+    /// [`Signal::Tick`] values, repainting only on [`UpdateResult::Dirty`] or
+    /// when a [`RedrawHandle`] requests it.
+    pub fn run<F: FrameSource>(&self, theme: &Theme, mut frames: F) -> io::Result<()> {
         let graphics = FrameGraphics::detected();
-        self.run_with_backend_inner(
+        self.run_inner(
             theme,
             CrosstermBackend::new(io::stdout()),
-            state,
-            |state, frame, paint_root| {
-                let root = view(state, frame);
-                paint_root(root.as_ref());
-            },
-            update,
-            Some(&graphics),
-        )
-    }
-
-    /// Run a data-driven [`Application`] on the real terminal.
-    ///
-    /// This is the borrowed-view counterpart to [`run`](Self::run). It uses the
-    /// same terminal lifecycle, scheduling, redraw, and split-footer behavior.
-    pub fn run_app<A: Application>(&self, theme: &Theme, app: &mut A) -> io::Result<()> {
-        let graphics = FrameGraphics::detected();
-        self.run_with_backend_inner(
-            theme,
-            CrosstermBackend::new(io::stdout()),
-            app,
-            |app, frame, paint_root| {
-                let root = app.view(frame);
-                paint_root(root.as_ref());
-            },
-            Application::update,
+            &mut frames,
             Some(&graphics),
         )
     }
 
     /// Run with a caller-provided backend, such as
     /// [`HyperlinkBackend`](crate::term::hyperlink::HyperlinkBackend).
-    pub fn run_with_backend<S, B, V, U>(
-        &self,
-        theme: &Theme,
-        backend: B,
-        state: &mut S,
-        mut view: V,
-        update: U,
-    ) -> io::Result<()>
+    pub fn run_with_backend<F, B>(&self, theme: &Theme, backend: B, mut frames: F) -> io::Result<()>
     where
+        F: FrameSource,
         B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64) -> Element,
-        U: FnMut(&mut S, Signal) -> UpdateResult,
     {
-        self.run_with_backend_inner(
-            theme,
-            backend,
-            state,
-            |state, frame, paint_root| {
-                let root = view(state, frame);
-                paint_root(root.as_ref());
-            },
-            update,
-            None,
-        )
+        self.run_inner(theme, backend, &mut frames, None)
+    }
+
+    /// Run a data-driven [`Application`] on the real terminal.
+    #[deprecated(since = "0.9.0", note = "use `run(theme, &mut app)` instead")]
+    pub fn run_app<A: Application>(&self, theme: &Theme, app: &mut A) -> io::Result<()> {
+        self.run(theme, app)
     }
 
     /// Run a data-driven [`Application`] with a caller-provided backend.
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `run_with_backend(theme, backend, &mut app)` instead"
+    )]
     pub fn run_app_with_backend<A, B>(
         &self,
         theme: &Theme,
@@ -461,32 +541,19 @@ impl Runner {
         A: Application,
         B: Backend<Error = io::Error>,
     {
-        self.run_with_backend_inner(
-            theme,
-            backend,
-            app,
-            |app, frame, paint_root| {
-                let root = app.view(frame);
-                paint_root(root.as_ref());
-            },
-            Application::update,
-            None,
-        )
+        self.run_with_backend(theme, backend, app)
     }
 
-    fn run_with_backend_inner<S, B, V, U>(
+    fn run_inner<F, B>(
         &self,
         theme: &Theme,
         backend: B,
-        state: &mut S,
-        mut view: V,
-        mut update: U,
+        frames: &mut F,
         graphics: Option<&FrameGraphics>,
     ) -> io::Result<()>
     where
+        F: FrameSource,
         B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64, PaintRoot<'_>),
-        U: FnMut(&mut S, Signal) -> UpdateResult,
     {
         let mode = self.config.screen_mode;
         let split = !mode.is_alternate();
@@ -515,8 +582,7 @@ impl Runner {
             draw(
                 &mut terminal,
                 theme,
-                &mut view,
-                state,
+                frames,
                 frame,
                 graphics,
                 &mut selection,
@@ -544,7 +610,7 @@ impl Runner {
 
             if now.saturating_duration_since(last_tick) >= self.config.tick_rate {
                 last_tick = now;
-                let result = update(state, Signal::Tick);
+                let result = frames.update(Signal::Tick);
                 core.apply(result);
                 if core.is_exited() {
                     break;
@@ -563,8 +629,7 @@ impl Runner {
                     draw(
                         &mut terminal,
                         theme,
-                        &mut view,
-                        state,
+                        frames,
                         frame,
                         graphics,
                         &mut selection,
@@ -587,9 +652,9 @@ impl Runner {
                 let requires_redraw = signal.requires_redraw();
                 let selection_event = match &signal {
                     Signal::Event(event) => Some(event.clone()),
-                    Signal::Tick => None,
+                    _ => None,
                 };
-                let result = update(state, signal);
+                let result = frames.update(signal);
                 core.apply(result);
                 if core.is_exited() {
                     break 'running;
@@ -624,24 +689,23 @@ impl Runner {
 }
 
 /// Paint one numbered frame from immutable state.
-fn draw<S, B, V>(
+fn draw<F, B>(
     terminal: &mut Terminal<B>,
     theme: &Theme,
-    view: &mut V,
-    state: &S,
+    frames: &mut F,
     frame: u64,
     graphics: Option<&FrameGraphics>,
     selection: &mut RunnerSelection,
 ) -> io::Result<()>
 where
     B: Backend<Error = io::Error>,
-    V: FnMut(&S, u64, PaintRoot<'_>),
+    F: FrameSource,
 {
     let mut copied = None;
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
-        view(state, frame, &mut |root| {
+        frames.frame(frame, &mut |root| {
             paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root, &[]);
         });
         copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -19,17 +19,57 @@
 //! question about the host's existing runtime, not about which part of tuika to
 //! reach for.
 //!
-//! Synchronous applications whose views borrow their own state implement
-//! [`Application`] and run through [`Runner::run_app`]. The original
-//! state/view/update closure API remains available for owned [`Element`] trees.
-//!
 //! A host with its own event loop needs neither: call [`crate::paint`] directly.
+//!
+//! # Choosing a `run` method
+//!
+//! There is one loop; the `run*` methods are its **axes**, not variants. Each
+//! name is built from the axes it departs from the default on:
+//!
+//! `run` `[_app]` `[_with_backend | _with_events]` `[_and_messages]`
+//!
+//! | Axis | Default | Alternative |
+//! | --- | --- | --- |
+//! | Frame source | closure pair over `&State` | `_app`: an [`Application`] that borrows itself |
+//! | Terminal | the runner enters a [`TerminalSession`] | `_with_backend`: caller's backend; `_with_events`: caller's terminal *and* event stream |
+//! | Input | terminal events and ticks | `_and_messages` / `_with_messages`: a typed application stream |
+//!
+//! The runtime axis is the runner you construct, and everything else — screen
+//! mode, tick rate, session policy, text selection — is [`RunnerConfig`] or a
+//! builder method rather than another name.
+//!
+//! The message axis is [`AsyncRunner`]-only: it needs a [`Stream`] to select
+//! over, and a synchronous loop has nothing to select with. A synchronous host
+//! whose background work produces data keeps that data behind a
+//! [`Live`](crate::live::Live) (or any shared value) and marks the frame stale
+//! through [`Runner::redraw_handle`]; both runners expose that handle.
+//!
+//! # The two frame sources
+//!
+//! Both describe the same thing and neither is legacy:
+//!
+//! - **Closures** (`run`): `view: FnMut(&State, u64) -> Element` beside
+//!   `update: FnMut(&mut State, Signal)`. State is the runner's argument
+//!   because a closure cannot hold `&state` and `&mut state` at once. The view
+//!   closure is `FnMut`, so it may carry scratch state of its own, and it
+//!   returns an *owned* tree.
+//! - **An application** (`run_app`): [`Application`] (or [`AsyncApplication`]).
+//!   `view(&self)` returns a [`ScopedElement<'_>`](crate::ScopedElement) — a
+//!   tree that borrows the application for the frame — so a large transcript,
+//!   table, or log is painted in place instead of being cloned into an owned
+//!   tree or shared through `Rc<RefCell<_>>`. The `&self` receiver also states
+//!   the contract the closure form only documents: rendering is pure.
+//!
+//! Since `Element` is `ScopedElement<'static>`, the application seam is the more
+//! general of the two in what it can *return*; the closure seam is the more
+//! permissive in how the view may *capture*. Start with closures, move to
+//! [`Application`] when a frame wants to borrow host data.
 
 #[cfg(feature = "async")]
 mod asynchronous;
 
 #[cfg(feature = "async")]
-pub use asynchronous::{AsyncRunner, AsyncSignal};
+pub use asynchronous::{AsyncApplication, AsyncRunner, AsyncSignal};
 
 use std::io::{self, Write};
 use std::sync::Arc;
@@ -51,6 +91,13 @@ use crate::{
     Clock, Element, Event, RenderCtx, ScopedElement, SystemClock, TerminalSession, Theme, View,
     paint_with_context, translate_event,
 };
+
+/// Receives a frame's root view for painting.
+///
+/// A frame source hands its root to this callback instead of returning it,
+/// which is what lets one loop serve an owned [`Element`] and a tree that
+/// borrows application state: the borrow only has to outlive the call.
+pub(crate) type PaintRoot<'a> = &'a mut dyn FnMut(&dyn View);
 
 const RESIZE_FRAME_INTERVAL: Duration = Duration::from_millis(16);
 
@@ -154,7 +201,10 @@ pub enum UpdateResult {
     Exit,
 }
 
-/// A data-driven synchronous terminal application.
+/// A data-driven terminal application, driven by [`Runner::run_app`].
+///
+/// [`AsyncApplication`] is the same seam for a host whose `update` awaits;
+/// the split exists because only the runtime differs, not the contract.
 ///
 /// The runner mutably borrows the application only while delivering a
 /// [`Signal`], then immutably borrows it to build the next frame. Because the
@@ -435,7 +485,7 @@ impl Runner {
     ) -> io::Result<()>
     where
         B: Backend<Error = io::Error>,
-        V: FnMut(&S, u64, &mut dyn FnMut(&dyn View)),
+        V: FnMut(&S, u64, PaintRoot<'_>),
         U: FnMut(&mut S, Signal) -> UpdateResult,
     {
         let mode = self.config.screen_mode;
@@ -585,7 +635,7 @@ fn draw<S, B, V>(
 ) -> io::Result<()>
 where
     B: Backend<Error = io::Error>,
-    V: FnMut(&S, u64, &mut dyn FnMut(&dyn View)),
+    V: FnMut(&S, u64, PaintRoot<'_>),
 {
     let mut copied = None;
     terminal.draw(|terminal_frame| {


### PR DESCRIPTION
## What changed

The runner's `run*` surface was a cross product of four axes — frame source,
runtime, terminal ownership, extra input — encoded as method names. Ten of them
on `AsyncRunner`. A product encoded as names grows holes, and it had real ones:
a frame could borrow application state only on the *synchronous* runner, so a
Tokio host had to clone into an owned tree or reach for interior mutability
(`Rc` plus `RefCell`); and only `Runner` exposed a redraw handle, so `Live` —
documented as *the* data-driven primitive — silently did nothing on
`AsyncRunner`.

Two axes stop being names:

- **The frame source is an argument.** `FrameSource` has exactly two
  implementors — `&mut app` for an `Application`, and
  `from_fn(&mut state, view, update)` for the closure form — so no method has to
  name which one it takes, and the `_app` row disappears. This works because
  `FrameSource::frame` takes `&mut self` and a paint callback, which accommodates
  the closure seam's `FnMut` view *and* `Application`'s pure `&self` view without
  tightening either.
- **Messages ride the signal the loop always delivered.** `Signal` gained a
  message type parameter defaulting to the uninhabited `Infallible`, and carries
  them in a new `Message` variant. `AsyncSignal` becomes a deprecated alias.

What is left in the names is only where the terminal and the input come from:

| Method | Terminal | Input |
| --- | --- | --- |
| `Runner::run` / `AsyncRunner::run` | runner enters a `TerminalSession` | events + ticks |
| `Runner::run_with_backend` / `AsyncRunner::run_with_backend` | runner enters a session over your backend | events + ticks |
| `AsyncRunner::run_with_messages` | runner enters a session | plus a typed application stream |
| `AsyncRunner::run_driven_by` | yours, no lifecycle | your event and message streams |

`AsyncRunner`: 10 → 4. `Runner`: 4 → 2.

Also closed on the way: `AsyncApplication` (the borrowed-view seam for the async
runner) and `AsyncRunner::redraw_handle`. `RedrawHandle` now registers the
waiting task's waker, so a request wakes a parked `select!` instead of waiting
for the next tick — executor-neutral, a plain `poll_fn`, no new dependency.
Bursts still coalesce into one repaint.

## Why

The holes were not deliberate omissions, they were what an unmanaged cross
product does. Making the two axes that *can* be values into values means the
missing combinations cannot recur — there is nothing left to forget to add.

The final commit is documentation: `run_with_messages` explained its stream
semantics before saying what the feature is *for*, so a reader who did not
already know finished no better off. It now leads with the decision (does
`update` need to decide about each arrival, or does the frame just re-read the
newest value?), names the sharp consequence (redraw requests coalesce, messages
do not), and lists the producers that motivate it. `Signal::Message` also now
says what it is *not*: Elm and Iced use one message type for everything reaching
`update`, key presses included, and a reader carrying that model over cannot
place this variant.

## Before / After

No observable behavior change for an unchanged host, with one deliberate
exception: `Live` plus `AsyncRunner` previously did nothing, and now repaints.
That path is pinned by a new test:

```
test runner::asynchronous::tests::redraw_handle_wakes_the_loop_and_repaints ... ok
```

It runs under `#[tokio::test(start_paused = true)]`, so the producer's sleep
cannot advance until the runner is parked — the repaint is ordered before the
quit key without a wall-clock race — and asserts two frames plus the producer's
data on screen.

API shape, before and after:

```rust
// before
runner.run(&theme, &mut state, view, update)?;
runner.run_app(&theme, &mut app)?;

// after — one method, two sources
runner.run(&theme, from_fn(&mut state, view, update))?;
runner.run(&theme, &mut app)?;
```

Evidence, all on this branch:

- `cargo test --workspace --all-features` — 644 unit + 57 doc + all integration, 0 failures
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 0
- `cargo fmt --all -- --check`, `cargo doc --all-features --no-deps` — 0 warnings
- `cargo +1.88 check --workspace --all-features --all-targets` — MSRV clean
- `cargo run --example demo -- check` — 42 scenes in sync
- `python3 scripts/validate_okf.py knowledge --check-links` — 15 concepts, 0 errors

## Risk

- **Medium** — breaking, but mechanically so, and the compiler catches every case.
- Because the new message type parameter defaults to an uninhabited type, an
  existing two-arm `match` over a `Signal` value (tick and event) still compiles
  and stays exhaustive (`min_exhaustive_patterns`, stable since 1.82; MSRV is
  1.88 and this was verified against it). **A match on a *reference* does need a
  `_` arm added** — that one bit our own loop, and is called out in the changelog.
- Shipped names whose replacement has a different name keep working as
  deprecated shims: `run_app`, `run_app_with_backend`, `run_with_events`,
  `run_with_events_and_messages`, `AsyncSignal`. Each carries the exact
  replacement call in its `note`.
- `run`, `run_with_backend`, and `run_with_messages` changed shape under the same
  name, so they fail to compile rather than warn. The CHANGELOG carries the full
  before/after migration table.
- The riskiest part of the diff is the async runner's session lifecycle, which
  was restructured. Audited: see **Security**.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

## Knowledge

Updated `knowledge/specs/architecture.md` (the frame source is an argument, not
a method name; both seams kept because neither subsumes the other) and
`knowledge/specs/api-surface.md` (`AsyncApplication` at the crate root). Two new
`knowledge/log.md` entries: the seam/axis collapse, and that a redraw request
must reach a parked loop. No concepts added, removed, renamed, or reclassified,
so `knowledge/index.md` is unchanged. Validated with `--check-links`.

## Security

Reviewed against all five threat-model categories.

- **TM-STATE** — the category that actually applies, since the async runner's
  session lifecycle was restructured. Every session-owning path binds
  `let _session = …` as a *named* binding (never `let _ = …`, which would drop
  the guard immediately and strand raw mode), so the `?` on
  `Terminal::with_options` still restores. `run_with_messages` and
  `run_with_backend` each own an enter and a matching `clear`/`close_footer`;
  `run_driven_by` deliberately owns neither, because the caller does. Graphics
  cleanup stays declared *after* `_session`, so it drops first and placements
  belong to the screen on which they were made. The 13 PTY smoke tests cover
  this end to end — alt-screen enter/leave, mouse-capture lifecycle, resize, and
  the split footer handing its rows back on exit — and pass.
- **TM-ESC** — no change to escape emission; no encoder touched, no
  caller-supplied string newly reaches the terminal.
- **TM-PARSE** — no parsing surface touched.
- **TM-CLIP** — painting is unchanged; the same `paint_with_context` call, now
  reached through the frame source.
- **TM-DEP** — no new dependency. The `RedrawHandle` wakeup is `std::task::Waker`
  plus a `poll_fn`, deliberately not `tokio::sync::Notify`, so the handle stays
  executor-neutral and the `async` feature's dependency set is untouched.

One non-obvious detail worth a reviewer's eye: cancelling the redraw wait leaves
at most a stale waker registered, which costs one spurious wakeup and never a
lost one — the flag is re-checked after registration. That race is pinned by a
hand-polled unit test in `src/live.rs` that needs no executor.

## Follow-ups

- **`run_driven_by` has no synchronous twin.** The sync runner has no
  caller-owned-terminal entry point at all: `run_with_backend` takes your backend
  but still enters a session and reads crossterm itself, so a sync host cannot
  drive its app hermetically. The cost is visible in this repo — the async loop
  has ~20 end-to-end tests through `run_driven_by`, while the sync runner's tests
  only exercise pieces (`RunnerCore`, the clock, selection), never the loop that
  ships to every sync host. Deferred because it needs a sync event-source design
  (an iterator, or a closure returning the next event if there is one) rather
  than a mechanical port, and it is worth its own commit with the loop tests it
  unlocks.
- **The message axis stays async-only, deliberately.** The sync loop blocks in
  `crossterm::event::poll`, which a channel send cannot wake, so a sync
  `run_with_messages` would have latency bounded by `tick_rate` — a worse
  primitive wearing the same name. Now documented on `Runner::redraw_handle`
  rather than left as an apparent gap.
- **`with_clock` stays sync-only**, because the async runner gets the same
  determinism from `tokio::time::pause()` — which this branch's own
  `start_paused` test uses.