### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -214,6 +214,11 @@ cargo update -p tuika-codeformatters   # only if it was bumped
 cargo update -p tuika-mermaid          # only if it was bumped
 ```
 
+Update the three root README image URLs (`logo.svg`, `docs/hero.gif`, and
+`docs/demos/image.svg`) to
+`https://raw.githubusercontent.com/everruns/tuika/vX.Y.Z/...`. The packaging
+test derives `CARGO_PKG_VERSION` and fails if any URL points at another tag.
+
 ### 5. Run local verification
 
 Review commits since the previous tag for durable knowledge impact. Update the
@@ -353,9 +358,9 @@ Releases).
 - **Tag/Cargo drift.** A same-day patch release is almost always caused by
   version drift between `Cargo.toml` and what `cargo publish` actually sees. The
   dry-run catches it.
-- **Stale demo assets in the tarball.** `docs/hero.gif` ships in the crate. If it
-  no longer matches the current look, the crates.io page misrepresents the
-  release — regenerate before cutting.
+- **A stale root README asset pin.** Root README images live outside the crate
+  and pin the release tag. Update all three URLs with the version bump; the
+  packaging test guards this mechanically.
 - **A highlight demo that shows the old behavior.** Recording is part of
   preparing the release, not something to inherit from the gallery. If the
   scene existed before the change, re-record it, or the release note advertises

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -214,10 +214,11 @@ cargo update -p tuika-codeformatters   # only if it was bumped
 cargo update -p tuika-mermaid          # only if it was bumped
 ```
 
-Update the three root README image URLs (`logo.svg`, `docs/hero.gif`, and
-`docs/demos/image.svg`) to
-`https://raw.githubusercontent.com/everruns/tuika/vX.Y.Z/...`. The packaging
-test derives `CARGO_PKG_VERSION` and fails if any URL points at another tag.
+Update every release-pinned root README URL from the previous tag to `vX.Y.Z`:
+the public guide links under `https://github.com/everruns/tuika/blob/vX.Y.Z/`
+and the three raw image URLs (`logo.svg`, `docs/hero.gif`, and
+`docs/demos/image.svg`). The packaging test derives `CARGO_PKG_VERSION` and
+fails if a guide or image points at another tag.
 
 ### 5. Run local verification
 
@@ -358,9 +359,9 @@ Releases).
 - **Tag/Cargo drift.** A same-day patch release is almost always caused by
   version drift between `Cargo.toml` and what `cargo publish` actually sees. The
   dry-run catches it.
-- **A stale root README asset pin.** Root README images live outside the crate
-  and pin the release tag. Update all three URLs with the version bump; the
-  packaging test guards this mechanically.
+- **A stale root README repository pin.** Root guides and images live outside
+  the crate and pin the release tag. Update every pinned URL with the version
+  bump; the packaging test guards this mechanically.
 - **A highlight demo that shows the old behavior.** Recording is part of
   preparing the release, not something to inherit from the gallery. If the
   scene existed before the change, re-record it, or the release note advertises

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,9 +183,10 @@ tuika's own suite covers more:
   dump would throw away the styling that is half of what the crate does.
 
 The root package's alternate logo, demo, showcase, example, theme, and styling
-assets are GitHub-only: `Cargo.toml`'s `exclude` keeps them (and the repository
-machinery — `knowledge/`, `.agents/`, `.github/`, `scripts/`) out of tuika's
-published `.crate`, and `tests/packaging.rs` guards that split. Only `logo.svg`,
+assets are GitHub-only: `Cargo.toml`'s `exclude` keeps them (and the generated
+`site/` bundle plus repository machinery — `knowledge/`, `.agents/`, `.github/`,
+`scripts/`) out of tuika's published `.crate`, and `tests/packaging.rs` guards
+that split. Only `logo.svg`,
 `docs/hero.gif`, `docs/demos/image.svg`, and `docs/split-footer.gif`, which
 the crates.io README embeds by relative path, ship in tuika.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,8 @@ cargo run --example codex -- --split-footer   # the agent UI in that mode
 
 Criterion targets measure wall clock and are advisory; the `*_iai` targets count
 instructions against a committed baseline and are a CI gate. Procedure lives in
-[`benches/README.md`](benches/README.md).
+[`benches/README.md`](benches/README.md). The baseline snapshots are repository
+CI inputs and are excluded from the published crates; benchmark source remains.
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,8 @@ tuika's own suite covers more:
 
 - `logo.svg`, `logo-dark.svg`, and `logo-mono.svg` — the hand-authored vector
   sources for tuika's primary, dark-surface, and one-color marks. The primary is
-  embedded in the README and ships so crates.io can resolve the relative path.
+  embedded in the README through a release-tag-pinned absolute URL, so none of
+  the rendered copies need to ship in the crate.
   Their 1024 px PNG exports (`logo*.png`) are GitHub-only; regenerate them with
   `scripts/gen-logo-assets.sh`.
 - `docs/components.md` — the public component-gallery index, covering **every**
@@ -182,13 +183,13 @@ tuika's own suite covers more:
   example runs as a real app rather than printing a grid, because a plain-text
   dump would throw away the styling that is half of what the crate does.
 
-The root package's alternate logo, demo, showcase, example, theme, and styling
-assets are GitHub-only: `Cargo.toml`'s `exclude` keeps them (and the generated
-`site/` bundle plus repository machinery — `knowledge/`, `.agents/`, `.github/`,
-`scripts/`) out of tuika's published `.crate`, and `tests/packaging.rs` guards
-that split. Only `logo.svg`,
-`docs/hero.gif`, `docs/demos/image.svg`, and `docs/split-footer.gif`, which
-the crates.io README embeds by relative path, ship in tuika.
+The root package's alternate logo, demo, chart, showcase, example, theme, and
+styling assets are GitHub-only: `Cargo.toml`'s `exclude` keeps them (and the
+generated `site/` bundle plus repository machinery — `knowledge/`, `.agents/`,
+`.github/`, `scripts/`) out of tuika's published `.crate`, and
+`tests/packaging.rs` guards that split. The root README's three image embeds use
+release-tag-pinned absolute URLs, and the split-footer recording lives only in
+the focused guide, so no image asset ships in tuika.
 
 Every published member owns the same rule, and how its README embeds a recording
 decides the answer: `tuika-mermaid`'s small recording ships, because its README
@@ -347,8 +348,8 @@ ffprobe -v error -show_entries format=duration -of csv=p=0 docs/showcases/yolop.
 
 ## Split-footer demo
 
-`docs/split-footer.gif` (embedded in the README, `docs/features.md`, and
-`ScreenMode`'s rustdoc) shows a whole terminal, not a component: the footer *and*
+`docs/split-footer.gif` (embedded in `docs/features.md` and `ScreenMode`'s
+rustdoc) shows a whole terminal, not a component: the footer *and*
 the scrollback above it, which no `Buffer` holds — so it cannot come from the
 `DEMOS` registry. It is recorded from the real session by
 [`scripts/gen-split-footer-demo.sh`](scripts/gen-split-footer-demo.sh), which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,13 +184,13 @@ tuika's own suite covers more:
   example runs as a real app rather than printing a grid, because a plain-text
   dump would throw away the styling that is half of what the crate does.
 
-The root package's alternate logo, demo, chart, showcase, example, theme, and
-styling assets are GitHub-only: `Cargo.toml`'s `exclude` keeps them (and the
-generated `site/` bundle plus repository machinery — `knowledge/`, `.agents/`,
-`.github/`, `scripts/`) out of tuika's published `.crate`, and
-`tests/packaging.rs` guards that split. The root README's three image embeds use
+The root package's public `docs/` tree and alternate logo/demo assets are
+repository-only: `Cargo.toml`'s `exclude` keeps them (and the generated `site/`
+bundle plus repository machinery — `knowledge/`, `.agents/`, `.github/`,
+`scripts/`) out of tuika's published `.crate`, and `tests/packaging.rs` guards
+that split. The root README's guide links and three image embeds use
 release-tag-pinned absolute URLs, and the split-footer recording lives only in
-the focused guide, so no image asset ships in tuika.
+the focused guide, so no `docs/` file ships in tuika.
 
 Every published member owns the same rule, and how its README embeds a recording
 decides the answer: `tuika-mermaid`'s small recording ships, because its README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,20 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
+## [0.9.1] - 2026-08-15
+
+This release supersedes 0.9.0, whose GitHub Release was created but whose crate
+archive exceeded crates.io's 10 MiB upload limit. It publishes the companion
+versions announced with 0.9.0 unchanged.
+
+### What's Changed
+
+* fix(package): exclude the generated documentation site from the crate archive
+
 ## [0.9.0] - 2026-08-15
+
+> **Publication note:** the tag and GitHub Release exist, but this version was
+> not published to crates.io. Use 0.9.1 instead.
 
 Released alongside `tuika-charts` 0.1.0 — its first release — plus
 `tuika-mermaid` 0.3.0, `tuika-codeformatters` 0.4.2, and `tuika-html` 0.1.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ let several panes in one screen share focus and the mouse.
   asset, keeping the 0.9.0 archive below crates.io's 10 MiB upload limit. README
   images now use release-tag-pinned absolute URLs, and the split-footer
   recording lives in its focused guide rather than being duplicated there.
