### PR TITLE
fix(term)!: preserve native hyperlink activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,10 @@ tuika's own suite covers more:
   no out-of-clip writes.
 - **PTY smoke** (`tests/pty_smoke.rs`) — drives examples under a pseudo-terminal
   and asserts the terminal-facing protocol: `gallery` for the alternate screen
-  (enter/leave, cursor, keyboard-reporting and mouse-capture lifecycle, OSC 9;4
-  progress, OSC 8 hyperlinks, truecolor and Braille cells through a reference
-  terminal parser, resize survival, clean exit) and `split_footer`/`codex
+  (enter/leave, cursor, keyboard reporting, native mouse default plus explicit
+  capture lifecycle, OSC 9;4 progress, OSC 8 hyperlinks, truecolor and Braille
+  cells through a reference terminal parser, resize survival, clean exit),
+  `markdown` for a streaming OSC 8 link, and `split_footer`/`codex
   --split-footer` for the split-footer mode (no alt-screen, no mouse capture, the
   footer pinned to the bottom with published blocks above it, and its rows handed
   back on exit with the scrollback intact). The harness answers the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
+## Unreleased
+
+### Changed
+
+- **Breaking:** Mouse capture is now opt-in in alternate-screen mode, preserving native OSC 8
+  link activation, terminal selection, and scrolling by default. Applications
+  that need pointer or wheel events use `ScreenMode::with_mouse_capture`,
+  `MouseCapture::Enabled`, or `AltScreen::enter_with_mouse_capture`; captured
+  sessions may use runner selection and `ctrl_click_url` as application-side
+  fallbacks.
+- `MarkdownState::links` preserves labeled and bare hyperlink targets across
+  incremental updates, settled-prefix caching, wrapping, and resize, so hosts
+  drawing streaming lines can apply native OSC 8 links without re-parsing.
+
 ## [0.9.0] - 2026-08-15
 
 Released alongside `tuika-charts` 0.1.0 — its first release — plus

--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ let root = Flex::column()
 code and tables verbatim. `MarkdownState` is its streaming form: fed deltas as a
 message arrives, it re-parses only the in-flight tail and caches everything
 before the last stable block boundary, so long transcripts don't re-tokenize and
-settled code blocks aren't re-highlighted every frame.
+settled code blocks aren't re-highlighted every frame. Its `links()` metadata
+keeps OSC 8 targets aligned with the cached lines through streaming and resize.
 
 Highlighting is a seam, not a dependency: `tuika` owns the *presentation* of code
 (framing, background, language label, wrapping) via `CodeBlock`, and takes token
@@ -533,8 +534,8 @@ Each takes over the terminal — the alternate screen, or a pinned footer for
 
 | Example    | Command                                   | Shows                                              |
 | ---------- | ----------------------------------------- | -------------------------------------------------- |
-| [`gallery`](examples/gallery.rs)  | `cargo run --example gallery`    | motion components + native OSC 9;4 progress        |
-| [`markdown`](examples/markdown.rs) | `cargo run --example markdown`   | streaming `MarkdownState` + highlighted `CodeBlock`, following the stream until you scroll back |
+| [`gallery`](examples/gallery.rs)  | `cargo run --example gallery`    | motion components + native OSC 9;4 progress and OSC 8 links |
+| [`markdown`](examples/markdown.rs) | `cargo run --example markdown`   | streaming `MarkdownState` + highlighted `CodeBlock`, native OSC 8 links, following the stream until you scroll back |
 | [`select`](examples/select.rs)   | `cargo run --example select`     | interactive multi-select with aliases, numbers, and mouse hit-testing |
 | [`keyed_table`](examples/keyed_table.rs) | `cargo run --example keyed_table` | dynamic borrowed rows, stable keyed selection, filtering, and reordering |
 | [`tree_list`](examples/tree_list.rs) | `cargo run --example tree_list` | expandable stable-id tree, refresh, mouse selection, and persistent scrolling |
@@ -649,7 +650,8 @@ threads, tasks, retries, and lifecycle.
 `ScreenMode` picks which part of the terminal a frame owns:
 
 - `ScreenMode::Alternate` (the default) takes the whole window on the alternate
-  buffer and restores the user's screen and scrollback on exit.
+  buffer and restores the user's screen and scrollback on exit. It leaves mouse
+  handling to the terminal, so native OSC 8 links, selection, and scrolling work.
 - `ScreenMode::split_footer(rows)` reserves those rows at the bottom of the
   *main* screen. Everything above stays the terminal's own scrollback: the shell
   prompt that launched the app, the wheel, and mouse selection all keep working,
@@ -697,8 +699,7 @@ the composer keeps the bottom rows. Hosts driving their own loop reserve and
 release the footer's rows with `screen::pin_footer` and `screen::close_footer`.
 
 `TerminalSession` is the complete RAII guard for either mode: it owns raw mode,
-enhanced
-keyboard reporting, the alternate screen, mouse capture, and cursor visibility,
+enhanced keyboard reporting, the alternate screen, optional mouse capture, and cursor visibility,
 including rollback after partial initialization, and restores exactly what it
 took. Enhanced reporting preserves
 non-character modifiers, so `Shift+Enter` reaches `TextInputState` as a
@@ -861,12 +862,20 @@ To check support across every terminal feature in one place — `graphics`,
 
 ## Mouse, selection, and clipboard
 
-Enabling mouse capture (which `AltScreen` / `TerminalSession` do) means the
-terminal stops doing its own click-drag text selection and hands every drag to
-the app instead. `Runner` and `AsyncRunner` restore selection by default over
-the final rendered grid: a plain left drag highlights text, a same-cell double
-click selects a word, and releasing copies through OSC 52. Wheel events still
-reach application scrolling. An
+Mouse handling stays with the terminal by default, including in alternate-screen
+mode. That preserves native OSC 8 link activation, click-drag selection, and
+terminal scrolling. An app that needs pointer or wheel events opts into capture
+with `ScreenMode::Alternate.with_mouse_capture()`,
+`ScreenMode::split_footer(rows).with_mouse_capture()`, an enabled
+`TerminalSessionConfig::mouse_capture`, or
+`AltScreen::enter_with_mouse_capture()`.
+
+Capture is a deliberate trade: the terminal stops activating OSC 8 links and
+performing its own selection/scrolling because it hands those mouse events to
+the app instead. `Runner` and `AsyncRunner` then restore selection over the
+final rendered grid: a plain left drag highlights text, a same-cell double
+click selects a word, and releasing copies through OSC 52. Wheel events reach
+application scrolling. An
 application claims a mouse gesture by returning `UpdateResult::Consumed` (no
 repaint) or `UpdateResult::Dirty` (repaint), and can disable the default
 entirely with `with_text_selection(false)`.
@@ -881,6 +890,10 @@ Hosts with their own loop use the `mouse` module to build the same affordances:
   style)` paints it in. A same-cell double click selects a word;
   `handle_with_clock` accepts a virtual monotonic `Clock`, while `handle` uses
   `SystemClock`.
