### PR TITLE
fix(selection): omit soft wraps from copied text

### DIFF
--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -239,6 +239,7 @@ impl View for Paragraph {
     }
 
     fn render(&self, area: Rect, surface: &mut Surface, ctx: &RenderCtx) {
+        ctx.record_selection_source(area, self.text.to_string());
         let mut buffer_links = Vec::new();
         let link_style = ctx.sheet.resolve(Role::Link).apply(self.style);
         for (row, line) in self

--- a/src/host.rs
+++ b/src/host.rs
@@ -34,7 +34,7 @@ use super::overlay::Overlay;
 use super::screen::ScreenMode;
 use super::style::{StyleSheet, Theme};
 use super::surface::Surface;
-use super::view::{RenderCtx, View};
+use super::view::{RenderCtx, SelectionSources, View};
 
 /// RAII guard for the alternate screen.
 pub struct AltScreen {
@@ -440,6 +440,20 @@ pub fn paint_with_context(
     root: &dyn View,
     overlays: &[Overlay],
 ) {
+    let sources = SelectionSources::default();
+    paint_with_context_and_sources(buffer, area, ctx, root, overlays, &sources);
+}
+
+pub(crate) fn paint_with_context_and_sources(
+    buffer: &mut Buffer,
+    area: Rect,
+    ctx: &RenderCtx,
+    root: &dyn View,
+    overlays: &[Overlay],
+    sources: &SelectionSources,
+) {
+    sources.clear();
+    let ctx = ctx.clone().with_selection_sources(sources);
     // Base background so the alternate screen is fully owned (no stale cells).
     {
         let mut surface = Surface::new(buffer, area);
@@ -447,7 +461,7 @@ pub fn paint_with_context(
     }
     {
         let mut surface = Surface::new(buffer, area);
-        root.render(area, &mut surface, ctx);
+        root.render(area, &mut surface, &ctx);
     }
     for overlay in overlays {
         let mut surface = Surface::new(buffer, overlay.area);

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -25,11 +25,12 @@
 //! flows through this same path — there is no separate touch event to model.
 
 use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
+use ratatui_core::layout::{Position, Rect};
 use ratatui_core::style::Style;
 use std::time::{Duration, Instant};
 
 use crate::event::{Mouse, MouseButton, MouseKind};
+use crate::view::SelectionSource;
 use crate::{Clock, SystemClock};
 
 /// A normalized text selection in reading order: `start` is at or before `end`
@@ -238,6 +239,29 @@ pub fn word_at(buffer: &Buffer, area: Rect, column: u16, row: u16) -> Option<Sel
 /// row, joined with `\n`. Trailing blanks on each row are trimmed. Wide glyphs
 /// come back once (their trailing spacer cell is empty in the buffer).
 pub fn selected_text(buffer: &Buffer, area: Rect, sel: SelectionRange) -> String {
+    selected_text_from_sources(buffer, area, sel, &[])
+}
+
+pub(crate) fn selected_text_from_sources(
+    buffer: &Buffer,
+    area: Rect,
+    sel: SelectionRange,
+    sources: &[SelectionSource],
+) -> String {
+    if let Some(source) = sources.iter().rev().find(|source| {
+        source
+            .area
+            .contains(Position::new(sel.start.0, sel.start.1))
+            && source.area.contains(Position::new(sel.end.0, sel.end.1))
+            && source_matches_selection(buffer, area, sel, &source.text)
+    }) && let Some(text) = extract_source_selection(buffer, area, sel, &source.text)
+    {
+        return text;
+    }
+    selected_grid_text(buffer, area, sel)
+}
+
+fn selected_grid_text(buffer: &Buffer, area: Rect, sel: SelectionRange) -> String {
     let mut out = String::new();
     let mut first = true;
     for row in sel.start.1..=sel.end.1 {
@@ -255,6 +279,35 @@ pub fn selected_text(buffer: &Buffer, area: Rect, sel: SelectionRange) -> String
         out.push_str(line.trim_end_matches(' '));
     }
     out
+}
+
+fn source_matches_selection(
+    buffer: &Buffer,
+    area: Rect,
+    sel: SelectionRange,
+    source: &str,
+) -> bool {
+    selected_grid_text(buffer, area, sel)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .all(|line| source.contains(line.trim()))
+}
+
+fn extract_source_selection(
+    buffer: &Buffer,
+    area: Rect,
+    sel: SelectionRange,
+    source: &str,
+) -> Option<String> {
+    let selected = selected_grid_text(buffer, area, sel);
+    let first = selected.lines().next()?.trim_start();
+    let last = selected.lines().last()?.trim_end();
+    if first.is_empty() || last.is_empty() {
+        return None;
+    }
+    let start = source.find(first)?;
+    let end = source[start..].find(last)? + start + last.len();
+    Some(source[start..end].to_string())
 }
 
 /// Paint `style` over the selected cells of `buffer` (patching, so glyphs and
@@ -495,6 +548,109 @@ mod tests {
     }
     fn up(col: u16, row: u16) -> Mouse {
         Mouse::at(MouseKind::Up(MouseButton::Left), col, row)
+    }
+
+    fn buffer_with_rows(rows: &[&str]) -> Buffer {
+        let width = rows
+            .iter()
+            .map(|row| row.chars().count())
+            .max()
+            .unwrap_or(0) as u16;
+        let area = Rect::new(0, 0, width, rows.len() as u16);
+        let mut buffer = Buffer::empty(area);
+        for (y, row) in rows.iter().enumerate() {
+            buffer.set_string(0, y as u16, *row, Style::default());
+        }
+        buffer
+    }
+
+    #[test]
+    fn source_aware_copy_omits_soft_wraps() {
+        let buffer = buffer_with_rows(&["hello", "world"]);
+        let selection = SelectionRange::between((0, 0), (4, 1));
+
+        assert_eq!(
+            selected_text_from_sources(
+                &buffer,
+                buffer.area,
+                selection,
+                &[SelectionSource {
+                    area: buffer.area,
+                    text: "helloworld".to_string()
+                }],
+            ),
+            "helloworld",
+        );
+    }
+
+    #[test]
+    fn source_aware_copy_preserves_explicit_newlines() {
+        let buffer = buffer_with_rows(&["hello", "world"]);
+        let selection = SelectionRange::between((0, 0), (4, 1));
+
+        assert_eq!(
+            selected_text_from_sources(
+                &buffer,
+                buffer.area,
+                selection,
+                &[SelectionSource {
+                    area: buffer.area,
+                    text: "hello\nworld".to_string()
+                }],
+            ),
+            "hello\nworld",
+        );
+    }
+
+    #[test]
+    fn source_aware_copy_handles_unicode_and_clipped_endpoints() {
+        let buffer = buffer_with_rows(&["pha α", "β omega"]);
+        let selection = SelectionRange::between((0, 0), (0, 1));
+
+        assert_eq!(
+            selected_text_from_sources(
+                &buffer,
+                buffer.area,
+                selection,
+                &[SelectionSource {
+                    area: buffer.area,
+                    text: "alpha αβ omega".to_string()
+                }],
+            ),
+            "pha αβ",
+        );
+    }
+
+    #[test]
+    fn source_area_disambiguates_identical_rendered_text() {
+        let buffer = buffer_with_rows(&["hello", "world", "hello", "world"]);
+        let selection = SelectionRange::between((0, 2), (4, 3));
+        let sources = [
+            SelectionSource {
+                area: Rect::new(0, 0, 5, 2),
+                text: "hello\nworld".to_string(),
+            },
+            SelectionSource {
+                area: Rect::new(0, 2, 5, 2),
+                text: "helloworld".to_string(),
+            },
+        ];
+
+        assert_eq!(
+            selected_text_from_sources(&buffer, buffer.area, selection, &sources),
+            "helloworld",
+        );
+    }
+
+    #[test]
+    fn copy_falls_back_to_visual_rows_without_source_metadata() {
+        let buffer = buffer_with_rows(&["hello", "world"]);
+        let selection = SelectionRange::between((0, 0), (4, 1));
+
+        assert_eq!(
+            selected_text(&buffer, buffer.area, selection),
+            "hello\nworld"
+        );
     }
 
     #[test]

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -72,12 +72,13 @@ use super::{
     FrameGraphics, FrameGraphicsCleanup, PaintRoot, RESIZE_FRAME_INTERVAL, RunnerAction,
     RunnerCore, RunnerSelection, Signal,
 };
+use crate::host::paint_with_context_and_sources;
 use crate::live::RedrawHandle;
 use crate::screen::{Scrollback, close_footer, pin_footer};
-use crate::view::ScopedElement;
+use crate::view::{ScopedElement, SelectionSources};
 use crate::{
     Element, Event, RenderCtx, RunnerConfig, SystemClock, TerminalSession, Theme, UpdateResult,
-    paint_with_context, translate_event,
+    translate_event,
 };
 
 /// The signal type an [`AsyncRunner`] delivers when it also listens to a typed
@@ -742,13 +743,26 @@ where
     S: AsyncFrameSource<M>,
 {
     let mut copied = None;
+    let sources = SelectionSources::default();
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
         frames.frame(frame, &mut |root| {
-            paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root, &[]);
+            paint_with_context_and_sources(
+                terminal_frame.buffer_mut(),
+                area,
+                &ctx,
+                root,
+                &[],
+                &sources,
+            );
         });
-        copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);
+        copied = selection.finish_frame(
+            terminal_frame.buffer_mut(),
+            area,
+            theme,
+            &sources.snapshot(),
+        );
     })?;
     Ok(copied)
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -98,14 +98,16 @@ use ratatui_core::layout::Rect;
 use ratatui_core::terminal::{Terminal, TerminalOptions};
 use ratatui_crossterm::CrosstermBackend;
 
+use crate::host::paint_with_context_and_sources;
 use crate::live::RedrawHandle;
-use crate::mouse::{SelectionState, paint_selection, selected_text};
+use crate::mouse::{SelectionState, paint_selection, selected_text_from_sources};
 use crate::screen::{ScreenMode, Scrollback, close_footer, pin_footer};
 use crate::term::clipboard;
 use crate::term::image::{ImageLayer, ImageSupport};
+use crate::view::SelectionSources;
 use crate::{
     Clock, Element, Event, RenderCtx, ScopedElement, SystemClock, TerminalSession, Theme, View,
-    paint_with_context, translate_event,
+    translate_event,
 };
 
 /// Receives a frame's root view for painting.
@@ -908,13 +910,26 @@ where
     F: FrameSource,
 {
     let mut copied = None;
+    let sources = SelectionSources::default();
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
         frames.frame(frame, &mut |root| {
-            paint_with_context(terminal_frame.buffer_mut(), area, &ctx, root, &[]);
+            paint_with_context_and_sources(
+                terminal_frame.buffer_mut(),
+                area,
+                &ctx,
+                root,
+                &[],
+                &sources,
+            );
         });
-        copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme);
+        copied = selection.finish_frame(
+            terminal_frame.buffer_mut(),
+            area,
+            theme,
+            &sources.snapshot(),
+        );
     })?;
     Ok(copied)
 }