+  Committed IAI benchmark result snapshots are excluded from both crates that
+  own them; benchmark source remains available.
 - `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a
   diagram, with every label line inside the shape. The upstream defect
   ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)) — which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,10 @@ let several panes in one screen share focus and the mouse.
 
 ### Fixed
 
-- The published crate excludes the generated `site/` bundle, keeping the 0.9.0
-  archive below crates.io's 10 MiB upload limit while retaining every source,
-  manifest, README, and README asset needed by consumers.
+- The published crate excludes the generated `site/` bundle and every image
+  asset, keeping the 0.9.0 archive below crates.io's 10 MiB upload limit. README
+  images now use release-tag-pinned absolute URLs, and the split-footer
+  recording lives in its focused guide rather than being duplicated there.
 - `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a
   diagram, with every label line inside the shape. The upstream defect
   ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)) — which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,7 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
-## [0.9.1] - 2026-08-15
-
-This release supersedes 0.9.0, whose GitHub Release was created but whose crate
-archive exceeded crates.io's 10 MiB upload limit. It publishes the companion
-versions announced with 0.9.0 unchanged.
-
-### What's Changed
-
-* fix(package): exclude the generated documentation site from the crate archive
-
 ## [0.9.0] - 2026-08-15
-
-> **Publication note:** the tag and GitHub Release exist, but this version was
-> not published to crates.io. Use 0.9.1 instead.
 
 Released alongside `tuika-charts` 0.1.0 — its first release — plus
 `tuika-mermaid` 0.3.0, `tuika-codeformatters` 0.4.2, and `tuika-html` 0.1.2.
@@ -117,6 +104,9 @@ let several panes in one screen share focus and the mouse.
 
 ### Fixed
 
+- The published crate excludes the generated `site/` bundle, keeping the 0.9.0
+  archive below crates.io's 10 MiB upload limit while retaining every source,
+  manifest, README, and README asset needed by consumers.
 - `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a
   diagram, with every label line inside the shape. The upstream defect
   ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)) — which

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,10 +104,11 @@ let several panes in one screen share focus and the mouse.
 
 ### Fixed
 
-- The published crate excludes the generated `site/` bundle and every image
-  asset, keeping the 0.9.0 archive below crates.io's 10 MiB upload limit. README
-  images now use release-tag-pinned absolute URLs, and the split-footer
-  recording lives in its focused guide rather than being duplicated there.
+- The published crate excludes the generated `site/` bundle and the public
+  `docs/` tree, keeping the 0.9.0 archive below crates.io's 10 MiB upload limit.
+  README guide and image links now use release-tag-pinned absolute URLs, and the
+  split-footer recording lives in its focused guide rather than being
+  duplicated in the README.
   Committed IAI benchmark result snapshots are excluded from both crates that
   own them; benchmark source remains available.
 - `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.9.1"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,11 @@ keywords = ["tui", "terminal", "ratatui", "framework", "widgets"]
 categories = ["command-line-interface"]
 # Three kinds of file are kept out of the published `.crate`:
 #
-# 1. The alternate logo exports, demo/chart/showcase/theme/styling assets under
-#    `docs/`, and recording beside the `codex` example are consumed only from
-#    the repository by public pages or tooling. rustdoc/docs.rs references none
-#    of them from its crate front page, so bundling them just bloats the tarball.
-#    The crates.io README reaches its images through release-tag-pinned absolute
-#    URLs, so their packaged copies are unreachable and excluded too.
+# 1. The public `docs/` tree, alternate logo exports, and recording beside the
+#    `codex` example are consumed from the tagged repository by public pages or
+#    tooling. rustdoc/docs.rs references none of them from its crate front page,
+#    and the crates.io README uses release-tag-pinned absolute URLs for guides
+#    and images, so packaged copies would be incomplete and unreachable.
 # 2. Benchmark result snapshots. Benchmark sources remain reproducible, but the
 #    committed IAI baseline is a CI input rather than a consumer file.
 # 3. Repository machinery. Since tuika is the root package, everything beside it