+- **Application link fallback.** `ctrl_click_url` resolves an OSC 8 target or
+  bare URL under a captured Ctrl-click. The host must open it itself. This is
+  opt-in fallback behavior for an app that chose capture, not a replacement for
+  native terminal activation.
 - **Clicks and regions.** `HitMap<T>` maps screen rects to values (a button, a
   link, a row); the last-pushed match wins, so children/overlays registered
   after their parents take precedence. `ClickTracker` turns a same-cell

--- a/docs/features.md
+++ b/docs/features.md
@@ -140,7 +140,8 @@ terminal actually answers without taking over the screen.
 ## Screen modes: alternate screen & split footer
 
 `ScreenMode` decides which part of the terminal a frame owns. The default takes
-the whole window on the alternate buffer. `ScreenMode::split_footer(rows)`
+the whole window on the alternate buffer while leaving mouse handling native.
+`ScreenMode::split_footer(rows)`
 instead reserves rows at the bottom of the *main* screen and leaves everything
 above as the terminal's own scrollback — the shell prompt, the wheel, mouse
 selection, and the output the app publishes, which is still there after it
@@ -211,9 +212,12 @@ so the host chooses which schemes are linked. The default (`LinkPolicy::WEB`) is
 `LinkPolicy::WEB.with_mailto()` also links `mailto:` addresses.
 `LinkPolicy::NONE` skips emission entirely.
 
-OSC 8 activation belongs to the terminal emulator. A host should not open the
-same URL again when mouse reporting also delivers the modifier-click to the
-application. Full-screen hosts that capture pointer motion can use
+OSC 8 activation belongs to the terminal emulator, and tuika leaves mouse
+handling native by default in both screen modes. This is required for terminal
+modifier-click activation: enabling mouse capture routes mouse events to the
+application instead, disabling the emulator's native link activation,
+selection, and scrolling. A host should opt into capture only when it needs
+application pointer/wheel events. Full-screen hosts that capture pointer motion can use
 `write_pointer_shape(..., PointerShape::Pointer)` on link hover; it emits OSC 22
 and should be paired with `PointerShape::Default` on hover exit and shutdown.
 
@@ -246,8 +250,13 @@ must be enabled: `set -g allow-passthrough on`.
 
 ## Mouse: selection, highlight & clicks
 
-Once an app captures the mouse, the terminal stops doing its own click-drag text
-selection. `Runner` and `AsyncRunner` restore it by default over the final cell
+Tuika leaves mouse handling to the terminal by default, preserving native OSC 8
+activation, selection, and scrolling. Capture is explicit through
+`ScreenMode::with_mouse_capture`, `MouseCapture::Enabled`, or
+`AltScreen::enter_with_mouse_capture`.
+
+Once an app opts into capture, the terminal stops handling links and selection.
+`Runner` and `AsyncRunner` restore selection over the final cell
 frame: a plain left drag highlights text, a same-cell double click selects a
 word, and releasing copies through OSC 52. Wheel events continue to reach the
 application. Return
@@ -271,11 +280,13 @@ selection, copy, and hit-testing — from tuika's enriched event model
   back out of the rendered buffer (wide glyphs intact) and `mouse::paint_selection(buffer,
   area, range, style)` paints it in. `handle_with_clock` accepts a host `Clock`
   for deterministic gesture timing; `handle` uses `SystemClock`.
-- `ctrl_click_url(event, buffer, area)` returns the URL under a Ctrl+left-button
+- `ctrl_click_url(event, buffer, area)` is an application-side fallback for a
+  host that opted into capture. It returns the URL under a Ctrl+left-button
   release: first an OSC 8 target embedded in the cell run (labeled markdown
   links after `apply_buffer_links`), then a visible bare `http(s)://` run. The
-  host remains responsible for opening it; Yolop's fullscreen host opens it in
-  the system browser.
+  host remains responsible for opening it. Because capture disables terminal
+  link activation and selection, prefer native OSC 8 unless the application
+  genuinely needs mouse events.
 - `HitMap<T>` maps screen rects to values (a button, a link, a row); the
   last-pushed match wins, so children and overlays registered after their
   parents take precedence. `ClickTracker` turns a same-cell `Down`/`Up` into a

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -50,13 +50,16 @@ neither a layout slot nor a stream.
 use tuika::prelude::*;
 let mut md = MarkdownState::new();
 md.push_str(delta);                                  // forward each stream delta
