### PR TITLE
feat(site): copyable install command, linked lede, highlighted sample

### DIFF
--- a/site/src/lib/home-install.client.ts
+++ b/site/src/lib/home-install.client.ts
@@ -1,0 +1,38 @@
+/**
+ * Copy-on-click for the hero install command.
+ *
+ * Selecting the text still works, so the button is a convenience rather than
+ * the only way to get the command out of the page. A failed copy (insecure
+ * context, denied permission) says so instead of silently pretending success.
+ */
+
+const RESET_MS = 1600;
+
+function initHomeInstall(button: HTMLButtonElement): void {
+  const label = button.querySelector<HTMLElement>("[data-home-install-label]");
+  const status = document.querySelector<HTMLElement>("[data-home-install-status]");
+  const defaultLabel = label?.textContent ?? "Install";
+  let timer: number | undefined;
+
+  button.addEventListener("click", async () => {
+    let state: "copied" | "failed" = "copied";
+    try {
+      await navigator.clipboard.writeText(button.dataset.command ?? "");
+    } catch {
+      state = "failed";
+    }
+
+    button.dataset.state = state;
+    if (label) label.textContent = state === "copied" ? "Copied" : "Press ⌘C";
+    if (status) status.textContent = state === "copied" ? "Copied to clipboard" : "Copy failed — select the command and copy it manually";
+
+    if (timer) window.clearTimeout(timer);
+    timer = window.setTimeout(() => {
+      delete button.dataset.state;
+      if (label) label.textContent = defaultLabel;
+      if (status) status.textContent = "";
+    }, RESET_MS);
+  });
+}
+
+document.querySelectorAll<HTMLButtonElement>("[data-home-install]").forEach(initHomeInstall);

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Header from "../components/Header.astro";
+import { Icon } from "astro-icon/components";
+import { Code } from "astro:components";
 import "../styles/home.css";
 
 const guides = [
@@ -62,8 +64,7 @@ const head = [{
             <h1>tuika</h1>
             <p class="home-subtitle">Rust terminal application framework</p>
             <p class="home-lede">
-              Layout, overlays, focus, keymaps, components, and terminal
-              lifecycle over ratatui.
+              <a href="/layout/">Layout</a>{", "}<a href="/components/interactive/#scene--dialog">overlays</a>{", "}<a href="/components/layout/#focusscope">focus</a>{", "}<a href="/keymap/">keymaps</a>{", "}<a href="/components/">components</a>{", and "}<a href="/features/">terminal lifecycle</a>{" over "}<a href="https://ratatui.rs">ratatui</a>.
             </p>
 
             <div class="home-actions">
@@ -71,10 +72,21 @@ const head = [{
               <a class="home-button" href="https://github.com/everruns/tuika">GitHub</a>
             </div>
 
-            <div class="home-install" aria-label="Install tuika">
-              <span>Install</span>
+            <button
+              class="home-install"
+              type="button"
+              data-home-install
+              data-command="cargo add tuika"
+              aria-label="Copy install command: cargo add tuika"
+            >
+              <span class="home-install-label" data-home-install-label>Install</span>
               <code>cargo add tuika</code>
-            </div>
+              <span class="home-install-icon" aria-hidden="true">
+                <Icon name="ph:copy" data-home-install-icon-copy />
+                <Icon name="ph:check" data-home-install-icon-check />
+              </span>
+            </button>
+            <span class="home-install-status" role="status" aria-live="polite" data-home-install-status></span>
           </div>
 
           <div class="home-mark" aria-hidden="true">
@@ -130,7 +142,9 @@ const head = [{
               <li>Render tests use an in-memory buffer, not a terminal.</li>
             </ul>
           </div>
-          <pre class="home-code"><code>{codeSample}</code></pre>
+          {/* Pinned to a dark Shiki theme rather than the docs' mode-aware pair:
+              this panel is dark in both color modes. */}
+          <Code class="home-code" code={codeSample} lang="rust" theme="github-dark-default" />
         </div>
       </section>
 
@@ -182,3 +196,7 @@ const head = [{
     </footer>
   </div>
 </BaseLayout>
+
+<script>
+  import "../lib/home-install.client";
+</script>

--- a/site/src/styles/home.css
+++ b/site/src/styles/home.css
@@ -76,6 +76,22 @@
   line-height: 1.6;
 }
 
+/* Each term points at the guide that covers it; underlined on hover only, so
+   the lede still reads as a sentence rather than a link list. */
+.home-lede a {
+  color: #cfcfcf;
+  text-decoration: underline;
+  text-decoration-color: #3a3a3a;
+  text-underline-offset: 0.25em;
+  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+}
+
+.home-lede a:hover,
+.home-lede a:focus-visible {
+  color: var(--home-gold);
+  text-decoration-color: var(--home-gold);
+}
+
 .home-actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 2rem; }
 
 .home-button {
@@ -95,17 +111,95 @@
 .home-button-primary { border-color: var(--home-gold); background: var(--home-gold); color: #090909; }
 .home-button-primary:hover { border-color: #e7b94f; background: #e7b94f; color: #090909; }
 
-.home-install {
-  display: flex;
-  width: fit-content;
-  margin-top: 1rem;
-  border: 1px solid #2a2a2a;
-  font-family: var(--nb-font-mono);
-  font-size: 0.78rem;
+/* These surfaces are dark in both color modes, so the global ::selection —
+   which resolves its text color from the mode-dependent --nb-foreground —
+   turns invisible on them in light mode. Pin it to their own palette. */
+.home-hero::selection,
+.home-hero ::selection,
+pre.home-code ::selection,
+pre.home-code::selection {
+  background: rgb(212 164 58 / 0.32);
+  color: #fff;
 }
 
-.home-install span { padding: 0.6rem 0.75rem; color: #777; border-right: 1px solid #2a2a2a; }
-.home-install code { padding: 0.6rem 0.75rem; background: transparent; color: #e6e6e6; }
+.home-install {
+  display: flex;
+  align-items: stretch;
+  width: fit-content;
+  margin-top: 1rem;
+  padding: 0;
+  border: 1px solid #2a2a2a;
+  background: transparent;
+  color: inherit;
+  font-family: var(--nb-font-mono);
+  font-size: 0.78rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.home-install:hover { border-color: #4a4a4a; background: #101010; }
+.home-install:hover .home-install-icon { color: #e6e6e6; }
+
+.home-install-label {
+  padding: 0.6rem 0.75rem;
+  border-right: 1px solid #2a2a2a;
+  color: #777;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.home-install code {
+  padding: 0.6rem 0.75rem;
+  background: transparent;
+  color: #e6e6e6;
+  user-select: text;
+}
+
+.home-install-icon {
+  display: grid;
+  place-items: center;
+  padding: 0 0.7rem;
+  border-left: 1px solid #2a2a2a;
+  color: #777;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.home-install-icon svg { width: 1rem; height: 1rem; }
+.home-install [data-home-install-icon-check] { display: none; }
+
+.home-install[data-state="copied"] {
+  border-color: var(--home-gold);
+  background: rgb(212 164 58 / 0.08);
+}
+
+.home-install[data-state="copied"] .home-install-label,
+.home-install[data-state="copied"] .home-install-icon {
+  border-color: var(--home-gold);
+  color: var(--home-gold);
+}
+
+.home-install[data-state="copied"] [data-home-install-icon-copy] { display: none; }
+.home-install[data-state="copied"] [data-home-install-icon-check] { display: block; }
+
+.home-install[data-state="failed"] .home-install-label { color: #e6e6e6; }
+
+@media (prefers-reduced-motion: no-preference) {
+  .home-install[data-state="copied"] { animation: home-install-flash 0.4s ease-out; }
+}
+
+@keyframes home-install-flash {
+  from { background: rgb(212 164 58 / 0.3); }
+  to { background: rgb(212 164 58 / 0.08); }
+}
+
+.home-install-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
 
 .home-mark {
   width: 100%;
@@ -169,7 +263,19 @@
 .home-model p { margin-top: 1.25rem; }
 .home-list { display: grid; gap: 0.65rem; margin-top: 1.5rem; color: var(--nb-muted-foreground); font-size: 0.9rem; }
 .home-list li { margin-left: 1rem; padding-left: 0.25rem; }
-.home-code { margin: 0; overflow-x: auto; border: 1px solid #252525; background: #0b0d10; padding: clamp(1.25rem, 4vw, 2rem); color: #e8e8e8; font: 0.84rem/1.8 var(--nb-font-mono); }
+pre.home-code {
+  margin: 0;
+  overflow-x: auto;
+  border: 1px solid #252525;
+  border-radius: 0;
+  background: #0b0d10;
+  padding: clamp(1.25rem, 4vw, 2rem);
+  color: #e8e8e8;
+  font: 0.84rem/1.8 var(--nb-font-mono);
+}
+
+/* Shiki paints tokens inline; only the panel chrome is ours. */
+pre.home-code code { background: transparent; }
 
 .home-guide-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border-top: 1px solid var(--nb-border-strong); }
 .home-guide-grid a { display: grid; grid-template-columns: 10rem 1fr auto; gap: 1rem; padding: 1.25rem 0; border-bottom: 1px solid var(--nb-border); color: var(--home-ink); text-decoration: none; }


### PR DESCRIPTION
## What changed

Homepage hero and rendering-model section:

- **Selected text is readable on the dark surfaces.** Selecting `cargo add tuika` (or anything else in the hero, or the code sample) no longer renders invisible text in light mode.
- **The install command copies on click.** The `Install | cargo add tuika` chip is now a button: clicking copies the command, the label flips to **Copied** with a gold border and check icon for 1.6s, and a visually-hidden live region announces the result. The command text stays selectable, so the manual path still works. A failed copy (insecure context, denied permission) shows `Press ⌘C` and says so in the live region instead of faking success.
- **The lede links each term to its guide** — Layout → `/layout/`, overlays → `/components/interactive/#scene--dialog`, focus → `/components/layout/#focusscope`, keymaps → `/keymap/`, components → `/components/`, terminal lifecycle → `/features/`, ratatui → ratatui.rs. Underlined faintly so the sentence still reads as prose; gold on hover/focus.
- **The code sample is syntax highlighted**, rendered through Shiki as Rust and pinned to a dark theme rather than the docs' mode-aware pair, because that panel is dark in both color modes.

## Why

The hero and the code panel are dark in both color modes, but the global `::selection` takes its text color from the mode-dependent `--nb-foreground` — so in light mode a selection painted near-black text over a near-black panel and the command disappeared exactly when a visitor tried to copy it. Copy-on-click removes the need to select at all; the linked lede turns the page's one-line summary into navigation into the guides it names; and the sample looked like a screenshot of plain text next to a page that highlights every other code block.

## Before / After

Rendered lede markup, `dist/index.html`:

```
before: <p class="home-lede">Layout, overlays, focus, keymaps, components, and terminal lifecycle over ratatui.</p>
after:  href="/layout/" href="/components/interactive/#scene--dialog" href="/components/layout/#focusscope"
        href="/keymap/" href="/components/" href="/features/" href="https://ratatui.rs"
```

Selection, before and after, in light mode: `background: color-mix(in oklch, var(--nb-primary) 10%, transparent); color: var(--nb-foreground)` (near-black on `#070707`) → `background: rgb(212 164 58 / 0.32); color: #fff`.

Sample panel: one flat `#e8e8e8` `<pre>` → `pre.astro-code.github-dark-default` with per-token colors (`use` `#FF7B72`, `Spinner`/`Markdown`/`StatusBar` `#FFA657`, calls `#D2A8FF`).

Verified in a real browser (headless Chromium at 1280×900) across four states — idle, text selected, post-click "Copied", and the highlighted panel with its own selection — each rendered as expected: gold selection wash with white text, the gold Copied chip with a check glyph, and colored Rust tokens.

## Risk

- Low
- The install chip becomes a `<button>`; drag-selecting inside a button is less natural than inside a `<div>`, so `user-select: text` is set on the command itself to keep that path. `navigator.clipboard` is unavailable over plain HTTP and under denied permissions — both land in the failure branch, which tells the visitor to copy manually rather than silently doing nothing.
- Anchors `#scene--dialog` and `#focusscope` are generated from docs headings; renaming either heading would break the deep link. Both were asserted present in the built output.
- No Rust code, public API, or dependency changed.

## Checklist

- [ ] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Tests: unchecked deliberately. The site has no page-level test harness (`site/src/worker.test.js` covers the Worker's request handling only), and this change is presentation and client-side interaction on one page. Verified instead by build + typecheck + browser automation across the four states above, plus an assertion that every new link target and anchor exists in the built output. Gap listed under **Follow-ups**.

Validation run:

```
pnpm build      # 19 pages; postbuild verify-site: 18 HTML pages, Markdown twins, SEO metadata OK
pnpm typecheck  # astro check — 104 files, 0 errors, 0 warnings, 0 hints
pnpm test       # worker suite, 0 fail
pnpm lint:docs  # 1 file lint clean
```

Rust workspace untouched, so no `cargo` evidence applies.

## Knowledge

No knowledge update required — `knowledge/specs/documentation.md` covers the website's role (browsable home for `docs/`, static Workers deployment, Markdown twins), and none of that changes. This is homepage presentation and one page's client-side interaction.

## Security

No Rust or terminal-facing code changed, so TM-ESC, TM-STATE, TM-PARSE, TM-CLIP, and TM-DEP are all inapplicable. Reviewing the added client script on its own terms: it writes a single page-authored constant (`data-command="cargo add tuika"`) to the clipboard — no user input, no URL or storage data reaches the clipboard — and all DOM updates go through `textContent` and `dataset`, never `innerHTML`, so no injection surface is introduced. No new dependency; the copy icons reuse the site's existing `@iconify-json/ph` set, and highlighting reuses Astro's bundled Shiki.

## Follow-ups

- No page-level (DOM) test harness exists for the site, so the copy interaction and the selection contrast are covered by manual browser verification rather than an automated check. Adding one is worth doing when a second interactive homepage element appears; a single button does not justify standing up the harness in this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHKzL3FnQCRXYhduT4MGfY)_