@@ -982,7 +997,13 @@ impl RunnerSelection {
         changed
     }
 
-    fn finish_frame(&mut self, buffer: &mut Buffer, area: Rect, theme: &Theme) -> Option<String> {
+    fn finish_frame(
+        &mut self,
+        buffer: &mut Buffer,
+        area: Rect,
+        theme: &Theme,
+        sources: &[crate::view::SelectionSource],
+    ) -> Option<String> {
         if !self.enabled {
             return None;
         }
@@ -995,7 +1016,7 @@ impl RunnerSelection {
         };
         let copied = self
             .pending_copy
-            .then(|| selected_text(buffer, area, range));
+            .then(|| selected_text_from_sources(buffer, area, range, sources));
         self.pending_copy = false;
         paint_selection(buffer, area, range, theme.selection_style());
         copied
@@ -1101,7 +1122,7 @@ mod tests {
         assert!(selection.handle_event(&Event::Mouse(drag), UpdateResult::Clean, &clock));
         assert!(selection.handle_event(&Event::Mouse(up), UpdateResult::Clean, &clock));
 
-        let copied = selection.finish_frame(&mut buffer, area, &Theme::default());
+        let copied = selection.finish_frame(&mut buffer, area, &Theme::default(), &[]);
         assert_eq!(copied.as_deref(), Some("hello"));
         for column in 0..=4 {
             assert_eq!(buffer[(column, 0)].bg, Theme::default().selection_bg);

--- a/src/view.rs
+++ b/src/view.rs
@@ -10,6 +10,8 @@
 //! `View` for its render, and, if interactive, a small state struct with an
 //! event handler. No trait-object tree to reconcile.
 
+use std::cell::RefCell;
+
 use ratatui_core::layout::Rect;
 
 use super::geometry::Size;
@@ -127,7 +129,32 @@ fn resolve_axis(known: Option<u16>, available: AvailableSpace, measured: u16) ->
 use super::surface::Surface;
 use crate::term::image::{ImageLayer, ImageSupport};
 
+/// Original text rendered in a frame, used to preserve source line breaks when copying.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SelectionSource {
+    pub(crate) area: Rect,
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SelectionSources(RefCell<Vec<SelectionSource>>);
+
+impl SelectionSources {
+    pub(crate) fn clear(&self) {
+        self.0.borrow_mut().clear();
+    }
+
+    pub(crate) fn push(&self, area: Rect, text: String) {
+        self.0.borrow_mut().push(SelectionSource { area, text });
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<SelectionSource> {
+        self.0.borrow().clone()
+    }
+}
+
 /// Context threaded to every [`View::measure`] and [`View::render`] call.
+#[derive(Clone)]
 pub struct RenderCtx<'a> {
     /// The active theme supplying colors for this frame.
     pub theme: &'a Theme,
@@ -142,6 +169,7 @@ pub struct RenderCtx<'a> {
     style_resolver: Option<&'a dyn StyleResolver>,
     /// Graphics protocol and per-frame placement collector supplied by a host.
     image_graphics: Option<(ImageSupport, &'a ImageLayer)>,
+    selection_sources: Option<&'a SelectionSources>,
     /// Whether the focused component of the frame is this one. Containers pass
     /// this down unchanged; focus-aware leaves use it to highlight borders.
     pub focused: bool,
@@ -155,6 +183,7 @@ impl<'a> RenderCtx<'a> {
             sheet: StyleSheet::from_theme(theme),
             style_resolver: None,
             image_graphics: None,
+            selection_sources: None,
             focused: false,
         }
     }
@@ -180,6 +209,17 @@ impl<'a> RenderCtx<'a> {
     pub fn with_image_graphics(mut self, support: ImageSupport, layer: &'a ImageLayer) -> Self {
         self.image_graphics = Some((support, layer));
         self
+    }
+
+    pub(crate) fn with_selection_sources(mut self, sources: &'a SelectionSources) -> Self {
+        self.selection_sources = Some(sources);
+        self
+    }
+
+    pub(crate) fn record_selection_source(&self, area: Rect, source: String) {
+        if let Some(sources) = self.selection_sources {
+            sources.push(area, source);
+        }
     }
 
     /// Graphics protocol and placement layer supplied by the current host.
@@ -212,6 +252,7 @@ impl<'a> RenderCtx<'a> {
             sheet: self.sheet,
             style_resolver: self.style_resolver,
             image_graphics: self.image_graphics,
+            selection_sources: self.selection_sources,
             focused,
         }
     }


### PR DESCRIPTION
## Summary

- preserve original source text for Tuika `Text` regions during rendering
- omit visual soft-wrap boundaries from default runner selection copies
- preserve explicit source newlines and retain visual-row fallback for custom views
- cover Unicode, clipped selections, repeated regions, and fallback behavior

## Validation

- `cargo test --lib` — 647 passed
- `git diff --check`

## Risk

Low. The source-aware path applies only when a selection is fully inside a built-in text region; other views keep the existing buffer-row behavior.

Produced by [yolop](https://everruns.com/yolop)