-let lines = md.lines(width, &theme, &sheet, CodeHighlighter::Plain);
-view! { node(tuika::components::Text::new(lines)) }
+let lines = md.lines(width, &theme, &sheet, CodeHighlighter::Plain).to_vec();
+let links = md.links().to_vec();
+view! { node(tuika::components::Text::new(lines)) }  // then apply links to this area
 ```
 
 Lines come out already wrapped to the width you passed. Draw them **without**
 further wrapping — tuika's `Text`, or ratatui's `Paragraph` with no `.wrap` —
-or code indentation and table borders will be re-flowed into nonsense.
+or code indentation and table borders will be re-flowed into nonsense. After
+painting, pass the visible `links` to `apply_buffer_links`; the metadata is
+cached and row-aligned with the lines, including while a URL is still streaming.
 
 ## What renders
 
@@ -308,6 +311,10 @@ A `[label](url)` paints the label in the theme's link style and emits the
 destination as an [OSC 8 hyperlink](features.md#hyperlinks-osc-8) — clickable in
 terminals that support it, plain styled text everywhere else. Bare URLs in prose
 are linked in place.
+
+The one-shot `Markdown` view applies this metadata itself. A host drawing
+`MarkdownState::lines` applies `MarkdownState::links` after scrolling or
+windowing the lines, as shown in the streaming example.
 
 `link_policy` decides which schemes are emitted:
 

--- a/examples/codex/main.rs
+++ b/examples/codex/main.rs
@@ -165,7 +165,7 @@ fn run() -> io::Result<()> {
     let sheet = StyleSheet::from_theme(&theme);
     let probe = RectProbe::new();
 
-    let _session = TerminalSession::enter()?;
+    let _session = TerminalSession::enter_with(ScreenMode::Alternate.with_mouse_capture())?;
     let mut terminal = Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -1,6 +1,6 @@
 //! Live component gallery. Run with `cargo run --example gallery`
-//! (press `q` or `Esc` to quit). Pass `--no-mouse` to keep terminal mouse
-//! handling while still using the alternate screen.
+//! (press `q` or `Esc` to quit). Native terminal links work by default. Pass
+//! `--mouse` to opt into application mouse capture instead.
 //!
 //! Demonstrates the declarative `view!` DSL, the motion components, the native
 //! OSC 9;4 progress indicator, and OSC 8 hyperlinks (the footer URL is
@@ -134,16 +134,13 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
 }
 
 fn main() -> io::Result<()> {
-    let no_mouse = std::env::args().any(|argument| argument == "--no-mouse");
-    let config = tuika::TerminalSessionConfig {
-        mouse_capture: if no_mouse {
-            tuika::MouseCapture::Disabled
-        } else {
-            tuika::MouseCapture::ModeDefault
-        },
-        ..tuika::TerminalSessionConfig::default()
+    let capture_mouse = std::env::args().any(|argument| argument == "--mouse");
+    let mode = if capture_mouse {
+        ScreenMode::Alternate.with_mouse_capture()
+    } else {
+        ScreenMode::Alternate
     };
-    let _session = tuika::TerminalSession::enter_config(config)?;
+    let _session = tuika::TerminalSession::enter_with(mode)?;
     // Hyperlinks enabled so the footer URL demos as a real OSC 8 link.
     let mut terminal = Terminal::with_options(
         HyperlinkBackend::new(io::stdout(), true),

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,7 +8,16 @@ use tuika::prelude::*;
 
 fn main() -> io::Result<()> {
     let theme = Theme::default();
-    let runner = Runner::new(RunnerConfig::default());
+    let capture_mouse = std::env::args().any(|argument| argument == "--mouse");
+    let screen_mode = if capture_mouse {
+        ScreenMode::Alternate.with_mouse_capture()
+    } else {
+        ScreenMode::Alternate
+    };
+    let runner = Runner::new(RunnerConfig {
+        screen_mode,
+        ..RunnerConfig::default()
+    });
 
     runner.run(
         &theme,

--- a/examples/keyed_table.rs
+++ b/examples/keyed_table.rs
@@ -215,7 +215,7 @@ fn summary_line<'a>(summary: &'a str, positions: &[usize]) -> Line<'a> {
 
 fn main() -> io::Result<()> {
     let theme = Theme::default();
-    let _session = TerminalSession::enter()?;
+    let _session = TerminalSession::enter_with(ScreenMode::Alternate.with_mouse_capture())?;
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
     let mut app = App::new();
 

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -1,5 +1,5 @@
 //! Streaming Markdown renderer. Run with `cargo run --example markdown`
-//! (space pause/resume · r restart · PgUp/PgDn/Home/End or wheel scroll ·
+//! (space pause/resume · r restart · PgUp/PgDn/Home/End scroll ·
 //! q or esc quit).
 //!
 //! Demonstrates [`MarkdownState`]: a rich CommonMark document is fed in a few
@@ -7,7 +7,9 @@
 //! streams — while only the in-flight tail re-parses each frame. Fenced code is
 //! syntax-highlighted through a tiny self-contained [`Highlighter`](tuika::highlight::Highlighter)
 //! (see `DemoHighlighter` below); for production highlighting across many
-//! languages, use the `tuika-codeformatters` crate.
+//! languages, use the `tuika-codeformatters` crate. The document's URL is a
+//! native OSC 8 link; pass `--mouse` to trade native link activation for
+//! application mouse-wheel events.
 //!
 //! # Following a stream
 //!
@@ -32,12 +34,12 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self};
-use ratatui::backend::CrosstermBackend;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::Span;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
+use tuika::term::hyperlink::{HyperlinkBackend, LinkPolicy, apply_buffer_links};
 
 /// A tiny self-contained Rust highlighter — enough to satisfy the
 /// [`Highlighter`] seam without a grammar dependency. Real hosts use the
@@ -177,9 +179,15 @@ fn main() -> io::Result<()> {
     let mut cursor = 0usize;
     let mut paused = false;
 
-    let _session = TerminalSession::enter()?;
+    let capture_mouse = std::env::args().any(|argument| argument == "--mouse");
+    let mode = if capture_mouse {
+        ScreenMode::Alternate.with_mouse_capture()
+    } else {
+        ScreenMode::Alternate
+    };
+    let _session = TerminalSession::enter_with(mode)?;
     let mut terminal = Terminal::with_options(
-        CrosstermBackend::new(io::stdout()),
+        HyperlinkBackend::new(io::stdout(), true),
         TerminalOptions {
             viewport: Viewport::Fullscreen,
         },
@@ -216,6 +224,20 @@ fn main() -> io::Result<()> {
         // the newest content while the state is stuck to the bottom, and leaves
         // a reader who scrolled back exactly where they were.
         scroll.clamp(content_h, viewport_h);
+        let visible_links = state
+            .links()
+            .iter()
+            .filter_map(|link| {
+                let line = usize::from(link.line);
+                (line >= scroll.offset() && line < scroll.offset().saturating_add(viewport_h)).then(
+                    || {
+                        let mut visible = link.clone();
+                        visible.line = u16::try_from(line - scroll.offset()).unwrap_or(u16::MAX);
+                        visible
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
 
         terminal.draw(|f| {
             let area = f.area();
@@ -248,6 +270,15 @@ fn main() -> io::Result<()> {
                 }
             };
             paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
+            apply_buffer_links(
+                f.buffer_mut(),
+                ratatui::layout::Position {
+                    x: area.x.saturating_add(1),
+                    y: area.y.saturating_add(1),
+                },
+                &visible_links,
+                LinkPolicy::WEB,
+            );
         })?;
 
         if !event::poll(Duration::from_millis(70))? {

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -45,7 +45,7 @@ enum Btn {
 
 fn main() -> io::Result<()> {
     enable_raw_mode()?;
-    let mut alt = AltScreen::enter()?; // also enables mouse capture
+    let mut alt = AltScreen::enter_with_mouse_capture()?;
     let mut term = Terminal::with_options(
         CrosstermBackend::new(io::stdout()),
         TerminalOptions {

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -115,7 +115,10 @@ fn update(state: &mut PickerState, event: &Event) -> UpdateResult {
 
 fn main() -> io::Result<()> {
     let theme = Theme::default();
-    let runner = Runner::new(RunnerConfig::default());
+    let runner = Runner::new(RunnerConfig {
+        screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+        ..RunnerConfig::default()
+    });
     let mut state = PickerState::new();
     runner.run(
         &theme,

--- a/examples/tree_list.rs
+++ b/examples/tree_list.rs
@@ -146,7 +146,11 @@ impl Application for TreeApp {
 }
 
 fn main() -> io::Result<()> {
-    Runner::new(RunnerConfig::default()).run(&Theme::default(), &mut TreeApp::new())
+    Runner::new(RunnerConfig {
+        screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+        ..RunnerConfig::default()
+    })
+    .run(&Theme::default(), &mut TreeApp::new())
 }
 
 #[cfg(test)]

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,17 @@
 
 ## 2026-08-15
 
+- **Native terminal links own the default mouse path**
+  - Both screen modes leave mouse reporting disabled by default, so emulators
+    retain OSC 8 modifier-click activation, selection, and scrolling.
+  - Application mouse capture is explicit because terminal reporting is global:
+    opting in gives pointer and wheel events to the host and necessarily takes
+    those native behaviors away. Runner selection and `ctrl_click_url` remain
+    available as application-side fallbacks for captured sessions.
+  - Streaming markdown retains hyperlink runs alongside cached lines; backend
+    inference cannot recover a URL emitted across several incremental terminal
+    diffs, so hosts apply `MarkdownState::links` after viewporting instead.
+
 - **The generated website is not part of the published crate**
   - `site/` mirrors public documentation and bundles generated assets for the
     tuika.dev deployment; crates.io renders `README.md` directly and cannot use

--- a/knowledge/processes/release.md
+++ b/knowledge/processes/release.md
@@ -217,8 +217,10 @@ before a release when the renderer changed; tick a box only after confirming it
 yourself.
 
 Run `cargo run --example gallery` in each terminal and check alt-screen
-enter/exit, Braille and wide glyphs, truecolor, mouse-wheel scroll, and that the
-footer URL is a clickable OSC 8 link:
+enter/exit, Braille and wide glyphs, truecolor, and that the footer URL is a
+clickable OSC 8 link. Then run it with `-- --mouse` and check application mouse
+input, accepting that native link activation is intentionally unavailable while
+capture is active:
 
 - [ ] Ghostty
 - [ ] iTerm2

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -70,9 +70,11 @@ terminal on the other end of a pty could catch the difference (see
 cursor-position report an inline viewport is anchored with, from a vt100 model of
 the same byte stream — a fixed row would silently test a fiction.
 
-It asserts *pairs*: every enter has its matching restore. A renderer that leaves
-the terminal in the alternate screen, with the cursor hidden or mouse capture on,
-is the failure mode a user notices most and a buffer test can never catch.
+It asserts *pairs*: every enter has its matching restore, including the explicit
+mouse-capture path; the default alternate-screen path asserts that capture is
+never enabled. A renderer that leaves the terminal in the alternate screen,
+with the cursor hidden or mouse capture on, is the failure mode a user notices
+most and a buffer test can never catch.
 
 Because it launches a *built example* rather than calling into the library, the
 `gallery` binary must exist beside the test binary. That constrains how coverage

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -25,8 +25,9 @@ a document whose prefix cannot change.
   verbatim so their alignment survives.
 - `MarkdownState` is the streaming form. Fed deltas as a message arrives, it
   re-parses only the in-flight tail and caches everything before the last stable
-  block boundary. Settled blocks keep their already-computed lines — and their
-  already-computed highlighting.
+  block boundary. Settled blocks keep their already-computed lines, highlighting,
+  image placements, and hyperlink runs. `links()` exposes row-aligned targets
+  for hosts that scroll or window those lines before applying OSC 8.
 - Inline images (`![alt](url)`) are promoted to block images when the host
   supplies a resolver; see [images.md](./images.md).
 - A fixed whitelist of *inline* HTML tags renders through the same style roles as

--- a/knowledge/specs/out-of-band.md
+++ b/knowledge/specs/out-of-band.md
@@ -123,10 +123,12 @@ the terminal as a control sequence" class of bug out of scope by construction â€
 see [`SECURITY.md`](../../SECURITY.md).
 
 Runner-provided mouse selection is the one framework-initiated clipboard path.
-It reads only the cells the runner just rendered and passes that text through
-the same base64 OSC 52 encoder on release. A caller-owned async event loop gets
-the selection overlay only; it can disable that default and compose the public
-selection primitives when it needs a custom clipboard sink.
+It is active only after a host explicitly opts into mouse capture, reads only
+the cells the runner just rendered, and passes that text through the same
+base64 OSC 52 encoder on release. Native terminal mouse handling remains the
+default because capture also disables emulator-owned OSC 8 activation,
+selection, and scrolling. `ctrl_click_url` is an opt-in application fallback
+for captured sessions; opening its result remains host policy.
 
 ## Constraints
 

--- a/knowledge/specs/screen-modes.md
+++ b/knowledge/specs/screen-modes.md
@@ -26,12 +26,15 @@ until it happens.
 
 | Mode | Owns | Scrollback above | Mouse capture |
 | --- | --- | --- | --- |
-| `Alternate` (default) | the whole window, alternate buffer | n/a — restored on exit | on |
+| `Alternate` (default) | the whole window, alternate buffer | n/a — restored on exit | off by default |
 | `SplitFooter { height }` | `height` rows at the bottom of the main screen | the terminal's, live | off by default |
 
-When a runner captures the mouse, it restores plain drag selection over its
-final cell frame while continuing to route wheel events to the application.
-Custom-loop hosts opt into capture and selection independently.
+Both modes preserve the terminal's native OSC 8 activation, selection, and
+scrolling by default. A host that needs pointer or wheel events opts into mouse
+capture with `with_mouse_capture`; capture necessarily takes those native
+behaviors away from the terminal. When a runner captures, it restores plain
+drag selection over its final cell frame while continuing to route wheel events
+to the application. Custom-loop hosts opt into capture and selection independently.
 
 A split footer renders into a ratatui `Viewport::Inline`. The pieces around it:
 
@@ -67,13 +70,14 @@ surrounding session rather than a pasted panel.
 Queued blocks are discarded in `Alternate`: there is no scrollback of the host's
 to write into, and retaining them would grow without bound.
 
-### A split footer does not capture the mouse
+### Mouse capture is opt-in in both modes
 
-Capture is on for the alternate screen and off for a split footer. Capturing on
-the main screen takes the wheel and drag-selection away from the terminal —
-which is precisely the interaction the mode exists to preserve. A footer that
-needs mouse input opts back in with `with_mouse_capture`; that is a trade the
-host makes deliberately, not a default.
+Mouse reporting is global terminal state: there is no portable mode that sends
+ordinary clicks to the application while retaining native OSC 8 modifier-clicks.
+Both screen modes therefore leave mouse handling to the emulator. A mode that
+needs application pointer or wheel input opts in with `with_mouse_capture`,
+accepting that native link activation, selection, and scrolling stop until the
+session restores the terminal state.
 
 ### The footer is pinned, not merely inline
 

--- a/src/components/markdown/flatten.rs
+++ b/src/components/markdown/flatten.rs
@@ -52,20 +52,9 @@ pub(super) fn flatten_linked<R: MarkdownBlockRenderer + ?Sized>(
     flatten_linked_into(items, width, theme, sheet, renderers, &mut images)
 }
 
-/// Flatten into lines and collect the block images reserved, with the row each
-/// landed on, so the [`Markdown`](super::Markdown) view can overlay an [`Image`](crate::components::Image) at the matching
-/// screen rect. A block image reserves `rows` blank lines here.
-pub(super) fn flatten_into<R: MarkdownBlockRenderer + ?Sized>(
-    items: &[MdItem],
-    width: u16,
-    theme: &Theme,
-    sheet: &StyleSheet,
-    renderers: &R,
-    images: &mut Vec<MarkdownImage>,
-) -> Vec<Line<'static>> {
-    flatten_linked_into(items, width, theme, sheet, renderers, images).0
-}
-
+/// Flatten into lines and links while collecting each reserved block image and
+/// its row, so [`Markdown`](super::Markdown) can overlay an
+/// [`Image`](crate::components::Image) at the matching screen rect.
 pub(super) fn flatten_linked_into<R: MarkdownBlockRenderer + ?Sized>(
     items: &[MdItem],
     width: u16,

--- a/src/components/markdown/mod.rs
+++ b/src/components/markdown/mod.rs
@@ -16,6 +16,8 @@
 //! code, emoji). Callers draw the returned lines **without** further wrapping
 //! (e.g. ratatui's `Paragraph` with no `.wrap`, or tuika's
 //! [`Text`](crate::components::Text)).
+//! Streaming callers apply [`MarkdownState::links`] after painting so link
+//! targets stay aligned through incremental diffs and viewporting.
 //!
 //! For one-shot (non-streaming) text, [`to_lines`] renders a whole
 //! string in one call. The [`Markdown`] view wraps either for direct placement

--- a/src/components/markdown/stream.rs
+++ b/src/components/markdown/stream.rs
@@ -9,9 +9,10 @@ use ratatui_core::text::Line;
 
 use crate::highlight::CodeHighlighter;
 use crate::style::{StyleSheet, Theme};
+use crate::term::hyperlink::BufferLink;
 
 use super::MarkdownBlockRenderer;
-use super::flatten::flatten_into;
+use super::flatten::flatten_linked_into;
 use super::image::{ImageResolver, MarkdownImage};
 use super::item::MdItem;
 use super::parse::parse_with;
@@ -46,7 +47,8 @@ fn stable_boundary(source: &str, from: usize) -> usize {
 ///
 /// Feed it deltas with [`push_str`](Self::push_str) (or replace the whole buffer
 /// with [`set`](Self::set)); call [`lines`](Self::lines) each frame for the
-/// current width-fitted rendering. Settled blocks — everything before the last
+/// current width-fitted rendering, then read [`links`](Self::links) and
+/// [`images`](Self::images) for its out-of-band metadata. Settled blocks — everything before the last
 /// blank line outside an open code fence — are parsed, highlighted, **and
 /// flattened once** and cached; each delta re-does only the in-flight tail. That
 /// keeps a streamed render linear in the transcript length, instead of
@@ -98,6 +100,10 @@ pub struct MarkdownState {
     /// Settled + tail images with absolute rows, rebuilt each [`lines`](Self::lines)
     /// call; returned by [`images`](Self::images).
     frame_images: Vec<MarkdownImage>,
+    /// Settled + tail links with absolute rows, rebuilt by [`lines`](Self::lines).
+    frame_links: Vec<BufferLink>,
+    /// Count of leading `frame_links` entries that belong to settled lines.
+    settled_link_count: usize,
 }
 
 impl MarkdownState {
@@ -140,6 +146,16 @@ impl MarkdownState {
         &self.frame_images
     }
 
+    /// Hyperlink runs produced by the last [`lines`](Self::lines) call, with
+    /// rows relative to those lines.
+    ///
+    /// After painting the lines, pass the visible runs to
+    /// [`apply_buffer_links`](crate::term::hyperlink::apply_buffer_links) so
+    /// labeled and incrementally streamed links retain native OSC 8 activation.
+    pub fn links(&self) -> &[BufferLink] {
+        &self.frame_links
+    }
+
     /// Append a streamed delta to the buffer (the settled-prefix cache is kept).
     pub fn push_str(&mut self, delta: &str) {
         self.source.push_str(delta);
@@ -166,6 +182,8 @@ impl MarkdownState {
         self.rendered_width = None;
         self.settled_images.clear();
         self.frame_images.clear();
+        self.frame_links.clear();
+        self.settled_link_count = 0;
     }
 
     /// Render the current buffer to final, width-fitted styled lines, advancing
@@ -175,6 +193,7 @@ impl MarkdownState {
     /// every color via [`Theme::code`](crate::style::CodeTheme); `highlighter` colors
     /// fenced code ([`CodeHighlighter::Plain`] for none). Draw the result
     /// **without** further wrapping (e.g. ratatui `Paragraph` with no `.wrap`).
+    /// After painting, apply [`links`](Self::links) to the same area.
     ///
     /// Returns a borrow of an internally-cached line buffer: settled blocks are
     /// flattened once and only the in-flight tail is recomputed per call, so a
@@ -204,6 +223,8 @@ impl MarkdownState {
             self.settled_lines = 0;
             self.flattened_items = 0;
             self.settled_images.clear();
+            self.frame_links.clear();
+            self.settled_link_count = 0;
         }
 
         let boundary = stable_boundary(&self.source, self.stable_len);
@@ -228,10 +249,11 @@ impl MarkdownState {
         // `flatten` maps each item independently, so appending the new items'
         // lines equals re-flattening the whole prefix.
         self.rendered.truncate(self.settled_lines);
+        self.frame_links.truncate(self.settled_link_count);
         if self.flattened_items < self.stable.len() {
             let base = self.rendered.len() as u16;
             let mut settled_imgs = Vec::new();
-            let settled = flatten_into(
+            let (settled, settled_links) = flatten_linked_into(
                 &self.stable[self.flattened_items..],
                 width,
                 theme,
@@ -239,6 +261,10 @@ impl MarkdownState {
                 self.block_renderers.as_slice(),
                 &mut settled_imgs,
             );
+            for mut link in settled_links {
+                link.line = link.line.saturating_add(base);
+                self.frame_links.push(link);
+            }
             for mut img in settled_imgs {
                 img.row = img.row.saturating_add(base);
                 self.settled_images.push(img);
@@ -246,6 +272,7 @@ impl MarkdownState {
             self.rendered.extend(settled);
             self.flattened_items = self.stable.len();
             self.settled_lines = self.rendered.len();
+            self.settled_link_count = self.frame_links.len();
         }
 
         let tail = parse_with(
@@ -256,7 +283,7 @@ impl MarkdownState {
             self.resolver.as_deref(),
         );
         let mut tail_imgs = Vec::new();
-        let tail_lines = flatten_into(
+        let (tail_lines, tail_links) = flatten_linked_into(
             &tail,
             width,
             theme,
@@ -284,6 +311,10 @@ impl MarkdownState {
             img.row = img.row.saturating_add(tail_base);
             self.frame_images.push(img);
         }
+        for mut link in tail_links {
+            link.line = link.line.saturating_add(tail_base);
+            self.frame_links.push(link);
+        }
         &self.rendered
     }
 }
@@ -309,6 +340,30 @@ mod tests {
     use std::rc::Rc;
 
     use super::super::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
+
+    #[test]
+    fn streaming_preserves_link_targets_across_tail_settling_and_resize() {
+        let theme = Theme::default();
+        let sheet = StyleSheet::from_theme(&theme);
+        let mut state = MarkdownState::new();
+
+        state.push_str("see <https://docs.rs/");
+        state.lines(40, &theme, &sheet, CodeHighlighter::Plain);
+
+        state.push_str("tuika>.\n\nnext");
+        state.lines(40, &theme, &sheet, CodeHighlighter::Plain);
+        assert_eq!(state.links().len(), 1);
+        assert_eq!(state.links()[0].url, "https://docs.rs/tuika");
+
+        state.lines(20, &theme, &sheet, CodeHighlighter::Plain);
+        assert!(!state.links().is_empty());
+        assert!(
+            state
+                .links()
+                .iter()
+                .all(|link| link.url == "https://docs.rs/tuika")
+        );
+    }
 
     #[test]
     fn sheet_change_invalidates_stream_cache() {

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -26,8 +26,9 @@ use super::parse::parse_with;
 ///
 /// ![markdown demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/markdown.gif)
 ///
-/// For a *streaming* transcript, hold a [`MarkdownState`](super::MarkdownState) and draw its
-/// [`lines`](super::MarkdownState::lines) directly (that is what the demo above does);
+/// For a *streaming* transcript, hold a [`MarkdownState`](super::MarkdownState), draw its
+/// [`lines`](super::MarkdownState::lines), and apply its
+/// [`links`](super::MarkdownState::links) directly (that is what the demo above does);
 /// this view is the one-shot convenience for static markdown placed in a layout.
 ///
 /// The presentational inline HTML tags render through the same style roles as the

--- a/src/host.rs
+++ b/src/host.rs
@@ -36,19 +36,38 @@ use super::style::{StyleSheet, Theme};
 use super::surface::Surface;
 use super::view::{RenderCtx, View};
 
-/// RAII guard for the alternate screen + mouse capture.
+/// RAII guard for the alternate screen.
 pub struct AltScreen {
     active: bool,
+    mouse_capture: bool,
 }
 
 impl AltScreen {
-    /// Enter the alternate screen and enable mouse capture. Assumes raw mode is
-    /// already enabled by the caller.
+    /// Enter the alternate screen, leaving mouse handling to the terminal.
+    /// Assumes raw mode is already enabled by the caller.
     pub fn enter() -> io::Result<Self> {
+        Self::enter_with(false)
+    }
+
+    /// Enter the alternate screen and enable terminal mouse reporting.
+    ///
+    /// Capture gives the application pointer and wheel events, but prevents
+    /// native OSC 8 link activation, selection, and scrolling.
+    pub fn enter_with_mouse_capture() -> io::Result<Self> {
+        Self::enter_with(true)
+    }
+
+    fn enter_with(mouse_capture: bool) -> io::Result<Self> {
         let mut out = io::stdout();
-        execute!(out, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(out, EnterAlternateScreen)?;
+        if mouse_capture {
+            execute!(out, EnableMouseCapture)?;
+        }
         out.flush()?;
-        Ok(Self { active: true })
+        Ok(Self {
+            active: true,
+            mouse_capture,
+        })
     }
 
     /// Explicitly leave (also runs on drop; idempotent).
@@ -59,7 +78,10 @@ impl AltScreen {
                 crate::term::pointer::encode(crate::term::pointer::PointerShape::Default)
                     .as_bytes(),
             );
-            let _ = execute!(out, DisableMouseCapture, LeaveAlternateScreen);
+            if self.mouse_capture {
+                let _ = execute!(out, DisableMouseCapture);
+            }
+            let _ = execute!(out, LeaveAlternateScreen);
             let _ = out.flush();
             self.active = false;
         }
@@ -75,8 +97,9 @@ impl Drop for AltScreen {
 /// Complete RAII ownership of a terminal session, in either [`ScreenMode`].
 ///
 /// Construction enables raw mode and enhanced keyboard reporting, hides the
-/// cursor, and — depending on the mode — enters the alternate screen and
-/// enables mouse capture. Enhanced reporting is what lets crossterm distinguish
+/// cursor, and — depending on the mode — enters the alternate screen. Mouse
+/// capture is explicit; the defaults preserve native terminal links, selection,
+/// and scrolling. Enhanced reporting is what lets crossterm distinguish
 /// chords such as Shift+Enter from plain Enter on ANSI terminals; Windows
 /// console events already carry modifier state through the native input API.
 /// Drop restores exactly what it took, including when unwinding from a panic.
@@ -105,9 +128,10 @@ pub enum MouseCapture {
     /// Follow the selected [`ScreenMode`].
     #[default]
     ModeDefault,
-    /// Enable mouse reporting regardless of the mode default.
+    /// Enable mouse reporting regardless of the mode default. This gives mouse
+    /// events to the application instead of native terminal links and selection.
     Enabled,
-    /// Leave mouse reporting disabled.
+    /// Leave mouse reporting disabled, preserving native terminal handling.
     Disabled,
 }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,9 +1,10 @@
 //! Mouse interaction over the rendered cell grid: text selection, click
 //! hit-testing, and click detection.
 //!
-//! Terminals don't hand you selection or clickable regions — once an app
-//! enables mouse capture (see [`AltScreen`](crate::host::AltScreen)) the terminal's
-//! own click-drag selection stops working, and every drag arrives as a
+//! Terminals don't hand captured applications selection or clickable regions —
+//! once an app opts into mouse capture (see
+//! [`AltScreen::enter_with_mouse_capture`](crate::host::AltScreen::enter_with_mouse_capture))
+//! the terminal's own link activation and click-drag selection stop working, and every drag arrives as a
 //! [`Mouse`] event instead. This module rebuilds those affordances *on top of*
 //! the grid the app already rendered:
 //!

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -766,6 +766,7 @@ mod tests {
     use std::convert::Infallible;
 
     use super::*;
+    use crate::ScreenMode;
     use crate::components::Text;
     use crate::event::{Key, KeyCode, Mouse, MouseButton, MouseKind};
     use crate::view::element;
@@ -904,10 +905,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clean_mouse_drag_uses_default_text_selection() {
+    async fn clean_mouse_drag_uses_selection_when_mouse_is_captured() {
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
-            ..RunnerConfig::default()
+            screen_mode: ScreenMode::Alternate.with_mouse_capture(),
         });
         let mut terminal = terminal(11, 1);
         let mut mouse_events = 0usize;

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1127,7 +1127,14 @@ mod tests {
 
     #[test]
     fn text_selection_follows_capture_and_can_be_disabled() {
-        assert!(Runner::new(RunnerConfig::default()).selects_text());
+        assert!(!Runner::new(RunnerConfig::default()).selects_text());
+        assert!(
+            Runner::new(RunnerConfig {
+                screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+                ..RunnerConfig::default()
+            })
+            .selects_text()
+        );
         assert!(
             !Runner::new(RunnerConfig {
                 screen_mode: ScreenMode::split_footer(3),

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -5,8 +5,8 @@
 //!
 //! - [`ScreenMode::Alternate`] — the terminal's alternate buffer. The frame owns
 //!   the whole window and the user's scrollback is restored untouched on exit.
-//!   This is the default and what [`TerminalSession`](crate::TerminalSession)
-//!   has always done.
+//!   This is the default; native terminal mouse handling stays active so OSC 8
+//!   links, selection, and scrolling keep their emulator behavior.
 //! - [`ScreenMode::SplitFooter`] — a reserved region pinned to the bottom of the
 //!   *main* screen. The frame owns only those rows; everything above stays the
 //!   terminal's own scrollback, so ordinary program output, the shell prompt
@@ -87,9 +87,16 @@ pub const DEFAULT_FOOTER_HEIGHT: u16 = 12;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum ScreenMode {
     /// Own the whole window on the terminal's alternate buffer, restoring the
-    /// previous screen and scrollback on exit. Captures the mouse.
+    /// previous screen and scrollback on exit. Leaves mouse handling to the
+    /// terminal so native OSC 8 links and selection keep working.
     #[default]
     Alternate,
+    /// Alternate-screen mode with terminal mouse reporting enabled.
+    ///
+    /// Prefer constructing this through [`with_mouse_capture`](Self::with_mouse_capture).
+    /// Capture gives the application pointer and wheel events, but prevents the
+    /// terminal from providing native OSC 8 activation, selection, and scrolling.
+    AlternateWithMouseCapture,
     /// Own `height` rows pinned to the bottom of the main screen, leaving the
     /// rows above as ordinary terminal scrollback.
     SplitFooter {
@@ -120,11 +127,13 @@ impl ScreenMode {
         Self::split_footer(DEFAULT_FOOTER_HEIGHT)
     }
 
-    /// Capture the mouse in this mode. [`Alternate`](Self::Alternate) already
-    /// does, so this only affects a split footer.
+    /// Capture the mouse in this mode.
+    ///
+    /// This is opt-in because terminal mouse reporting takes native OSC 8 link
+    /// activation, selection, and scrolling away from the terminal emulator.
     pub fn with_mouse_capture(self) -> Self {
         match self {
-            Self::Alternate => Self::Alternate,
+            Self::Alternate | Self::AlternateWithMouseCapture => Self::AlternateWithMouseCapture,
             Self::SplitFooter { height, .. } => Self::SplitFooter {
                 height,
                 mouse_capture: true,
@@ -134,13 +143,13 @@ impl ScreenMode {
 
     /// Whether this mode owns the alternate screen.
     pub fn is_alternate(self) -> bool {
-        matches!(self, Self::Alternate)
+        matches!(self, Self::Alternate | Self::AlternateWithMouseCapture)
     }
 
     /// The reserved footer height, or `None` in [`Alternate`](Self::Alternate).
     pub fn footer_height(self) -> Option<u16> {
         match self {
-            Self::Alternate => None,
+            Self::Alternate | Self::AlternateWithMouseCapture => None,
             Self::SplitFooter { height, .. } => Some(height),
         }
     }
@@ -148,7 +157,8 @@ impl ScreenMode {
     /// Whether the host should enable mouse capture for this mode.
     pub fn captures_mouse(self) -> bool {
         match self {
-            Self::Alternate => true,
+            Self::Alternate => false,
+            Self::AlternateWithMouseCapture => true,
             Self::SplitFooter { mouse_capture, .. } => mouse_capture,
         }
     }
@@ -157,7 +167,7 @@ impl ScreenMode {
     /// own [`Terminal`].
     pub fn viewport(self) -> Viewport {
         match self {
-            Self::Alternate => Viewport::Fullscreen,
+            Self::Alternate | Self::AlternateWithMouseCapture => Viewport::Fullscreen,
             Self::SplitFooter { height, .. } => Viewport::Inline(height),
         }
     }
@@ -478,16 +488,19 @@ mod tests {
     }
 
     #[test]
-    fn alternate_is_the_default_and_always_captures_the_mouse() {
+    fn alternate_defaults_to_native_terminal_mouse_handling() {
         let mode = ScreenMode::default();
         assert_eq!(mode, ScreenMode::Alternate);
         assert_eq!(mode.viewport(), Viewport::Fullscreen);
         assert_eq!(mode.footer_height(), None);
-        assert!(mode.captures_mouse());
+        assert!(!mode.captures_mouse());
         assert!(mode.is_alternate());
-        // Requesting capture on the alternate screen is redundant, not a
-        // different mode.
-        assert_eq!(mode.with_mouse_capture(), ScreenMode::Alternate);
+
+        let captured = mode.with_mouse_capture();
+        assert!(captured.captures_mouse());
+        assert!(captured.is_alternate());
+        assert_eq!(captured.viewport(), Viewport::Fullscreen);
+        assert_eq!(captured.with_mouse_capture(), captured);
     }
 
     #[test]

--- a/src/term/hyperlink.rs
+++ b/src/term/hyperlink.rs
@@ -281,6 +281,10 @@ fn osc8_target_in(symbol: &str) -> Option<String> {
 
 /// Return the visible HTTP(S) URL under a Ctrl+left-button release.
 ///
+/// This is an application-side fallback for a host that explicitly captured
+/// the mouse. Prefer native terminal OSC 8 activation when application mouse
+/// events are not required; capture disables that native path.
+///
 /// Resolution order:
 /// 1. An OSC 8 target already embedded in the cell run under the pointer
 ///    (markdown `[label](url)` after [`apply_buffer_links`]).

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -4,8 +4,8 @@
 //! and never touch a real terminal. This drives real examples under a
 //! pseudo-terminal (`portable-pty`) and asserts the terminal-facing behavior a
 //! buffer test cannot see: entering and restoring the alternate screen, enhanced
-//! keyboard reporting, cursor and mouse-capture lifecycle, runner-provided OSC
-//! 52 text selection, the native OSC 9;4 progress indicator, OSC 8 hyperlinks,
+//! keyboard reporting, native mouse defaults and explicit capture lifecycle,
+//! runner-provided OSC 52 text selection, the native OSC 9;4 progress indicator, OSC 8 hyperlinks,
 //! truecolor and Braille cells surviving a reference terminal parser, resize
 //! survival, and a clean exit — `hello` and `gallery` for the alternate screen,
 //! and `split_footer` for a footer over live scrollback.
@@ -25,6 +25,7 @@ use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 
 /// The URL rendered in the gallery footer, emitted as an OSC 8 hyperlink target.
 const GALLERY_URL: &str = "https://github.com/everruns/tuika";
+const MARKDOWN_URL: &str = "https://docs.rs/tuika";
 
 /// Locate a compiled example binary.
 ///
@@ -424,10 +425,13 @@ fn gallery_drives_altscreen_and_native_progress() {
         contains(out, b"\x1b[?25h"),
         "should restore the cursor on exit"
     );
-    assert!(contains(out, b"\x1b[?1000h"), "should enable mouse capture");
     assert!(
-        contains(out, b"\x1b[?1000l"),
-        "should disable mouse capture on exit"
+        !contains(out, b"\x1b[?1000h"),
+        "native terminal mouse handling should remain enabled"
+    );
+    assert!(
+        !contains(out, b"\x1b[?1000l"),
+        "uncaptured mouse needs no teardown"
     );
     assert!(
         contains(out, b"\x1b[>7u"),
@@ -460,6 +464,7 @@ fn runner_drag_selection_copies_the_rendered_cells() {
     // one-based: press on H, drag through o, then release there.
     let drag_hello = b"\x1b[<0;4;3M\x1b[<32;8;3M\x1b[<0;8;3m";
     let run = Script::new("hello")
+        .arg("--mouse")
         .size(8, 40)
         .settle(Duration::from_millis(500))
         .key(drag_hello, Duration::from_millis(500))
@@ -473,9 +478,9 @@ fn runner_drag_selection_copies_the_rendered_cells() {
 }
 
 #[test]
-fn gallery_session_config_can_disable_mouse_without_leaking_terminal_state() {
+fn gallery_can_opt_into_mouse_capture_without_leaking_terminal_state() {
     let run = Script::new("gallery")
-        .arg("--no-mouse")
+        .arg("--mouse")
         .size(24, 80)
         .settle(Duration::from_millis(900))
         .run();
@@ -487,12 +492,12 @@ fn gallery_session_config_can_disable_mouse_without_leaking_terminal_state() {
     );
     assert!(contains(out, b"\x1b[?1049l"), "should restore main screen");
     assert!(
-        !contains(out, b"\x1b[?1000h"),
-        "mouse override must be honored"
+        contains(out, b"\x1b[?1000h"),
+        "explicit mouse capture must be honored"
     );
     assert!(
-        !contains(out, b"\x1b[?1000l"),
-        "disabled mouse needs no teardown"
+        contains(out, b"\x1b[?1000l"),
+        "captured mouse must be restored on exit"
     );
     assert!(
         contains(out, b"\x1b[?25l"),
@@ -580,6 +585,24 @@ fn gallery_emits_osc8_hyperlink() {
     assert!(
         footer.contains("docs") && footer.contains(GALLERY_URL),
         "OSC 8 wrapping should leave the footer text intact: {footer:?}"
+    );
+}
+
+#[test]
+fn markdown_emits_native_link_without_capturing_the_mouse() {
+    let run = Script::new("markdown")
+        .size(30, 100)
+        .settle(Duration::from_millis(2200))
+        .run();
+    assert!(run.exited_ok, "markdown should exit cleanly");
+    let osc8 = format!("\x1b]8;;{MARKDOWN_URL}\x1b\\");
+    assert!(
+        contains(&run.output, osc8.as_bytes()),
+        "expected an OSC 8 hyperlink for {MARKDOWN_URL}"
+    );
+    assert!(
+        !contains(&run.output, b"\x1b[?1000h"),
+        "native link activation requires mouse capture to stay disabled"
     );
 }
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -493,4 +493,6 @@ fn the_non_prelude_surface_keeps_its_module_path() {
     let _ = tuika::runner::Runner::new(RunnerConfig::default());
     // `AltScreen::enter` touches the real terminal, so only its path is pinned.
     let _: fn() -> std::io::Result<tuika::host::AltScreen> = tuika::host::AltScreen::enter;
+    let _: fn() -> std::io::Result<tuika::host::AltScreen> =
+        tuika::host::AltScreen::enter_with_mouse_capture;
 }


### PR DESCRIPTION
## What changed

- Leave alternate-screen mouse handling with the terminal by default, preserving native OSC 8 activation, selection, and scrolling.
- Make application mouse reporting explicit through `ScreenMode::with_mouse_capture`, `MouseCapture::Enabled`, or `AltScreen::enter_with_mouse_capture`.
- Preserve `MarkdownState` hyperlink metadata across streaming, stable-prefix caching, wrapping, and resize, and apply it in the runnable markdown example.
- Keep mouse-driven examples working by opting them into capture, while `gallery`, `hello`, and `markdown` expose `--mouse` only when application mouse input is wanted.

This is a breaking behavior/API change for the next pre-1.0 minor release: `ScreenMode::Alternate` no longer captures by default, and the public enum has a new `AlternateWithMouseCapture` variant. Exhaustive downstream matches must handle the new variant. The public `MarkdownState::links` and `AltScreen::enter_with_mouse_capture` APIs are additive.

## Why

Terminal mouse reporting intercepts modifier-clicks before Ghostty and other OSC 8-capable emulators can activate links. The markdown example therefore emitted a link target that could not be clicked. Streaming markdown also discarded link destinations after flattening, so hosts could not reliably reapply labeled links after incremental updates or viewporting.

## Before / After

Before, `cargo run --example markdown` enabled DEC mouse reporting on entry. OSC 8 bytes could be present, but the emulator did not receive Cmd/Ctrl-click activation.

After, an interactive run of the same command emitted the native target `https://docs.rs/tuika` and no mouse-capture enable sequence. `cargo run --example markdown -- --mouse` emitted the capture enable sequence and its matching restore, proving the non-native path is explicit.

