### PR TITLE
feat(components): add label_style and selection anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ described in the release process begins with the entry below.
 
 ## Unreleased
 
+### Added
+
+- **Components**: `ProgressBar::label_style` styles the caption set by
+  `label`, the same theme-by-default/explicit-override pattern as `colors`. The
+  trailing `NN%` of `percent` stays separate chrome on the theme's muted style.
+- **Components**: `SelectionAnchor` selects how `Table` and `SelectList` window
+  themselves around the selection when they resolve their own window —
+  `Center` (today's recentering behavior, still the default) or `Edge`, which
+  moves the window only when the selection would leave it.
+- **Virtualization**: `VirtualWindow::keeping` is the edge-following policy as a
+  pure function of the caller's current start; `SelectViewportState::resolve`
+  now uses it, so the persistent and stateless paths share one implementation.
+
 ### Changed
 
 - **Breaking:** Mouse capture is now opt-in in alternate-screen mode, preserving native OSC 8

--- a/docs/components/interactive.md
+++ b/docs/components/interactive.md
@@ -191,7 +191,9 @@ A selectable list; `SelectState` navigates with the arrow keys (wrapping),
 confirms on Enter, cancels on Esc. `new()` and `default()` select the first row;
 `SelectState::unselected()` starts cursorless, and `state.select(None)` clears an
 existing selection so neither caret nor highlight is drawn. `.selection_style(style)`
-overrides the theme selection style for one list. `handle_with` accepts a
+overrides the theme selection style for one list, and
+`.selection_anchor(SelectionAnchor::Edge)` scrolls only when the selection would
+leave the window instead of recentering on it. `handle_with` accepts a
 `SelectNavigation` policy; `SelectNavigation::common()` enables j/k, Ctrl+N/P,
 Tab/Shift+Tab, and numeric shortcuts. `handle_mouse` hit-tests explicit list
 bounds and a viewport offset. `MultiSelectState` adds Enter/Space/click toggling
@@ -295,7 +297,10 @@ sets the gutter marker,
 `.header_style(Style)` restyles the header, `.selection_style(Style)` controls
 one table's selection band (including modifiers), and
 `.preserve_selection_fg(true)` keeps color-coded columns' own colors under the
-selection highlight.
+selection highlight. `.selection_anchor(SelectionAnchor::Edge)` swaps the
+stateless windowing policy from "recenter on the selection" (the default,
+`SelectionAnchor::Center`) to "move only when the selection would leave the
+window".
 [API](https://docs.rs/tuika/latest/tuika/components/struct.Table.html)
 
 ```rust

--- a/docs/components/motion.md
+++ b/docs/components/motion.md
@@ -33,7 +33,9 @@ view! {
 
 A single-row bar: determinate (sub-cell eighth-block fill, optional `NN%`) or an
 indeterminate marquee driven by the frame counter. `.label("…")` overlays a
-centered caption and clips it on narrow terminals.
+centered caption and clips it on narrow terminals; `.colors(filled, track)` and
+`.label_style(Style)` override the theme defaults for a host whose bar has its
+own palette.
 [API](https://docs.rs/tuika/latest/tuika/components/struct.ProgressBar.html)
 
 <img src="../demos/progress_bar.gif" width="880" alt="ProgressBar demo">
@@ -42,7 +44,12 @@ centered caption and clips it on narrow terminals.
 use tuika::prelude::*;
 view! {
     col(gap = 1) {
-        node(ProgressBar::determinate(0.6).label("0:42/3:07").percent(true))
+        node(
+            ProgressBar::determinate(0.6)
+                .label("0:42/3:07")
+                .label_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::ITALIC))
+                .percent(true),
+        )
         node(ProgressBar::indeterminate(frame))
     }
 }

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -13,6 +13,24 @@
     inference cannot recover a URL emitted across several incremental terminal
     diffs, so hosts apply `MarkdownState::links` after viewporting instead.
 
+- **A stateless component still owes a choice of windowing policy**
+  - `VirtualWindow::around` was the only policy a component could reach without
+    host state, so the more common list behaviour — scroll only when the
+    selection leaves the window — was available exclusively through
+    `SelectViewportState`, i.e. by threading persistent state and a known pane
+    height through a host's model. That is the custom-`View` cost the
+    render-height windowing was added to remove.
+  - The two policies were never different math, only different memory:
+    `VirtualWindow::keeping` takes the caller's current start (`0` for a
+    stateless caller) and `around` recenters unconditionally. `SelectViewportState`
+    now uses `keeping`, so there is one implementation and `SelectionAnchor`
+    exposes the choice on `Table` and `SelectList`.
+  - Component chrome overridable "everywhere except one place" is a defect, not
+    a gap: `ProgressBar` could recolor its fill and track but pinned the caption
+    to the theme, which silently dropped a host's configured caption color. Each
+    visual property a component paints needs its own override, and semantically
+    distinct chrome (the caption vs the `NN%` suffix) keeps distinct knobs.
+
 - **The generated website is not part of the published crate**
   - `site/` mirrors public documentation and bundles generated assets for the
     tuika.dev deployment; crates.io renders `README.md` directly and cannot use

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -62,6 +62,10 @@ rather than beside it.
   `SelectViewportState` resolves one explicit `VirtualWindow` that is reused by
   rendering and mouse hit testing. Selection crossing an edge moves the window
   minimally; resize and collection refresh are explicit reconciliation points.
+  Centering and edge-following are the *same* window math (`VirtualWindow::around`
+  and `VirtualWindow::keeping`) with and without a remembered start, so a
+  stateless component can offer either policy via `SelectionAnchor` without a
+  host threading persistent state through its model to get the common one.
   `TreeState` extends the same host-owned model with stable node identity,
   expansion, and remembered ancestry while domain traversal remains outside the
   toolkit.

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -116,4 +116,4 @@ pub use textinput::{
 pub use toast::{ToastLevel, ToastList, Toasts};
 pub use tree_list::{TreeList, TreeRow, TreeState};
 pub use viewport::Viewport;
-pub use virtualization::{Scrollbar, VirtualWindow};
+pub use virtualization::{Scrollbar, SelectionAnchor, VirtualWindow};

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -27,6 +27,7 @@ pub struct ProgressBar {
     /// Append a right-aligned `NN%` label to a determinate bar.
     show_percent: bool,
     label: Option<String>,
+    label_style: Option<Style>,
     filled: Option<ratatui_core::style::Color>,
     track: Option<ratatui_core::style::Color>,
 }
@@ -39,6 +40,7 @@ impl ProgressBar {
             frame: 0,
             show_percent: false,
             label: None,
+            label_style: None,
             filled: None,
             track: None,
         }
@@ -51,6 +53,7 @@ impl ProgressBar {
             frame,
             show_percent: false,
             label: None,
+            label_style: None,
             filled: None,
             track: None,
         }
@@ -65,6 +68,18 @@ impl ProgressBar {
     /// Draw a centered caption over the bar, clipped to its available width.
     pub fn label(mut self, label: impl Into<String>) -> Self {
         self.label = Some(label.into());
+        self
+    }
+
+    /// Style the caption set by [`label`](Self::label), overriding the default
+    /// (the theme's body-text style) — the same theme-by-default,
+    /// explicit-override pattern as [`colors`](Self::colors).
+    ///
+    /// This restyles only the caption; the trailing `NN%` of
+    /// [`percent`](Self::percent) is separate chrome and keeps the theme's
+    /// muted style.
+    pub fn label_style(mut self, style: Style) -> Self {
+        self.label_style = Some(style);
         self
     }
 
@@ -177,7 +192,8 @@ impl ProgressBar {
             .x
             .saturating_add(region.width.saturating_sub(width) / 2);
         let mut clipped = surface.child(region);
-        clipped.set_string(x, area.y, label, ctx.theme.text_style());
+        let style = self.label_style.unwrap_or_else(|| ctx.theme.text_style());
+        clipped.set_string(x, area.y, label, style);
     }
 }
 
@@ -248,6 +264,34 @@ mod tests {
         let narrow = crate::testing::render(&bar, 4, 1, &theme);
         assert_eq!(row(&narrow, 0), "0:42");
         assert_eq!(narrow[(0, 0)].fg, theme.text);
+    }
+
+    #[test]
+    fn progress_bar_label_style_overrides_the_theme() {
+        let theme = Theme::default();
+        let style = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(ratatui_core::style::Modifier::ITALIC);
+        let bar = ProgressBar::determinate(0.5)
+            .colors(Color::Green, Color::Black)
+            .label("0:42")
+            .label_style(style);
+        // 10 cells, a 4-column caption: centered at x = 3..7.
+        let buf = crate::testing::render(&bar, 10, 1, &theme);
+        assert!(row(&buf, 0).contains("0:42"));
+        for x in 3..7 {
+            assert_eq!(buf[(x, 0)].fg, Color::Cyan, "caption fg at {x}");
+            assert!(
+                buf[(x, 0)]
+                    .modifier
+                    .contains(ratatui_core::style::Modifier::ITALIC),
+                "caption italic at {x}"
+            );
+        }
+        // Track cells keep the bar colors; the caption did not bleed into them.
+        assert_eq!(buf[(0, 0)].fg, Color::Green, "filled cell fg");
+        assert_eq!(buf[(9, 0)].bg, Color::Black, "track cell bg");
+        assert_ne!(buf[(9, 0)].fg, Color::Cyan, "track cell fg");
     }
 
     #[test]

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -15,7 +15,7 @@ use crate::geometry::Size;
 use crate::surface::Surface;
 use crate::view::{RenderCtx, View};
 
-use super::{Scrollbar, VirtualWindow};
+use super::{Scrollbar, SelectionAnchor, VirtualWindow};
 
 /// Optional navigation bindings for [`SelectState`].
 ///
@@ -129,19 +129,16 @@ impl SelectViewportState {
     /// never changes its start.
     pub fn resolve(&mut self, len: usize, visible: usize) -> VirtualWindow {
         self.selection.clamp(len);
-        let visible = visible.min(len);
-        self.offset = self.offset.min(VirtualWindow::max_start_for(len, visible));
-        if self.follow_selection
-            && visible > 0
-            && let Some(selected) = self.selection.selected()
-        {
-            if selected < self.offset {
-                self.offset = selected;
-            } else if selected >= self.offset.saturating_add(visible) {
-                self.offset = selected.saturating_add(1).saturating_sub(visible);
-            }
-        }
-        VirtualWindow::new(len, visible, self.offset)
+        // The persistent offset is exactly `keeping`'s `start`: the stateless
+        // policy and this one are the same math, differing only in whether the
+        // caller remembers where the window was.
+        let anchor = self
+            .follow_selection
+            .then(|| self.selection.selected())
+            .flatten();
+        let window = VirtualWindow::keeping(len, visible, self.offset, anchor);
+        self.offset = window.start();
+        window
     }
 
     /// Handle keyboard navigation and wheel scrolling, then reconcile the
@@ -505,6 +502,7 @@ pub struct SelectList {
     visible_window: Option<VirtualWindow>,
     scrollbar: bool,
     selection_style: Option<Style>,
+    selection_anchor: SelectionAnchor,
 }
 
 pub(crate) struct SelectRows<'items> {
@@ -515,6 +513,7 @@ pub(crate) struct SelectRows<'items> {
     visible_window: Option<VirtualWindow>,
     scrollbar: bool,
     selection_style: Option<Style>,
+    selection_anchor: SelectionAnchor,
 }
 
 impl<'items> SelectRows<'items> {
@@ -527,6 +526,7 @@ impl<'items> SelectRows<'items> {
             visible_window: None,
             scrollbar: true,
             selection_style: None,
+            selection_anchor: SelectionAnchor::default(),
         }
     }
 
@@ -576,7 +576,9 @@ impl<'items> SelectRows<'items> {
                     )
                 }
             }
-            None => VirtualWindow::around(self.items.len(), visible, self.selected),
+            None => self
+                .selection_anchor
+                .window(self.items.len(), visible, self.selected),
         }
     }
 }
@@ -675,6 +677,7 @@ impl SelectList {
             visible_window: None,
             scrollbar: true,
             selection_style: None,
+            selection_anchor: SelectionAnchor::default(),
         }
     }
 
@@ -692,6 +695,7 @@ impl SelectList {
             visible_window: None,
             scrollbar: true,
             selection_style: None,
+            selection_anchor: SelectionAnchor::default(),
         }
     }
 
@@ -726,6 +730,17 @@ impl SelectList {
         self
     }
 
+    /// Choose how the list windows itself around the selection when it resolves
+    /// its own window — i.e. under [`viewport`](Self::viewport) or a smaller
+    /// assigned height, not under [`visible_window`](Self::visible_window) or
+    /// [`windowed`](Self::windowed).
+    ///
+    /// Defaults to [`SelectionAnchor::Center`].
+    pub fn selection_anchor(mut self, anchor: SelectionAnchor) -> Self {
+        self.selection_anchor = anchor;
+        self
+    }
+
     fn rows(&self) -> SelectRows<'_> {
         SelectRows {
             items: &self.items,
@@ -735,6 +750,7 @@ impl SelectList {
             visible_window: self.visible_window,
             scrollbar: self.scrollbar,
             selection_style: self.selection_style,
+            selection_anchor: self.selection_anchor,
         }
     }
 }
@@ -977,6 +993,33 @@ mod tests {
             has_scrollbar,
             "overflowing list should draw a scrollbar:\n{text}"
         );
+    }
+
+    #[test]
+    fn select_list_edge_anchor_trails_the_selection_instead_of_centering() {
+        let items: Vec<Line> = (0..20).map(|i| Line::from(format!("item{i}"))).collect();
+        let mut state = SelectState::new();
+        state.select(Some(7));
+        let list = |anchor: SelectionAnchor| {
+            SelectList::new(items.clone(), &state)
+                .viewport(5)
+                .selection_anchor(anchor)
+                .rows()
+                .window(Some(5))
+                .range()
+        };
+        // Edge trails the selection by one row; Center recenters on it.
+        assert_eq!(list(SelectionAnchor::Edge), 3..8);
+        assert_eq!(list(SelectionAnchor::Center), 5..10);
+
+        // The rendered rows follow the policy, not just the window token.
+        let edge = SelectList::new(items, &state)
+            .viewport(5)
+            .selection_anchor(SelectionAnchor::Edge);
+        let text = crate::testing::grid(&crate::testing::render(&edge, 12, 5, &Theme::default()));
+        assert!(text.contains("item3"), "top of the edge window:\n{text}");
+        assert!(text.contains("item7"), "selection stays visible:\n{text}");
+        assert!(!text.contains("item9"), "below the edge window:\n{text}");
     }
 
     #[test]

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -33,7 +33,7 @@ use crate::view::{RenderCtx, View};
 
 use super::select::SelectState;
 use super::text::line_width;
-use super::{Scrollbar, VirtualWindow};
+use super::{Scrollbar, SelectionAnchor, VirtualWindow};
 
 /// One table column: a header cell and a main-axis width policy.
 #[derive(Clone)]
@@ -111,6 +111,7 @@ pub struct Table {
     header_style: Option<Style>,
     preserve_selection_fg: bool,
     selection_style: Option<Style>,
+    selection_anchor: SelectionAnchor,
 }
 
 impl Table {
@@ -131,6 +132,7 @@ impl Table {
             header_style: None,
             preserve_selection_fg: false,
             selection_style: None,
+            selection_anchor: SelectionAnchor::default(),
         }
     }
 
@@ -161,6 +163,7 @@ impl Table {
             header_style: None,
             preserve_selection_fg: false,
             selection_style: None,
+            selection_anchor: SelectionAnchor::default(),
         }
     }
 
@@ -236,6 +239,17 @@ impl Table {
         self
     }
 
+    /// Choose how the table windows itself around the selection when it
+    /// resolves its own window — i.e. under [`viewport`](Self::viewport) or a
+    /// body shorter than the row count, not under
+    /// [`visible_window`](Self::visible_window) or [`windowed`](Self::windowed).
+    ///
+    /// Defaults to [`SelectionAnchor::Center`].
+    pub fn selection_anchor(mut self, anchor: SelectionAnchor) -> Self {
+        self.selection_anchor = anchor;
+        self
+    }
+
     /// Cells the caret gutter occupies (caret + space), or 0 when hidden.
     fn gutter_width(&self) -> u16 {
         if self.gutter { 2 } else { 0 }
@@ -277,7 +291,8 @@ impl Table {
 
     /// The visible data-row window: the whole table unless a
     /// [`viewport`](Self::viewport) smaller than the row count is set, in which
-    /// case a slice centered on the selection and clamped to the ends.
+    /// case a slice placed around the selection by
+    /// [`selection_anchor`](Self::selection_anchor) and clamped to the ends.
     fn window(&self, available_rows: u16) -> VirtualWindow {
         let viewport = self
             .viewport
@@ -295,7 +310,10 @@ impl Table {
                 source.len().min(usize::from(viewport)),
                 source.start(),
             ),
-            None => VirtualWindow::around(self.rows.len(), usize::from(viewport), self.selected),
+            None => {
+                self.selection_anchor
+                    .window(self.rows.len(), usize::from(viewport), self.selected)
+            }
         }
     }
 
@@ -523,6 +541,73 @@ mod tests {
         // 20 - 4 (fixed) - 1 (gap) = 15 for the flex column.
         assert_eq!(rects[1].width, 15, "flex column takes the leftover");
         assert_eq!(rects[1].x, 5, "second column starts after col1 + gap");
+    }
+
+    /// The acceptance table for [`SelectionAnchor`]: 20 rows in a 5-row pane.
+    #[test]
+    fn table_selection_anchor_picks_the_windowing_policy() {
+        let table = |selected: usize, anchor: SelectionAnchor| {
+            let rows: Vec<Vec<Line>> = (0..20)
+                .map(|i| vec![Line::from(format!("row{i}"))])
+                .collect();
+            let mut state = SelectState::new();
+            state.select(Some(selected));
+            Table::new(vec![Column::auto("n")], rows, &state)
+                .viewport(5)
+                .selection_anchor(anchor)
+                .window(5)
+                .start()
+        };
+
+        // Near the top neither policy has anything to scroll.
+        assert_eq!(table(2, SelectionAnchor::Edge), 0);
+        assert_eq!(table(2, SelectionAnchor::Center), 0);
+        // Mid-collection is where the two differ.
+        assert_eq!(table(7, SelectionAnchor::Edge), 3);
+        assert_eq!(table(7, SelectionAnchor::Center), 5);
+        // Both clamp to the last full window at the end.
+        assert_eq!(table(19, SelectionAnchor::Edge), 15);
+        assert_eq!(table(19, SelectionAnchor::Center), 15);
+
+        // Center stays the default.
+        let rows: Vec<Vec<Line>> = (0..20)
+            .map(|i| vec![Line::from(format!("row{i}"))])
+            .collect();
+        let mut state = SelectState::new();
+        state.select(Some(7));
+        assert_eq!(
+            Table::new(vec![Column::auto("n")], rows, &state)
+                .viewport(5)
+                .window(5)
+                .start(),
+            5
+        );
+    }
+
+    /// The stateless `Edge` window re-derives itself every frame; the
+    /// persistent one remembers. Moving 7 -> 6 is where that shows.
+    #[test]
+    fn table_edge_anchor_is_stateless_where_the_viewport_state_is_not() {
+        let rows: Vec<Vec<Line>> = (0..20)
+            .map(|i| vec![Line::from(format!("row{i}"))])
+            .collect();
+        let mut state = SelectState::new();
+        state.select(Some(6));
+        let stateless = Table::new(vec![Column::auto("n")], rows.clone(), &state)
+            .viewport(5)
+            .selection_anchor(SelectionAnchor::Edge)
+            .window(5);
+        assert_eq!(stateless.start(), 2, "trails the selection from the top");
+
+        let mut viewport = super::super::SelectViewportState::new();
+        viewport.select(Some(7));
+        assert_eq!(viewport.resolve(20, 5).start(), 3);
+        viewport.select(Some(6));
+        let persistent = viewport.resolve(20, 5);
+        assert_eq!(persistent.start(), 3, "row 6 is already visible");
+        let table = Table::new(vec![Column::auto("n")], rows, viewport.selection())
+            .visible_window(persistent);
+        assert_eq!(table.window(5), persistent, "explicit window wins");
     }
 
     #[test]

--- a/src/components/virtualization.rs
+++ b/src/components/virtualization.rs
@@ -54,6 +54,36 @@ impl VirtualWindow {
         Self::new(total, len, anchor.saturating_sub(len / 2))
     }
 
+    /// Create the window that keeps `anchor` visible with the smallest possible
+    /// adjustment of `start`.
+    ///
+    /// `start` is the caller's current top entry — a host's persistent offset,
+    /// or `0` for a stateless caller. The window does not move while the anchor
+    /// is inside it; when the anchor leaves, it trails the anchor by exactly one
+    /// edge. This is the complement of [`around`](Self::around), which recenters
+    /// on every move.
+    ///
+    /// A missing anchor leaves `start` alone (clamped to the collection); an
+    /// out-of-range anchor is clamped to the last entry.
+    pub fn keeping(total: usize, visible: usize, start: usize, anchor: Option<usize>) -> Self {
+        if total == 0 {
+            return Self::default();
+        }
+        let len = visible.min(total);
+        let mut start = start.min(Self::max_start_for(total, len));
+        if len > 0
+            && let Some(anchor) = anchor
+        {
+            let anchor = anchor.min(total - 1);
+            if anchor < start {
+                start = anchor;
+            } else if anchor >= start.saturating_add(len) {
+                start = anchor.saturating_add(1).saturating_sub(len);
+            }
+        }
+        Self::new(total, len, start)
+    }
+
     /// Total entries in the logical collection.
     pub const fn total(self) -> usize {
         self.total
@@ -97,6 +127,41 @@ impl VirtualWindow {
     /// Whether `index` is visible in this window.
     pub fn contains(self, index: usize) -> bool {
         self.range().contains(&index)
+    }
+}
+
+/// How a stateless component places its window around the selection.
+///
+/// Only consulted when a component resolves its own window — a host that
+/// supplies an explicit window (`visible_window`, or a `source_window` it
+/// already sliced) has already made this decision itself.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SelectionAnchor {
+    /// Keep the selection mid-window, recentering on every move
+    /// ([`VirtualWindow::around`]). The default.
+    #[default]
+    Center,
+    /// Move the window only when the selection would leave it
+    /// ([`VirtualWindow::keeping`]).
+    ///
+    /// A stateless component starts at the top of the collection, so the
+    /// selection rides the bottom edge moving down and the top edge moving up —
+    /// the familiar list-scrolling policy.
+    Edge,
+}
+
+impl SelectionAnchor {
+    /// Resolve the stateless window for `selected` under this policy.
+    pub(crate) fn window(
+        self,
+        total: usize,
+        visible: usize,
+        selected: Option<usize>,
+    ) -> VirtualWindow {
+        match self {
+            Self::Center => VirtualWindow::around(total, visible, selected),
+            Self::Edge => VirtualWindow::keeping(total, visible, 0, selected),
+        }
     }
 }
 
@@ -230,5 +295,64 @@ impl View for Scrollbar {
             };
             surface.set(x, y, glyph, style);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A 20-row collection in a 5-row pane, the two policies side by side.
+    #[test]
+    fn keeping_trails_the_anchor_while_around_recenters() {
+        let edge = |anchor: usize| VirtualWindow::keeping(20, 5, 0, Some(anchor)).start();
+        let center = |anchor: usize| VirtualWindow::around(20, 5, Some(anchor)).start();
+
+        // Inside the first window: neither policy can scroll yet.
+        assert_eq!(edge(2), 0);
+        assert_eq!(center(2), 0);
+        // Past the bottom edge: `keeping` trails by one row, `around` centers.
+        assert_eq!(edge(7), 3);
+        assert_eq!(center(7), 5);
+        // At the end both clamp to the last full window.
+        assert_eq!(edge(19), 15);
+        assert_eq!(center(19), 15);
+    }
+
+    #[test]
+    fn keeping_holds_start_for_an_anchor_already_inside_the_window() {
+        // Moving 7 -> 6 with the window already at 3 changes nothing...
+        assert_eq!(VirtualWindow::keeping(20, 5, 3, Some(6)).start(), 3);
+        // ...while a stateless caller re-derives the trailing window.
+        assert_eq!(VirtualWindow::keeping(20, 5, 0, Some(6)).start(), 2);
+        // Above the window, the anchor becomes the top row.
+        assert_eq!(VirtualWindow::keeping(20, 5, 10, Some(4)).start(), 4);
+    }
+
+    #[test]
+    fn keeping_survives_degenerate_input() {
+        assert_eq!(
+            VirtualWindow::keeping(0, 5, 9, Some(3)),
+            VirtualWindow::default()
+        );
+        // No anchor leaves the start alone, clamped to the collection.
+        assert_eq!(VirtualWindow::keeping(20, 5, 99, None).start(), 15);
+        // A zero-height pane can show no anchor at all, so the start is simply
+        // carried through — the same as `new` with an empty window.
+        let empty = VirtualWindow::keeping(20, 0, 4, Some(19));
+        assert!(empty.is_empty());
+        assert_eq!(empty.start(), 4);
+        // An out-of-range anchor clamps to the last entry.
+        assert_eq!(
+            VirtualWindow::keeping(20, 5, 0, Some(usize::MAX)).start(),
+            15
+        );
+    }
+
+    #[test]
+    fn selection_anchor_dispatches_to_the_two_policies() {
+        assert_eq!(SelectionAnchor::default(), SelectionAnchor::Center);
+        assert_eq!(SelectionAnchor::Center.window(20, 5, Some(7)).start(), 5);
+        assert_eq!(SelectionAnchor::Edge.window(20, 5, Some(7)).start(), 3);
     }
 }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -145,7 +145,8 @@ fn components_are_reachable_flat() {
         ConfirmDialogState, Console, Dialog, Diff, Form, FormField, FormState, Image, InputDialog,
         InputDialogState, KeyedColumn, KeyedMultiSelectState, KeyedRowSource, KeyedSelectState,
         KeyedTable, Markdown, MultiChoiceDialog, MultiChoiceDialogState, NavigableKeyedRowSource,
-        QrCode, SelectViewportState, Toasts, TreeList, TreeRow, TreeState, Viewport,
+        QrCode, SelectViewportState, SelectionAnchor, Toasts, TreeList, TreeRow, TreeState,
+        Viewport,
     };
 
     let theme = Theme::default();
@@ -164,6 +165,7 @@ fn components_are_reachable_flat() {
     let _ = Markdown::new("# hi");
     let _ = QrCode::encode("hi", QrEcc::Low);
     let _ = Toasts::new;
+    let _ = SelectionAnchor::Edge;
     let state = FormState::new();
     let _ = Form::new(
         vec![FormField::new("name", element(Text::raw("Ada")))],

--- a/tests/virtual_collections.rs
+++ b/tests/virtual_collections.rs
@@ -1,4 +1,7 @@
-use tuika::components::{Column, Scrollbar, SelectList, SelectState, Table, VirtualWindow};
+use tuika::components::{
+    Column, Scrollbar, SelectList, SelectState, SelectViewportState, SelectionAnchor, Table,
+    VirtualWindow,
+};
 use tuika::prelude::{Line, Style, Theme};
 use tuika::testing::{grid, render};
 
@@ -64,4 +67,39 @@ fn built_in_collections_accept_only_the_visible_data_window() {
             .skip(1)
             .any(|line| line.ends_with(['█', '│']))
     );
+}
+
+/// Both windowing policies are reachable from a stateless host: 20 rows in a
+/// 5-row pane, with the selection past the first window.
+#[test]
+fn selection_anchor_picks_centering_or_edge_following() {
+    let rows: Vec<Vec<Line>> = (0..20).map(|i| vec![Line::from(format!("r{i}"))]).collect();
+    let mut state = SelectState::new();
+    state.select(Some(7));
+    let table = |anchor: SelectionAnchor| {
+        let table = Table::new(vec![Column::auto("n")], rows.clone(), &state)
+            .viewport(5)
+            .header(false)
+            .selection_anchor(anchor);
+        grid(&render(&table, 8, 5, &Theme::default()))
+    };
+
+    // Edge trails the selection by one row: rows 3..8.
+    let edge = table(SelectionAnchor::Edge);
+    assert!(edge.contains("r3") && edge.contains("r7"), "{edge}");
+    assert!(!edge.contains("r9"), "{edge}");
+
+    // Center puts it mid-window: rows 5..10.
+    let centered = table(SelectionAnchor::Center);
+    assert!(
+        centered.contains("r5") && centered.contains("r9"),
+        "{centered}"
+    );
+    assert!(!centered.contains("r3"), "{centered}");
+
+    // The same policy as a bare window, against the persistent path's math.
+    assert_eq!(VirtualWindow::keeping(20, 5, 0, Some(7)).range(), 3..8);
+    let mut viewport = SelectViewportState::new();
+    viewport.select(Some(7));
+    assert_eq!(viewport.resolve(20, 5).range(), 3..8);
 }


### PR DESCRIPTION
## What changed

Two overrides a host previously had to reimplement a `View` to get.

**`ProgressBar::label_style(Style)`** styles the caption set by `label`, the same
theme-by-default / explicit-override pattern as `colors`. The default is today's
behavior (the theme's body-text style); centring, the `show_percent` suffix
reservation, and clipping are untouched. The `NN%` suffix stays separate chrome
on the theme's muted style — the two are semantically distinct, so they keep
distinct knobs.

**`SelectionAnchor`** lets `Table` and `SelectList` pick how they window
themselves around the selection when they resolve their *own* window
(`viewport`, or a body shorter than the collection):

- `Center` — recenter on the selection. Today's behavior, still the default.
- `Edge` — move only when the selection would leave the window: the selection
  rides the bottom edge going down and the top edge going up.

Both explicit-window paths (`visible_window`, `windowed`) are untouched — a host
that supplies a window has already made this decision.

The policy itself is lifted onto **`VirtualWindow::keeping(total, visible, start,
anchor)`**, and `SelectViewportState::resolve` now calls it. Centering and
edge-following were never different math, only different memory: `keeping` takes
the caller's current start (`0` for a stateless caller), so the persistent and
stateless paths are one implementation.

## Why

Every other visual property of `ProgressBar` was overridable and the caption was
not, which silently drops a host's configured caption color — spotify-tui's
`playbar_progress_text` and `enable_text_emphasis` become no-ops on adoption, and
the app carries a 26-line `View` that calls `ProgressBar::render` and then
repaints the caption just to change one `Style`.

Likewise, edge-following windowing — what tui-rs `List`/`Table` do and what most
list UIs do — was reachable only through `SelectViewportState`, i.e. by threading
persistent state and a known pane height through the host model. That is exactly
the custom-`View` cost `Table`'s render-height windowing was added to remove.

## Before / After

`ProgressBar::determinate(0.6).label("0:42/3:07").percent(true)` at 30 cells,
caption cells 9..17 (`fg`/`modifier`):

```
BEFORE |████████0:42/3:07          60%|
  caption: Rgb(235,230,230)/NONE ×8      <- theme.text, not overridable

AFTER  |████████0:42/3:07          60%|  .label_style(fg(Cyan) + ITALIC)
  caption: Cyan/ITALIC ×8                <- glyphs and layout identical
```

20 rows in a 5-row pane, row 7 selected (`›` = selection, right column = scrollbar):

```
BEFORE / SelectionAnchor::Center      AFTER / SelectionAnchor::Edge
  row5   │                              row3   █
  row6   █                              row4   │
› row7   │                              row5   │
  row8   │                              row6   │
  row9   │                            › row7   │
```

Default appearance is unchanged in both cases (both features are opt-in), so no
demo recording needed regeneration; `cargo run --example demo -- check` passes,
and the `progress_bar`, `select`, and `keyed_table` scene dumps are byte-identical
to `main`.

## Risk

- **Low.**
- The one shared-code change is `SelectViewportState::resolve` delegating to
  `VirtualWindow::keeping`. It is the same algorithm moved verbatim, including the
  degenerate cases (`total == 0`, zero-height pane, stale out-of-range selection),
  and the existing persistent-viewport suite — including the mouse hit-testing
  tests that depend on `resolve` returning the exact painted window — passes
  unchanged.
- Everything else is additive and defaulted to current behavior.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets
--all-features -- -D warnings`, `cargo test --workspace --all-features` (659 lib
tests + integration suites), `cargo run --example demo -- check` (42 scenes),
`python3 scripts/validate_okf.py knowledge --check-links` (15 concepts, 0 errors).

New tests, all asserting cells or window tokens through the real entry points:

- `progress_bar_label_style_overrides_the_theme` — caption cells carry the
  override's `fg` and `ITALIC` while the filled/track cells keep `.colors(...)`.
- `keeping_*` (3) — the policy's acceptance table, the
  already-inside-the-window hold, and degenerate input.
- `selection_anchor_dispatches_to_the_two_policies`.
- `table_selection_anchor_picks_the_windowing_policy` — the full acceptance
  table (`selected` 2 / 7 / 19 × both anchors), plus `Center` still being the
  default.
- `table_edge_anchor_is_stateless_where_the_viewport_state_is_not` — pins the
  7 → 6 distinction deliberately: persistent keeps `start == 3`, stateless gives
  `start == 2`.
- `select_list_edge_anchor_trails_the_selection_instead_of_centering` — window
  token *and* rendered rows.
- `selection_anchor_picks_centering_or_edge_following` (integration) — the same
  through the public API only.

No real-terminal run was possible in this environment (no tty); per the ship
skill, `demo -- <scene> --dump` was used instead for the scenes covering the
touched components.

## API

**This is an API change — additive, non-breaking, no migration needed.**

New public items:

- `ProgressBar::label_style(Style) -> Self`
- `components::SelectionAnchor` (`Center` = `Default`, `Edge`), also in `prelude`
- `Table::selection_anchor(SelectionAnchor) -> Self`
- `SelectList::selection_anchor(SelectionAnchor) -> Self`
- `VirtualWindow::keeping(usize, usize, usize, Option<usize>) -> VirtualWindow`

No item was removed, renamed, or changed signature; no new dependency. Declared
under a new `## [Unreleased]` section in `CHANGELOG.md`, and `tests/public_api.rs`
pins the new flat path.

## Knowledge

Updated:

- `knowledge/specs/architecture.md` — records that centering and edge-following
  are the same window math with and without a remembered start, so a stateless
  component can offer either policy without a host threading persistent state
  through its model to reach the common one.
- `knowledge/log.md` — why the policy was only reachable through host state, and
  the general rule the `ProgressBar` half illustrates: chrome that is overridable
  "everywhere except one place" is a defect, and semantically distinct chrome
  keeps distinct knobs.

Also updated `docs/components/motion.md` and `docs/components/interactive.md`.

## Security

Reviewed against the repository threat model.

- **TM-ESC** — no out-of-band sequences touched. `label_style` swaps a `Style`
  argument; no caller-supplied string reaches the terminal by a new path.
- **TM-STATE** — no terminal state entered or restored.
- **TM-PARSE** — `keeping` does arithmetic on host-supplied indices. `total == 0`
  returns early so `total - 1` cannot underflow; every other operation is
  saturating; an out-of-range anchor clamps to the last entry, and the result goes
  through `VirtualWindow::new`, which clamps again. Covered by
  `keeping_survives_degenerate_input` (empty collection, zero-height pane,
  `usize::MAX` anchor and start).
- **TM-CLIP** — no new writes. The caption still draws through the same
  `surface.child(region)` clip; the window changes only which existing rows are
  painted, and remains bounded by the collection and the assigned height.
- **TM-DEP** — no dependency change.

## Follow-ups

- `SelectList`'s `source_window` path centers within the host-supplied slice and
  is deliberately left on that policy, matching the issue's "both explicit-window
  paths are untouched". If a host wants `Edge` there too, it is a small follow-up
  — but it is a behavior change to an existing path, so it should be asked for
  rather than assumed.


---
_Generated by [Claude Code](https://claude.ai/code/session_014Mne9G1ivBDScRvirc25ND)_