@@ -62,16 +61,8 @@ exclude = [
     "/logo-dark.svg",
     "/logo-mono.svg",
     "/logo*.png",
-    "docs/demos/*.gif",
-    "docs/demos/*.png",
-    "docs/demos/image.svg",
-    "docs/charts/*.png",
-    "docs/hero.gif",
-    "docs/split-footer.gif",
-    "docs/showcases/*.gif",
+    "/docs",
     "examples/codex/*.gif",
-    "docs/styling/*.gif",
-    "docs/themes/*.gif",
     "/benches/*.json",
     "/.agents",
     "/.claude",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.9.1"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,15 +43,12 @@ keywords = ["tui", "terminal", "ratatui", "framework", "widgets"]
 categories = ["command-line-interface"]
 # Two kinds of file are kept out of the published `.crate`:
 #
-# 1. The alternate logo exports, demo/showcase/theme/styling assets under
+# 1. The alternate logo exports, demo/chart/showcase/theme/styling assets under
 #    `docs/`, and recording beside the `codex` example are consumed only from
 #    the repository by public pages or tooling. rustdoc/docs.rs references none
 #    of them from its crate front page, so bundling them just bloats the tarball.
-#    Keep `logo.svg`, `hero.gif`, `demos/image.svg`, and `split-footer.gif`:
-#    those are the four assets the crates.io README (`README.md`) embeds by
-#    relative path. Like the hero, the split-footer recording sits directly
-#    under `docs/` rather than in `docs/demos/`, which is reserved for the
-#    registry's component scenes and excluded wholesale.
+#    The crates.io README reaches its images through release-tag-pinned absolute
+#    URLs, so their packaged copies are unreachable and excluded too.
 # 2. Repository machinery. Since tuika is the root package, everything beside it
 #    in the repo would otherwise ship: the generated documentation site,
 #    internal knowledge, agent skills, CI definitions, and asset-generation
@@ -59,11 +56,16 @@ categories = ["command-line-interface"]
 #
 # See `tests/packaging.rs` for the guard that keeps this list honest.
 exclude = [
+    "/logo.svg",
     "/logo-dark.svg",
     "/logo-mono.svg",
     "/logo*.png",
     "docs/demos/*.gif",
     "docs/demos/*.png",
+    "docs/demos/image.svg",
+    "docs/charts/*.png",
+    "docs/hero.gif",
+    "docs/split-footer.gif",
     "docs/showcases/*.gif",
     "examples/codex/*.gif",
     "docs/styling/*.gif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ repository.workspace = true
 readme = "README.md"
 keywords = ["tui", "terminal", "ratatui", "framework", "widgets"]
 categories = ["command-line-interface"]
-# Two kinds of file are kept out of the published `.crate`:
+# Three kinds of file are kept out of the published `.crate`:
 #
 # 1. The alternate logo exports, demo/chart/showcase/theme/styling assets under
 #    `docs/`, and recording beside the `codex` example are consumed only from
@@ -49,7 +49,9 @@ categories = ["command-line-interface"]
 #    of them from its crate front page, so bundling them just bloats the tarball.
 #    The crates.io README reaches its images through release-tag-pinned absolute
 #    URLs, so their packaged copies are unreachable and excluded too.
-# 2. Repository machinery. Since tuika is the root package, everything beside it
+# 2. Benchmark result snapshots. Benchmark sources remain reproducible, but the
+#    committed IAI baseline is a CI input rather than a consumer file.
+# 3. Repository machinery. Since tuika is the root package, everything beside it
 #    in the repo would otherwise ship: the generated documentation site,
 #    internal knowledge, agent skills, CI definitions, and asset-generation
 #    scripts are all repo-only.
@@ -70,6 +72,7 @@ exclude = [
     "examples/codex/*.gif",
     "docs/styling/*.gif",
     "docs/themes/*.gif",
+    "/benches/*.json",
     "/.agents",
     "/.claude",
     "/.github",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -53,8 +53,9 @@ categories = ["command-line-interface"]
 #    under `docs/` rather than in `docs/demos/`, which is reserved for the
 #    registry's component scenes and excluded wholesale.
 # 2. Repository machinery. Since tuika is the root package, everything beside it
-#    in the repo would otherwise ship: internal knowledge, agent skills, CI
-#    definitions, and the asset-generation scripts are all repo-only.
+#    in the repo would otherwise ship: the generated documentation site,
+#    internal knowledge, agent skills, CI definitions, and asset-generation
+#    scripts are all repo-only.
 #
 # See `tests/packaging.rs` for the guard that keeps this list honest.
 exclude = [
@@ -72,6 +73,7 @@ exclude = [
     "/.github",
     "/knowledge",
     "/scripts",
+    "/site",
     "/AGENTS.md",
     "/CLAUDE.md",
     "/CODE_OF_CONDUCT.md",

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 [![downloads](https://img.shields.io/crates/d/tuika.svg)](https://crates.io/crates/tuika)
 [![license](https://img.shields.io/crates/l/tuika.svg)](https://github.com/everruns/tuika/blob/main/LICENSE)
 ![msrv](https://img.shields.io/badge/rust-1.88%2B-blue.svg) \
-[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](docs/getting-started.md) · [Components](docs/components.md) · [Layout](docs/layout.md) ·
-[Markdown](docs/markdown.md) · [Charts](docs/charts.md) ·
-[Terminal features](docs/features.md) ·
-[Keymap](docs/keymap.md) · [Styling](docs/styling.md) ·
-[Themes](docs/themes.md) \
-[Showcases](docs/showcases.md) · [Examples](#runnable-examples) ·
+[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](https://github.com/everruns/tuika/blob/v0.9.0/docs/getting-started.md) · [Components](https://github.com/everruns/tuika/blob/v0.9.0/docs/components.md) · [Layout](https://github.com/everruns/tuika/blob/v0.9.0/docs/layout.md) ·
+[Markdown](https://github.com/everruns/tuika/blob/v0.9.0/docs/markdown.md) · [Charts](https://github.com/everruns/tuika/blob/v0.9.0/docs/charts.md) ·
+[Terminal features](https://github.com/everruns/tuika/blob/v0.9.0/docs/features.md) ·
+[Keymap](https://github.com/everruns/tuika/blob/v0.9.0/docs/keymap.md) · [Styling](https://github.com/everruns/tuika/blob/v0.9.0/docs/styling.md) ·
+[Themes](https://github.com/everruns/tuika/blob/v0.9.0/docs/themes.md) \
+[Showcases](https://github.com/everruns/tuika/blob/v0.9.0/docs/showcases.md) · [Examples](#runnable-examples) ·
 [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) ·
 [Report a bug](https://github.com/everruns/tuika/issues)
 
@@ -28,7 +28,7 @@
 
 <div align="center">
 
-### tuika's goal is to become the default TUI [application](./docs/showcases.md) framework for Rust
+### tuika's goal is to become the default TUI [application](https://github.com/everruns/tuika/blob/v0.9.0/docs/showcases.md) framework for Rust
 
 **Build the app, not the render loop.**
 
@@ -70,14 +70,14 @@ You write views; tuika owns the rest:
 
 - **A whole app, not a widget set** — [flexbox layout](#model), anchored
   [overlays](#owned-scenes-dialogs-and-forms), focus, a declarative
-  [keymap](docs/keymap.md), [themes and stylesheets](#theming), and a
+  [keymap](https://github.com/everruns/tuika/blob/v0.9.0/docs/keymap.md), [themes and stylesheets](#theming), and a
   [runner](#screen-modes-lifecycle-and-runner) that owns raw mode, the alternate
   screen (or a [split footer](#screen-modes-lifecycle-and-runner) over live
   scrollback), and event translation.
 - **Batteries the terminal era expects** — [30+ components](#components)
-  including streaming [Markdown](docs/markdown.md) with pluggable syntax
+  including streaming [Markdown](https://github.com/everruns/tuika/blob/v0.9.0/docs/markdown.md) with pluggable syntax
   highlighting, [images](#images) over Kitty/iTerm2/Sixel, adaptive
-  [charts](docs/charts.md), mermaid diagrams,
+  [charts](https://github.com/everruns/tuika/blob/v0.9.0/docs/charts.md), mermaid diagrams,
   [mouse selection and clipboard](#mouse-selection-and-clipboard), and
   [native OSC 9;4 progress](#native-terminal-progress).
 - **No lock-in** — it is additive to ratatui, not a replacement: wrap any
@@ -104,7 +104,7 @@ ratatui widget it likes (see [Compatibility](#compatibility)). (The optional
 `async` feature adds Tokio for [`AsyncRunner`](#screen-modes-lifecycle-and-runner);
 it is off by default.)
 
-See what that buys in practice: the [showcases](docs/showcases.md) are
+See what that buys in practice: the [showcases](https://github.com/everruns/tuika/blob/v0.9.0/docs/showcases.md) are
 recordings of real applications running on tuika (also listed under
 [Used in](#used-in)), and the [`codex` example](examples/codex) is a whole
 coding-agent UI built with nothing else.
@@ -132,7 +132,7 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Live data** (`Live` / `LiveView`) is shared application state read at render
   time. Updates request a redraw from the runner; Tuika does not spawn data
   sources or reconcile a retained widget tree.
-- **Layout** is an [integer-native flexbox subset](docs/layout.md) (`layout`): wrapped flex lines,
+- **Layout** is an [integer-native flexbox subset](https://github.com/everruns/tuika/blob/v0.9.0/docs/layout.md) (`layout`): wrapped flex lines,
   independent basis/grow/shrink/min/max child styles, cross-line alignment, and
   exact boundary rounding over one direction-agnostic solver. `Flow` packages
   intrinsic wrapping; `Grid` is the smaller equal-column, row-major alternative
@@ -140,14 +140,14 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Overlays** (`overlay`) anchor a view over the base tree; the **host**
   (`host`) owns the alternate screen, translates crossterm input, and
   composites the frame.
-- **Keymap** ([`keymap`](docs/keymap.md)) resolves declarative key bindings to
+- **Keymap** ([`keymap`](https://github.com/everruns/tuika/blob/v0.9.0/docs/keymap.md)) resolves declarative key bindings to
   named commands: chords (`ctrl+r`) and multi-stroke sequences (`g g`) grouped
   into prioritized, mode-gated `Layer`s, dispatched from a translated `Key` and
   queryable for help/`KeyHints` surfaces. Character chords are exact logical
   text (`A`, `?`, `ж`), so the active keyboard layout is applied before
   matching; Shift stays explicit for non-character keys such as `Shift+Enter`.
   Host-agnostic, so it unit-tests without a terminal. See the
-  [keymap guide](docs/keymap.md).
+  [keymap guide](https://github.com/everruns/tuika/blob/v0.9.0/docs/keymap.md).
 - **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
   `term::progress::TerminalProgress`) animates from a host-supplied frame counter and
   can drive the terminal's own OSC 9;4 progress indicator. `anim::Timeline` adds
@@ -182,50 +182,50 @@ path always means "you will use this constantly".
 
 ## Components
 
-See the [component gallery](docs/components.md) for an animated demo of each
+See the [component gallery](https://github.com/everruns/tuika/blob/v0.9.0/docs/components.md) for an animated demo of each
 component. Linked names below jump straight to their demo.
 
 | Component | Purpose |
 | --- | --- |
-| [`Text`](docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
+| [`Text`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
 | `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
-| [`Markdown`](docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](docs/markdown.md) |
-| [`CodeBlock`](docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
-| [`Html`](docs/components/markdown-code.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
+| [`Markdown`](https://github.com/everruns/tuika/blob/v0.9.0/docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](https://github.com/everruns/tuika/blob/v0.9.0/docs/markdown.md) |
+| [`CodeBlock`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
+| [`Html`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/markdown-code.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
 | `Diff` | Line diff (LCS), unified or side-by-side, with `+`/`-` gutters and line numbers |
 | `AsciiFont` | Large "figlet-style" block-letter banner text |
 | `QrCode` (+ `QrEcc`) | QR code (byte-mode v1–4 encoder) rendered with half-blocks |
-| [`Rule`](docs/components/text.md#rule) | Horizontal separator: optional title + fill glyph to width |
-| [`Flex`](docs/components/layout.md#flex) | Flexbox container (the composition primitive) |
-| [`Flow`](docs/components/layout.md#flow) | Intrinsic-width items wrapped into flex lines |
-| [`Grid`](docs/components/layout.md#grid) | Small equal-column, row-major terminal grid |
+| [`Rule`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/text.md#rule) | Horizontal separator: optional title + fill glyph to width |
+| [`Flex`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#flex) | Flexbox container (the composition primitive) |
+| [`Flow`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#flow) | Intrinsic-width items wrapped into flex lines |
+| [`Grid`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#grid) | Small equal-column, row-major terminal grid |
 | `Responsive` / `Constrained` | Breakpoint selection and min/max measurement |
-| [`Boxed`](docs/components/layout.md#boxed) | Border + padding + title, focus-aware |
+| [`Boxed`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#boxed) | Border + padding + title, focus-aware |
 | `Scene` / `ScopedScene` / `Dialog` | Owned or frame-borrowed root + anchored overlays |
-| [`ConfirmDialog`](docs/components/interactive.md#dialog-presets) / `ChoiceDialog` / `MultiChoiceDialog` / `InputDialog` | Stateful presets for common modal flows |
+| [`ConfirmDialog`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#dialog-presets) / `ChoiceDialog` / `MultiChoiceDialog` / `InputDialog` | Stateful presets for common modal flows |
 | `Spacer` | Flexible filler |
-| [`Scroll`](docs/components/interactive.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
-| [`ItemScroll`](docs/components/interactive.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
+| [`Scroll`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
+| [`ItemScroll`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
 | `Viewport` | Two-dimensional clipping/panning over any child view |
-| [`Scrollbar`](docs/components/layout.md#scrollbar--virtualwindow) / `VirtualWindow` | Reusable bars and clamped ranges for virtualized collections |
+| [`Scrollbar`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#scrollbar--virtualwindow) / `VirtualWindow` | Reusable bars and clamped ranges for virtualized collections |
 | `Form` / `FormField` (+ `FormState`) | Responsive labeled controls and validation |
 | `DrawView` / `CanvasView` | Closure-based custom cell drawing |
-| [`SelectList`](docs/components/interactive.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
-| [`TreeList`](docs/components/interactive.md#treelist--treestate) (+ `TreeState`) | Stable-id expandable tree over host-provided rows |
-| [`SelectionScreen`](docs/components/layout.md#selectionscreen) | Responsive full-screen action/agent/permission pickers |
-| [`KeyedTable`](docs/components/interactive.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
-| [`CompletionPalette`](docs/components/interactive.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
+| [`SelectList`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
+| [`TreeList`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#treelist--treestate) (+ `TreeState`) | Stable-id expandable tree over host-provided rows |
+| [`SelectionScreen`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#selectionscreen) | Responsive full-screen action/agent/permission pickers |
+| [`KeyedTable`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
+| [`CompletionPalette`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
 | `Slider` (+ `SliderState`) | One-row value picker over a numeric range |
-| [`TextInput`](docs/components/interactive.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |
-| [`StatusBar`](docs/components/layout.md#statusbar) | One-row left/right status segments |
-| [`Tabs`](docs/components/interactive.md#tabs--tabsstate) / `KeyHints` | Host-state tab navigation and command hints |
+| [`TextInput`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |
+| [`StatusBar`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/layout.md#statusbar) | One-row left/right status segments |
+| [`Tabs`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/interactive.md#tabs--tabsstate) / `KeyHints` | Host-state tab navigation and command hints |
 | `TabSelect` (+ `TabSelectState`) | Value-selecting segmented control |
 | `Toasts` / `ToastList` | Transient notification stack with frame-driven expiry |
 | `Console` (+ `ConsoleLog`) | Captured stdout/log ring buffer + tailing overlay view |
-| [`Spinner`](docs/components/motion.md#spinner) | Frame-cycled activity glyph |
-| [`ProgressBar`](docs/components/motion.md#progressbar) | Determinate (sub-cell) / indeterminate bar |
-| [`ActivityList`](docs/components/motion.md#activitylist) | Multi-step lifecycle status with optional per-step progress |
-| [`Loader`](docs/components/motion.md#loader) | Spinner + message + hint row |
+| [`Spinner`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/motion.md#spinner) | Frame-cycled activity glyph |
+| [`ProgressBar`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/motion.md#progressbar) | Determinate (sub-cell) / indeterminate bar |
+| [`ActivityList`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/motion.md#activitylist) | Multi-step lifecycle status with optional per-step progress |
+| [`Loader`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/motion.md#loader) | Spinner + message + hint row |
 
 ## Example
 
@@ -484,10 +484,10 @@ HTML parser is a dependency tuika will not carry. Attach a
 same ordered renderer chain handles fenced diagrams and block HTML with one
 context, including the active stylesheet.
 [`tuika-html`](crates/tuika-html/) is the ready-made one, and it also supplies
-the [`Html`](docs/components/markdown-code.md#html) component for markup that is not inside
+the [`Html`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/markdown-code.md#html) component for markup that is not inside
 markdown at all. See the markdown guide for
-[inline HTML](docs/markdown.md#inline-html) and
-[block HTML](docs/markdown.md#block-html).
+[inline HTML](https://github.com/everruns/tuika/blob/v0.9.0/docs/markdown.md#inline-html) and
+[block HTML](https://github.com/everruns/tuika/blob/v0.9.0/docs/markdown.md#block-html).
 
 ## Theming
 
@@ -506,7 +506,7 @@ let b = tuika::Theme::gruvbox_dark();                  // named constructor
 let c = tuika::themes::by_name("gruvbox-dark").unwrap(); // config / --theme
 ```
 
-See the [theme gallery](docs/themes.md) for a screenshot of each bundled
+See the [theme gallery](https://github.com/everruns/tuika/blob/v0.9.0/docs/themes.md) for a screenshot of each bundled
 palette, or `themes::PRESETS` to enumerate them for a picker.
 
 An app can also inherit the palette the user already configured in their
@@ -514,7 +514,7 @@ terminal, rather than bringing its own — either implicitly with `themes::TERMI
 (ANSI slots, no I/O) or by asking the terminal for its actual colors and deriving
 a full theme from the reply. It is opt-in: tuika never probes unless a host asks
 it to. The query lives with the other out-of-band escapes, in `term::palette`. See
-[inheriting the terminal's colors](docs/features.md#inheriting-the-terminals-colors).
+[inheriting the terminal's colors](https://github.com/everruns/tuika/blob/v0.9.0/docs/features.md#inheriting-the-terminals-colors).
 
 Where a `Theme` is the color *tokens*, a `StyleSheet` is the *rules* — a mapping
 from a semantic role (heading, link, inline code, a panel's border and fill, …)
@@ -522,7 +522,7 @@ onto the style it draws with. Override a role in one place and every element wit
 that role restyles at once; markdown, toast severities, diff rows, and key hints
 are role-driven too. Companion crates and applications can define namespaced
 `StyleRole`s and install a `StyleResolver` without expanding tuika's closed data
-model. See the [styling guide](docs/styling.md). `StyleBundle::padding` is layout, not a
+model. See the [styling guide](https://github.com/everruns/tuika/blob/v0.9.0/docs/styling.md). `StyleBundle::padding` is layout, not a
 paint-only hint: `Boxed` resolves panel padding during both measurement and
 rendering; an explicit `Boxed::padding` remains the per-instance override.
 
@@ -657,7 +657,7 @@ threads, tasks, retries, and lifecycle.
   shape for a long-running tool with a live composer, status line, or progress
   panel over output the user wants to keep.
 
-The [screen-modes guide](docs/features.md#screen-modes-alternate-screen--split-footer)
+The [screen-modes guide](https://github.com/everruns/tuika/blob/v0.9.0/docs/features.md#screen-modes-alternate-screen--split-footer)
 shows the mode in motion and covers its terminal contract in detail.
 
 In split-footer mode a host must not `println!` — the footer owns the cursor.
@@ -899,7 +899,7 @@ selection — so a host should act on `plain()` left-drags.
 `Down`+`Up` and a swipe to scroll or a drag, so touch flows through this same
 path — there is no separate touch event to handle.
 
-> See the [terminal features guide](docs/features.md) for these
+> See the [terminal features guide](https://github.com/everruns/tuika/blob/v0.9.0/docs/features.md) for these
 > terminal-integration capabilities — OSC 8 hyperlinks, mouse selection and
 > clicks, OSC 52 clipboard, OSC 9;4 progress, and Kitty/iTerm2/Sixel images —
 > plus `Capabilities` detection, with demos and runnable examples.
@@ -941,7 +941,7 @@ not enter raw mode, capture input, hide the cursor, or own a screen.
 - [**LLMSim**](https://github.com/chaliy/llmsim) — an LLM traffic simulator whose
   live stats dashboard is a tuika screen.
 
-See the [showcases](docs/showcases.md) for a recording of each. Building
+See the [showcases](https://github.com/everruns/tuika/blob/v0.9.0/docs/showcases.md) for a recording of each. Building
 something on tuika? Open a PR adding it here.
 
 ## Compatibility
@@ -994,7 +994,7 @@ The separately published companion crates live in this repository:
   terminal diagrams through mmdflux.
 - [`tuika-html`](crates/tuika-html/) lays out block-level HTML with html5ever —
   inside Markdown through the `MarkdownBlockRenderer` seam, or standalone
-  through its own [`Html`](docs/components/markdown-code.md#html) component.
+  through its own [`Html`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/markdown-code.md#html) component.
 
 All four keep specialized rendering and heavier parsers or grammars out of
 tuika core.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
+  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.9.0/logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
 </p>
 
 <h1 align="center">tuika</h1>
@@ -23,7 +23,7 @@
 </div>
 
 <p align="center">
-  <img src="docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
+  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.9.0/docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
 </p>
 
 <div align="center">
@@ -657,9 +657,8 @@ threads, tasks, retries, and lifecycle.
   shape for a long-running tool with a live composer, status line, or progress
   panel over output the user wants to keep.
 
-<p align="center">
-  <img src="docs/split-footer.gif" width="880" alt="A terminal running the split_footer example: a bordered status box pinned to the last rows while published build lines accumulate above it as ordinary scrollback; after the example exits the lines remain and the box's rows are gone.">
-</p>
+The [screen-modes guide](docs/features.md#screen-modes-alternate-screen--split-footer)
+shows the mode in motion and covers its terminal contract in detail.
 
 In split-footer mode a host must not `println!` — the footer owns the cursor.
 `Runner::scrollback()` (and `AsyncRunner::scrollback()`) returns a `Scrollback`
@@ -828,7 +827,7 @@ cells it reserves, using whichever terminal graphics protocol
 **iTerm2**, or **Sixel** (foot, xterm +sixel, mlterm, contour). Terminals with
 none show the alt text, so the same view tree renders everywhere.
 
-<img src="docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
+<img src="https://raw.githubusercontent.com/everruns/tuika/v0.9.0/docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
 
 Decoding stays in the host — a heavy dependency, kept out like the highlighter
 seam — so you hand in raw RGBA via `ImageData::from_rgba` and `tuika` owns the

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -17,8 +17,10 @@ categories = ["command-line-interface", "text-processing"]
 # crate's README embeds `docs/languages.gif` by absolute
 # `raw.githubusercontent.com` URL, so nothing in the published `.crate` reads it
 # — shipping it just adds ~400 KiB to every download. `tests/packaging.rs` in the
-# root package guards this for both crates.
-exclude = ["docs/*.gif"]
+# root package guards this for both crates. The committed IAI baseline is a CI
+# result snapshot, not a consumer file; benchmark sources still ship so the
+# published benchmark remains reproducible.
+exclude = ["docs/*.gif", "benches/*.json"]
 
 # See the root Cargo.toml: disable the default lib bench harness so `cargo bench`
 # runs only the Criterion target below.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -10,7 +10,9 @@
     and tests that boundary explicitly. The root copy of the companion chart
     screenshots follows the same GitHub-only rule. Root README images now use
     release-tag-pinned absolute URLs, allowing every image asset to stay out of
-    the crate without making past crates.io pages drift. Committed IAI
+    the crate without making past crates.io pages drift. The public Markdown
+    guides follow the same rule: the README pins them to the release tag and the
+    incomplete image-less `docs/` copy no longer ships. Committed IAI
     baselines remain repository CI inputs but are excluded from the two crates
     that own them; a workspace-wide packaging test rejects benchmark results.
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,12 @@
 
 ## 2026-08-15
 
+- **The generated website is not part of the published crate**
+  - `site/` mirrors public documentation and bundles generated assets for the
+    tuika.dev deployment; crates.io renders `README.md` directly and cannot use
+    it. Shipping that tree inflated 0.9.0 past crates.io's 10 MiB archive limit,
+    so the package boundary now excludes it and tests that boundary explicitly.
+
 - **A run loop that cannot be driven without a terminal cannot be tested**
   - The synchronous loop had no end-to-end coverage for as long as every entry
     point reached crossterm; only its extracted pieces were testable. Giving it

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -5,8 +5,9 @@
 - **The generated website is not part of the published crate**
   - `site/` mirrors public documentation and bundles generated assets for the
     tuika.dev deployment; crates.io renders `README.md` directly and cannot use
-    it. Shipping that tree inflated 0.9.0 past crates.io's 10 MiB archive limit,
-    so the package boundary now excludes it and tests that boundary explicitly.
+    it. The first 0.9.0 release attempt included that tree and exceeded
+    crates.io's 10 MiB archive limit, so the package boundary now excludes it
+    and tests that boundary explicitly.
 
 - **A run loop that cannot be driven without a terminal cannot be tested**
   - The synchronous loop had no end-to-end coverage for as long as every entry

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -10,7 +10,9 @@
     and tests that boundary explicitly. The root copy of the companion chart
     screenshots follows the same GitHub-only rule. Root README images now use
     release-tag-pinned absolute URLs, allowing every image asset to stay out of
-    the crate without making past crates.io pages drift.
+    the crate without making past crates.io pages drift. Committed IAI
+    baselines remain repository CI inputs but are excluded from the two crates
+    that own them; a workspace-wide packaging test rejects benchmark results.
 
 - **A run loop that cannot be driven without a terminal cannot be tested**
   - The synchronous loop had no end-to-end coverage for as long as every entry

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -7,7 +7,10 @@
     tuika.dev deployment; crates.io renders `README.md` directly and cannot use
     it. The first 0.9.0 release attempt included that tree and exceeded
     crates.io's 10 MiB archive limit, so the package boundary now excludes it
-    and tests that boundary explicitly.
+    and tests that boundary explicitly. The root copy of the companion chart
+    screenshots follows the same GitHub-only rule. Root README images now use
+    release-tag-pinned absolute URLs, allowing every image asset to stay out of
+    the crate without making past crates.io pages drift.
 
 - **A run loop that cannot be driven without a terminal cannot be tested**
   - The synchronous loop had no end-to-end coverage for as long as every entry

--- a/knowledge/processes/release.md
+++ b/knowledge/processes/release.md
@@ -127,7 +127,8 @@ When asked to release, the agent:
 3. **Bump the versions.** The root `Cargo.toml` for `tuika`; and either
    companion's `Cargo.toml` when its API changed or it must track a new tuika
    range — updating its `tuika` dependency requirement to match. Regenerate
-   `Cargo.lock`.
+   `Cargo.lock`. Update the three root README image URLs to the same `vX.Y.Z`
+   tag; the packaging test rejects stale pins.
 
 4. **Run local verification:**
    - `cargo fmt --all -- --check`
@@ -200,6 +201,7 @@ When asked to release, the agent:
 - [ ] Highlights embed a current, tag-pinned demo recording for the release's
       main TUI-facing feature (or the release genuinely has nothing visual).
 - [ ] `Cargo.toml` and `Cargo.lock` both read `X.Y.Z`.
+- [ ] Root README image URLs are pinned to `vX.Y.Z`.
 - [ ] `cargo publish --dry-run -p tuika` succeeds.
 - [ ] `X.Y.Z` is greater than the latest crates.io version.
 - [ ] Manual terminal matrix walked (below) if the renderer or an escape encoder

--- a/knowledge/processes/release.md
+++ b/knowledge/processes/release.md
@@ -127,8 +127,8 @@ When asked to release, the agent:
 3. **Bump the versions.** The root `Cargo.toml` for `tuika`; and either
    companion's `Cargo.toml` when its API changed or it must track a new tuika
    range — updating its `tuika` dependency requirement to match. Regenerate
-   `Cargo.lock`. Update the three root README image URLs to the same `vX.Y.Z`
-   tag; the packaging test rejects stale pins.
+   `Cargo.lock`. Update every release-pinned root README guide and image URL to
+   the same `vX.Y.Z` tag; the packaging test rejects stale pins.
 
 4. **Run local verification:**
    - `cargo fmt --all -- --check`
@@ -201,7 +201,7 @@ When asked to release, the agent:
 - [ ] Highlights embed a current, tag-pinned demo recording for the release's
       main TUI-facing feature (or the release genuinely has nothing visual).
 - [ ] `Cargo.toml` and `Cargo.lock` both read `X.Y.Z`.
-- [ ] Root README image URLs are pinned to `vX.Y.Z`.
+- [ ] Root README guide and image URLs are pinned to `vX.Y.Z`.
 - [ ] `cargo publish --dry-run -p tuika` succeeds.
 - [ ] `X.Y.Z` is greater than the latest crates.io version.
 - [ ] Manual terminal matrix walked (below) if the renderer or an escape encoder

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -131,6 +131,11 @@ baseline updated in a separate commit hides which change moved the numbers. To
 refresh from CI's exact environment, dispatch the workflow manually and commit
 the uploaded `iai-baseline` artifact.
 
+Those committed baselines are repository CI inputs, not crate contents. Package
+manifests exclude `benches/*.json` while retaining benchmark source, and the
+packaging test guards both the committed snapshots and generated `target/`
+results across every published workspace member.
+
 **Adding code to the library counts as a legitimate shift, even code the
 benchmark never calls.** rustc partitions a crate into codegen units, so a new
 module changes which functions share a unit and therefore which ones get inlined;

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -312,31 +312,30 @@ regeneration instead of leaving them stale.
 
 ### The crate/GitHub asset split
 
-The root package's alternate logo exports, demos, showcases, themes, and styling
-assets are consumed only by GitHub-rendered pages and repository tooling. docs.rs
-renders the hand-written `//!` header, which references none of them, so bundling
-them only bloats the published `.crate`. Root `Cargo.toml`'s `exclude` keeps them
+The root package's alternate logo exports, demos, chart screenshots, showcases,
+themes, and styling assets are consumed only by GitHub-rendered pages and
+repository tooling. docs.rs renders the hand-written `//!` header, which
+references none of them, so bundling them only bloats the published `.crate`.
+Root `Cargo.toml`'s `exclude` keeps them
 — the generated `site/` bundle, and the repository machinery (`knowledge/`,
-.agents/`, `.github/`, `scripts/`) — out of that tarball; only `logo.svg`,
-`docs/hero.gif`, `docs/demos/image.svg`, and `docs/split-footer.gif`, which its
-crates.io README embeds by relative path, ship. `docs/demos/` is excluded
-wholesale, so the two
-recordings that must ship live directly under `docs/` — which is also where they
-belong for a second reason: that directory is the registry's, and `demo -- check`
-fails an asset in it with no scene behind it.
+`.agents/`, `.github/`, `scripts/`) — out of that tarball. The root README
+reaches its logo, hero, and image-protocol demo through absolute URLs pinned to
+the release tag; the split-footer recording lives in the focused guide instead
+of the README. No image asset therefore ships in the root crate.
 
 The split is per **published crate**, not per repository, and the deciding
 question is how that crate's own README reaches the asset — because that is what
 determines whether the packaged copy is ever read:
 
 - **Relative path** — crates.io renders the page from the tarball, so the asset
-  must ship. tuika's README assets (`logo.svg`, `docs/hero.gif`,
-  `docs/demos/image.svg`, and `docs/split-footer.gif`) and `tuika-mermaid`'s
-  ~32 KiB recording beside its example are here.
+  must ship. `tuika-mermaid`'s and `tuika-html`'s recordings beside their
+  examples are here.
 - **Absolute `raw.githubusercontent.com` URL** — the packaged copy is
   unreachable from inside the `.crate` and is pure weight, so it is excluded
-  wherever it lives. `tuika-codeformatters`' `docs/languages.gif` was shipping
-  428 KiB this way, 94% of that crate's download.
+  wherever it lives. The root README pins these URLs to its release tag so a
+  later asset refresh cannot rewrite a published crates.io page;
+  `tuika-codeformatters` and `tuika-charts` use `main` for their repository-owned
+  galleries.
 
 So a member needs an `exclude` only when it has an absolute-URL asset; what every
 published member does need is a case in `tests/packaging.rs`, which drives the

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -316,10 +316,11 @@ The root package's alternate logo exports, demos, showcases, themes, and styling
 assets are consumed only by GitHub-rendered pages and repository tooling. docs.rs
 renders the hand-written `//!` header, which references none of them, so bundling
 them only bloats the published `.crate`. Root `Cargo.toml`'s `exclude` keeps them
-— and the repository machinery (`knowledge/`, `.agents/`, `.github/`,
-`scripts/`) — out of that tarball; only `logo.svg`, `docs/hero.gif`,
-`docs/demos/image.svg`, and `docs/split-footer.gif`, which its crates.io README
-embeds by relative path, ship. `docs/demos/` is excluded wholesale, so the two
+— the generated `site/` bundle, and the repository machinery (`knowledge/`,
+.agents/`, `.github/`, `scripts/`) — out of that tarball; only `logo.svg`,
+`docs/hero.gif`, `docs/demos/image.svg`, and `docs/split-footer.gif`, which its
+crates.io README embeds by relative path, ship. `docs/demos/` is excluded
+wholesale, so the two
 recordings that must ship live directly under `docs/` — which is also where they
 belong for a second reason: that directory is the registry's, and `demo -- check`
 fails an asset in it with no scene behind it.

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -312,16 +312,17 @@ regeneration instead of leaving them stale.
 
 ### The crate/GitHub asset split
 
-The root package's alternate logo exports, demos, chart screenshots, showcases,
-themes, and styling assets are consumed only by GitHub-rendered pages and
-repository tooling. docs.rs renders the hand-written `//!` header, which
-references none of them, so bundling them only bloats the published `.crate`.
+The root package's public `docs/` tree and alternate logo exports are consumed
+only by GitHub-rendered pages and repository tooling. docs.rs renders the
+hand-written `//!` header, which references neither, so bundling an incomplete
+copy without its large recordings adds weight without a usable offline guide.
 Root `Cargo.toml`'s `exclude` keeps them
 — the generated `site/` bundle, and the repository machinery (`knowledge/`,
 `.agents/`, `.github/`, `scripts/`) — out of that tarball. The root README
-reaches its logo, hero, and image-protocol demo through absolute URLs pinned to
-the release tag; the split-footer recording lives in the focused guide instead
-of the README. No image asset therefore ships in the root crate.
+reaches every public guide through a GitHub `blob` URL and its logo, hero, and
+image-protocol demo through a raw URL, all pinned to the release tag; the
+split-footer recording lives in the focused guide instead of the README. No
+`docs/` file therefore ships in the root crate.
 
 The split is per **published crate**, not per repository, and the deciding
 question is how that crate's own README reaches the asset — because that is what
@@ -336,6 +337,9 @@ determines whether the packaged copy is ever read:
   later asset refresh cannot rewrite a published crates.io page;
   `tuika-codeformatters` and `tuika-charts` use `main` for their repository-owned
   galleries.
+- **Absolute GitHub `blob` URL** — the same rule for public Markdown guides. The
+  root README pins all guide links to the release tag, so the complete guide and
+  its repository-hosted media remain versioned together outside the crate.
 
 So a member needs an `exclude` only when it has an absolute-URL asset; what every
 published member does need is a case in `tests/packaging.rs`, which drives the

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -3,7 +3,7 @@
 //! Two things must stay out of the tarball, and `Cargo.toml`'s `exclude` is the
 //! only thing keeping them out:
 //!
-//! - The demo/showcase/theme/styling assets under `docs/`, and the `codex`
+//! - The demo/chart/showcase/theme/styling assets under `docs/`, and the `codex`
 //!   example's own recording, are ~14 MiB and are read only from repository
 //!   docs or absolute rustdoc URLs; docs.rs builds the crate front page from the
 //!   hand-written `//!` header in `lib.rs`, which references no images.
@@ -24,10 +24,10 @@
 //! scattering equivalent subprocess tests. Which way it falls for a given
 //! recording is decided by how that crate's
 //! README embeds it: an absolute `raw.githubusercontent.com` URL means the
-//! packaged copy is unreachable and must not ship (`tuika-codeformatters` and
-//! `tuika-charts`), while a relative path means crates.io renders from the
-//! packaged copy and it must (`tuika-mermaid`, `tuika-html`, and tuika's four
-//! README assets).
+//! packaged copy is unreachable and must not ship (`tuika`,
+//! `tuika-codeformatters`, and `tuika-charts`), while a relative path means
+//! crates.io renders from the packaged copy and it must (`tuika-mermaid` and
+//! `tuika-html`).
 
 use std::process::Command;
 
@@ -66,15 +66,15 @@ fn packaged_files(package: &str) -> Vec<String> {
 fn heavy_doc_assets_are_excluded_from_the_package() {
     let files = packaged_files("tuika");
 
-    // No demo/showcase/theme/styling asset, and no example recording, may ship:
-    // those are GitHub-only assets. The two recordings the crates.io README
-    // embeds by relative path — the hero and the split footer — sit directly
-    // under `docs/` for exactly this reason, and are asserted below.
+    // No demo/chart/showcase/theme/styling asset, and no example recording, may
+    // ship: those are GitHub-only assets. README images use tag-pinned absolute
+    // URLs and are asserted below.
     let bundled_heavy_assets: Vec<&String> = files
         .iter()
         .filter(|f| {
             (f.ends_with(".gif") || f.ends_with(".png"))
                 && (f.starts_with("docs/demos/")
+                    || f.starts_with("docs/charts/")
                     || f.starts_with("docs/showcases/")
                     || f.starts_with("examples/codex/")
                     || f.starts_with("docs/styling/")
@@ -135,21 +135,33 @@ fn generated_site_is_excluded_from_the_package() {
 }
 
 #[test]
-fn crates_io_readme_assets_and_source_are_kept() {
+fn root_readme_assets_are_tag_pinned_and_excluded() {
     let files = packaged_files("tuika");
     let has = |p: &str| files.iter().any(|f| f == p);
 
-    // The assets the crates.io README embeds by relative path.
-    assert!(has("logo.svg"), "README logo must ship");
-    assert!(has("docs/hero.gif"), "README hero image must ship");
+    let readme = std::fs::read_to_string("README.md").expect("read root README");
+    let version = env!("CARGO_PKG_VERSION");
+    for asset in ["logo.svg", "docs/hero.gif", "docs/demos/image.svg"] {
+        let url = format!("https://raw.githubusercontent.com/everruns/tuika/v{version}/{asset}");
+        assert!(
+            readme.contains(&url),
+            "README must pin {asset} to v{version}"
+        );
+    }
     assert!(
-        has("docs/demos/image.svg"),
-        "README image-protocol asset must ship"
+        !readme.contains("docs/split-footer.gif"),
+        "split-footer recording belongs in the focused guide, not the root README"
     );
-    assert!(
-        has("docs/split-footer.gif"),
-        "README split-footer recording must ship"
-    );
+
+    for asset in [
+        "logo.svg",
+        "docs/hero.gif",
+        "docs/demos/image.svg",
+        "docs/split-footer.gif",
+    ] {
+        assert!(!has(asset), "absolute README asset must not ship: {asset}");
+    }
+
     // Sanity: the crate still carries its source and manifest.
     assert!(has("src/lib.rs"), "library source must ship");
     assert!(has("Cargo.toml"), "manifest must ship");

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -9,7 +9,9 @@
 //!   hand-written `//!` header in `lib.rs`, which references no images.
 //! - Repository machinery. tuika is the *root* package of its repo, so the
 //!   internal knowledge bundle, agent skills, CI definitions, and
-//!   asset-generation scripts all sit beside it and would otherwise ship.
+//!   asset-generation scripts all sit beside it and would otherwise ship. The
+//!   generated documentation site is repository-only too; crates.io renders
+//!   `README.md` directly and cannot use the site bundle.
 //!   `tuika-codeformatters` has one GitHub-only recording of its own
 //!   (`docs/languages.gif`) under the same rule.
 //!
@@ -118,6 +120,17 @@ fn repository_machinery_is_excluded_from_the_package() {
     assert!(
         nested.is_empty(),
         "nested workspace packages must not ship inside tuika's crate: {nested:?}"
+    );
+}
+
+#[test]
+fn generated_site_is_excluded_from_the_package() {
+    let files = packaged_files("tuika");
+    let leaked: Vec<&String> = files.iter().filter(|f| f.starts_with("site/")).collect();
+
+    assert!(
+        leaked.is_empty(),
+        "the generated documentation site must not ship in the crate: {leaked:?}"
     );
 }
 

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -3,10 +3,9 @@
 //! Three things must stay out of the tarball, and `Cargo.toml`'s `exclude` is the
 //! only thing keeping them out:
 //!
-//! - The demo/chart/showcase/theme/styling assets under `docs/`, and the `codex`
-//!   example's own recording, are ~14 MiB and are read only from repository
-//!   docs or absolute rustdoc URLs; docs.rs builds the crate front page from the
-//!   hand-written `//!` header in `lib.rs`, which references no images.
+//! - The root public `docs/` tree and the `codex` example's own recording are
+//!   read only from the tagged repository; docs.rs builds the crate front page
+//!   from the hand-written `//!` header in `lib.rs`, which references neither.
 //! - Repository machinery. tuika is the *root* package of its repo, so the
 //!   internal knowledge bundle, agent skills, CI definitions, and
 //!   asset-generation scripts all sit beside it and would otherwise ship. The
@@ -19,8 +18,8 @@
 //!   benchmark sources still ship and remain reproducible.
 //!
 //! This test drives the real packaging path (`cargo package --list`) so a stray
-//! asset — or a regression that drops an image the crates.io README needs —
-//! fails loudly instead of silently re-inflating the crate.
+//! repository file or stale README tag pin fails loudly instead of silently
+//! re-inflating the crate or breaking a published guide link.
 //!
 //! It guards all five published crates. The packaging rule is repository-wide,
 //! so the root package checks every companion in one place rather than
@@ -66,27 +65,29 @@ fn packaged_files(package: &str) -> Vec<String> {
 }
 
 #[test]
-fn heavy_doc_assets_are_excluded_from_the_package() {
+fn public_docs_are_tag_pinned_and_excluded_from_the_package() {
     let files = packaged_files("tuika");
-
-    // No demo/chart/showcase/theme/styling asset, and no example recording, may
-    // ship: those are GitHub-only assets. README images use tag-pinned absolute
-    // URLs and are asserted below.
-    let bundled_heavy_assets: Vec<&String> = files
-        .iter()
-        .filter(|f| {
-            (f.ends_with(".gif") || f.ends_with(".png"))
-                && (f.starts_with("docs/demos/")
-                    || f.starts_with("docs/charts/")
-                    || f.starts_with("docs/showcases/")
-                    || f.starts_with("examples/codex/")
-                    || f.starts_with("docs/styling/")
-                    || f.starts_with("docs/themes/"))
-        })
-        .collect();
+    let bundled_docs: Vec<&String> = files.iter().filter(|f| f.starts_with("docs/")).collect();
     assert!(
-        bundled_heavy_assets.is_empty(),
-        "these assets must not ship in the crate (see Cargo.toml `exclude`): {bundled_heavy_assets:?}"
+        bundled_docs.is_empty(),
+        "public docs must stay in the tagged repository, not the crate: {bundled_docs:?}"
+    );
+
+    let readme = std::fs::read_to_string("README.md").expect("read root README");
+    let version = env!("CARGO_PKG_VERSION");
+    let expected_prefix = format!("https://github.com/everruns/tuika/blob/v{version}/docs/");
+    let doc_links: Vec<&str> = readme
+        .split("](")
+        .skip(1)
+        .filter_map(|rest| rest.split(')').next())
+        .filter(|destination| destination.contains("docs/"))
+        .collect();
+    assert!(!doc_links.is_empty(), "README must link to the public docs");
+    assert!(
+        doc_links
+            .iter()
+            .all(|destination| destination.starts_with(&expected_prefix)),
+        "README doc links must be pinned to v{version}: {doc_links:?}"
     );
 }
 

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -1,6 +1,6 @@
 //! Guards the published `.crate` contents.
 //!
-//! Two things must stay out of the tarball, and `Cargo.toml`'s `exclude` is the
+//! Three things must stay out of the tarball, and `Cargo.toml`'s `exclude` is the
 //! only thing keeping them out:
 //!
 //! - The demo/chart/showcase/theme/styling assets under `docs/`, and the `codex`
@@ -14,6 +14,9 @@
 //!   `README.md` directly and cannot use the site bundle.
 //!   `tuika-codeformatters` has one GitHub-only recording of its own
 //!   (`docs/languages.gif`) under the same rule.
+//! - Benchmark output. Cargo naturally leaves generated `target/` reports out,
+//!   while manifest exclusions keep committed IAI result snapshots out. The
+//!   benchmark sources still ship and remain reproducible.
 //!
 //! This test drives the real packaging path (`cargo package --list`) so a stray
 //! asset — or a regression that drops an image the crates.io README needs —
@@ -132,6 +135,30 @@ fn generated_site_is_excluded_from_the_package() {
         leaked.is_empty(),
         "the generated documentation site must not ship in the crate: {leaked:?}"
     );
+}
+
+#[test]
+fn benchmark_results_are_excluded_from_every_package() {
+    for package in [
+        "tuika",
+        "tuika-charts",
+        "tuika-codeformatters",
+        "tuika-html",
+        "tuika-mermaid",
+    ] {
+        let files = packaged_files(package);
+        let leaked: Vec<&String> = files
+            .iter()
+            .filter(|path| {
+                path.starts_with("target/")
+                    || (path.starts_with("benches/") && path.ends_with(".json"))
+            })
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "benchmark results must not ship in {package}: {leaked:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## What changed

Prepare the corrected v0.9.0 release. The root crate now excludes the generated
`site/` bundle, the public `docs/` tree, and committed benchmark result
snapshots from its published archive. The root README uses release-tag-pinned
URLs for every guide and image; the split-footer animation lives in the focused
screen-modes guide. The packaging suite guards that boundary and every version
pin.

## Why

The first v0.9.0 archive accidentally included the documentation website and
grew to 18.5 MiB compressed, above crates.io's documented 10 MiB upload limit.
The registry edge returned HTTP 503 and HTTP/2 stream failures instead of a
useful size error. Because crates.io never accepted v0.9.0, the original GitHub
Release and tag were deleted so the version can be recreated from this fixed
commit.

## Before / After

- Before: 396 files, 21.5 MiB unpacked, 18.5 MiB compressed; upload failed.
- After: 160 files, 2.0 MiB unpacked, 528.6 KiB compressed; publish dry-run passes.

## [0.9.0] - 2026-08-15

Released alongside `tuika-charts` 0.1.0 — its first release — plus
`tuika-mermaid` 0.3.0, `tuika-codeformatters` 0.4.2, and `tuika-html` 0.1.2.
Their tuika dependency requirements now track 0.9.

### Highlights

**Charts, in a companion crate.** `tuika-charts` renders line, area, bar, step,
and scatter series and picks its own fidelity: terminal graphics where the
emulator supports them, portable half-block and Braille cells everywhere else,
from the same `Chart` description.

![chart demo](https://raw.githubusercontent.com/everruns/tuika/v0.9.0/docs/charts/line-graphics.png)

**Trees and multi-pane interaction.** `TreeList` brings stable-id expansion,
selection, and persistent scrolling over host-owned rows, on the same reusable
primitives — `SelectViewportState`, `FocusRegistry::focus`, hit testing — that
let several panes in one screen share focus and the mouse.

![tree list demo](https://raw.githubusercontent.com/everruns/tuika/v0.9.0/docs/demos/tree_list.gif)

- **Runner**: one `FrameSource` seam and one `Signal` replace ten `run*` methods
  across the two runtimes; the synchronous loop is now drivable from a
  caller-owned terminal, so a whole application can be tested with no tty.

### Added

- `Runner::run_driven_by` is the synchronous counterpart to
  `AsyncRunner::run_driven_by`: the loop against a caller-owned terminal and
  event source, with no `TerminalSession`, no terminal construction, and no
  stdout-facing graphics or clipboard work. `run` and `run_with_backend` are now
  built on it, so every synchronous entry point shares one loop. It is generic
  over the run's error type, so an infallible backend (`TestBackend`) pairs with
  an infallible source.
- `EventSource` is where that loop gets its input, and `scripted_events` builds
  one from a known sequence of events — replaying them in order, then going idle
  like a quiet terminal so tick pacing is unchanged. Together they let a host
  (or a test) drive a whole application with no tty: previously the synchronous
  loop could not be exercised at all, and only its pieces (`RunnerCore`, the
  clock, selection) had coverage. Seven end-to-end tests now cover the initial
  frame, event-driven state, clean updates neither rebuilding nor repainting,
  the borrowed application seam, redraw requests, deferred resize repaints, and
  split-footer publishing.
- `SelectViewportState` couples index selection to a persistent top row for
  `SelectList` and `Table`. Its resolved `VirtualWindow` is shared with mouse
  hit testing, so selection scrolls only across viewport edges and clicks do not
  recenter the list. The existing selection-centered `.viewport(rows)` remains
  available; persistent hosts migrate to `resolve` plus `.visible_window`.
- `TreeList`, `TreeRow`, and `TreeState` provide stable-id expansion, selection,
  keyboard/mouse navigation, ancestor fallback across refreshes, persistent
  scrolling, branch rendering, and a scrollbar over host-provided tree rows.
- `FocusRegistry::focus(id)` lets a `HitMap` focus a registered pane while
  rejecting unknown ids and requests blocked by overlay input ownership.
- `AsyncRunner::run_with_messages` delivers a typed application stream beside
  terminal events and ticks, with deterministic completion/error/redraw/exit
  behavior and no shared mutable state or polling.
- `AsyncApplication` is the borrowed-view application seam for the async runner,
  the counterpart to `Application`: previously a frame could borrow application
  state only on the synchronous runner, so a Tokio host had to clone into an
  owned tree or share through `Rc<RefCell<_>>`.
- `FrameSource` / `AsyncFrameSource` is the single seam every run method now
  takes, with exactly two implementors: `&mut app` for an `Application`, and
  `from_fn(&mut state, view, update)` (`async_from_fn` for the async runner) for
  the closure form. `no_messages()` is the empty application-message stream.
- `AsyncRunner::redraw_handle` matches `Runner::redraw_handle`, so a `Live`
  value (or any background producer) can mark the next frame stale on either
  runner. `RedrawHandle` now registers the waiting task's waker, so the async
  loop is woken by a request instead of only noticing one on its next tick;
  bursts still coalesce into a single repaint.
- `Runner` and `AsyncRunner` restore drag-to-select behavior by default when
  their terminal session captures the mouse. Selection is painted over the
  final cell frame, releasing copies through OSC 52 on real-terminal runs, and
  wheel events continue to reach application scrolling. Applications can claim
  gestures with `UpdateResult::Consumed` / `Dirty` or opt out with
  `with_text_selection(false)`.
- Hover styling: `mouse::HoverTracker` pairs the pointer-motion stream with the
  existing `HitMap` hit-testing, reporting when the hovered region changes so a
  host can restyle it (and knows a redraw is warranted).
- Timed style transitions: `anim::Transition` is a retargetable eased ramp for
  state-driven motion (hover on/off, focus, expansion) — retargeting mid-flight
  continues from the current value instead of jumping. `anim::lerp` and
  `style::lerp_color` interpolate scalars and 24-bit colors; non-RGB colors
  snap to the nearer endpoint, since an indexed color has no blendable value.
- Gradient color spans: `style::Gradient` is a multi-stop color ramp with
  even (`across`) or explicit (`with_stops`) stops; `Gradient::line` sweeps a
  string's foreground across the ramp per display column (wide glyphs get one
  coherent color) for use with `Text`. `Transition` and `Gradient` (with
  `lerp_color`) are also in the prelude.

### Fixed

- The published crate excludes the generated `site/` bundle and the public
  `docs/` tree, keeping the 0.9.0 archive below crates.io's 10 MiB upload limit.
  README guide and image links now use release-tag-pinned absolute URLs, and the
  split-footer recording lives in its focused guide rather than being
  duplicated in the README. Committed IAI benchmark result snapshots are
  excluded from both crates that own them; benchmark source remains available.
- `tuika-mermaid` renders a Mermaid decision node with a `<br/>` label as a
  diagram, with every label line inside the shape. The upstream defect
  ([mmdflux#387](https://github.com/kevinswiber/mmdflux/issues/387)) — which
  unwound out of `View::render` and took the host application down, and failed
  silently in release builds by dropping the label or painting a short one over
  the shape's own borders — is fixed in mmdflux 2.6.1, which `tuika-mermaid`
  now requires. The adapter-side guard that degraded these fences to the
  code-block fallback is gone with it; the unconditional panic containment
  around the layout engine stays.

### Changed

**Breaking: the runner's `run*` surface is one seam plus two axes.** The methods
were a cross product of frame source, runtime, terminal ownership, and extra
input, encoded as names — ten of them on `AsyncRunner` — with arbitrary holes in
the product. The frame source is now a `FrameSource` argument rather than a
name, and messages ride the existing `Signal`, which leaves only *where the
terminal and the input come from* in the names.

`Signal` gained a message type parameter, `Signal<M = Infallible>`. Because the
default is uninhabited, an existing `match signal { Signal::Tick => …,
Signal::Event(e) => … }` **still compiles and stays exhaustive**. A `match` on a
*reference* (`match &signal`) does need a `_` arm added. `AsyncSignal<M>` is now
a deprecated alias for `Signal<M>`.

| Before | After |
| --- | --- |
| `Runner::run(theme, state, view, update)` | `Runner::run(theme, from_fn(state, view, update))` |
| `Runner::run_app(theme, app)` | `Runner::run(theme, app)` *(shim, deprecated)* |
| `Runner::run_with_backend(theme, backend, state, view, update)` | `Runner::run_with_backend(theme, backend, from_fn(state, view, update))` |
| `Runner::run_app_with_backend(theme, backend, app)` | `Runner::run_with_backend(theme, backend, app)` *(shim, deprecated)* |
| `AsyncRunner::run(theme, state, view, update)` | `AsyncRunner::run(theme, async_from_fn(state, view, update))` |
| `AsyncRunner::run_with_messages(theme, state, messages, view, update)` | `AsyncRunner::run_with_messages(theme, async_from_fn(state, view, update), messages)` |
| `AsyncRunner::run_with_backend(theme, backend, state, view, update)` | `AsyncRunner::run_with_backend(theme, backend, async_from_fn(state, view, update))` |
| `AsyncRunner::run_with_events(terminal, theme, state, events, view, update)` | `AsyncRunner::run_driven_by(terminal, theme, async_from_fn(state, view, update), events, no_messages())` *(shim, deprecated)* |
| `AsyncRunner::run_with_events_and_messages(terminal, theme, state, events, messages, view, update)` | `AsyncRunner::run_driven_by(terminal, theme, async_from_fn(state, view, update), events, messages)` *(shim, deprecated)* |

Methods marked *shim* keep working with a deprecation warning. The rest changed
shape under the same name, so they fail to compile rather than warn — the
migration is mechanical and the table above is exhaustive.

- `Paragraph` now treats its input as human-facing prose: bare `http(s)` URLs
  use the stylesheet's link role and carry OSC 8 targets through wrapping by
  default. `Paragraph::link_policy(LinkPolicy::NONE)` restores literal,
  single-style rendering; `Text`, `Wrap`, `CodeBlock`, and `Console` remain
  inert.
- **Breaking**: `UpdateResult::Clean` now means an input was unhandled and may
  receive runner default behavior; return the new `UpdateResult::Consumed` for
  a handled input that does not need a repaint. Exhaustive matches over
  `UpdateResult` must add the new variant.
- `tuika-mermaid` re-lays out a diagram wider than the available columns at
  progressively tighter node separation until it fits, instead of letting it be
  clipped at the pane's right edge. Fitting is best-effort: a graph with many
  parallel branches can be irreducibly wider than the terminal, and the
  narrowest layout is used there. Diagrams that already fit keep mmdflux's own
  spacing, so existing renders are unchanged.

## Publish-readiness

- [x] `python3 scripts/validate_okf.py knowledge --check-links`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] `cargo run --example demo -- check`
- [x] `cargo doc --workspace --all-features --no-deps`
- [x] `cargo publish --dry-run --locked --allow-dirty -p tuika`
- [x] Packaging regression: `site/`, `docs/`, and benchmark results are absent;
      source, manifest, README, version-pinned guide/image URLs, and benchmark
      source remain
- [x] crates.io currently serves tuika 0.8.0 → publishing 0.9.0
- [x] Companion versions remain unpublished: charts 0.1.0, codeformatters 0.4.2,
      HTML 0.1.2, and Mermaid 0.3.0
- [x] `Cargo.toml` and `Cargo.lock` agree on 0.9.0
- [x] Highlight demos and root README guide/image URLs are current and pinned to v0.9.0

## Post-merge verification

- [ ] `release.yml` created tag `v0.9.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] crates.io serves 0.9.0 and every intended companion version
- [ ] docs.rs built tuika 0.9.0 and the published companion versions

## Risk

- Low
- An overly broad package exclusion could omit user-facing files. The packaging
  suite verifies required source, manifest, and README files remain, each root
  README guide/image URL matches the package version, and no incomplete docs copy
  or benchmark result ships.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered; runtime and public API are unchanged
- [x] Knowledge concepts updated

## Knowledge

Updated the documentation specification, release process, release skill, and
knowledge log with the generated-site, public-guide, and benchmark-result
package boundary.

## Security

No runtime or public API code changed. Reviewed the supply-chain boundary: the
published archive now contains buildable crate sources and public text docs, but
no credentials, repository-only website files, incomplete public guides, or
benchmark result snapshots.

## Follow-ups

No follow-ups.