Automated protocol proof: `markdown_emits_native_link_without_capturing_the_mouse` runs the built example under a PTY and asserts both the OSC 8 target and absence of mouse capture. Existing PTY coverage now also checks the explicit capture lifecycle.

## Risk

- Medium: applications that relied on implicit alternate-screen mouse events must opt in.
- Exhaustive matches on `ScreenMode` must account for `AlternateWithMouseCapture`.
- Link emission remains constrained by `LinkPolicy`; no new URL schemes or automatic URL opener were added.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (652 core tests, 14 PTY tests, packaging and companion crates green)
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --strict --check-links`
- `cargo run --example demo -- check` (42 scenes/references in sync)
- Interactive terminal smoke: `cargo run --example markdown`
- Interactive opt-in smoke: `cargo run --example markdown -- --mouse`

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered and breaking migration documented
- [x] Knowledge concepts updated

## Knowledge

Updated the markdown, out-of-band terminal behavior, screen-mode, testing, and release concepts; recorded the decision in `knowledge/log.md`. Public README, focused guides, rustdoc, examples, changelog, and agent guidance are aligned.

## Security

- **TM-ESC:** No new encoder or scheme was introduced. Markdown targets still pass through `LinkPolicy` and existing control-character sanitization before OSC 8 emission; no caller string is written as an unchecked control sequence.
- **TM-STATE:** Default sessions no longer enter mouse-reporting state. Explicit capture still has matching disable-on-exit and rollback paths, covered by PTY tests.
- **TM-PARSE:** Link caching is linear in rendered links, uses saturating row arithmetic, and is exercised across incomplete streamed input, settling, and resize without new recursion or parsed-input unwraps.
- **TM-CLIP:** Visible link runs are viewport-filtered and `apply_buffer_links` retains its buffer-bound checks.
- **TM-DEP:** No dependency or manifest changes.

No findings.

## Follow-ups

No follow-ups.
