### PR TITLE
docs: replace seam terminology

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -68,7 +68,7 @@ Actions:
 - confirm `ratatui` is still only a **dev**-dependency; under `[dependencies]` it
   means the umbrella crept back in
 - treat a `ratatui-core` major bump as an interoperability event, not a routine
-  upgrade: it changes the `Buffer` type on the public seam, so hosts must move in
+  upgrade: it changes the `Buffer` type on the public boundary, so hosts must move in
   lockstep. It is a breaking release for tuika
 - check `pulldown-cmark`, `textwrap`, `unicode-*` minors; verify
   `pulldown-cmark` still builds with default features off
@@ -146,7 +146,7 @@ On a deep pass, also scan for and collapse over-abstraction:
 
 - **Single-use abstractions** — traits with one impl, a wrapper type that only
   forwards, a generic with one instantiation, a builder for a two-field struct.
-  Inline them unless the seam is load-bearing (a real second impl, a public
+  Inline them unless the boundary is load-bearing (a real second impl, a public
   extension point, a test double that earns its keep).
 - **Premature generalization** — code shaped for hypothetical futures instead of
   current needs. Delete the unused flexibility; the git history keeps it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ tuika's own suite covers more:
 - `docs/layout.md` — the public layout guide: wrapping, flex-item sizing,
   Flow/Grid selection, measurement requests, and migration notes.
 - `docs/markdown.md` — the markdown guide: streaming, GFM tables, the
-  highlighter seam, link policy, and images in one page. It reuses the gallery's
+  highlighter boundary, link policy, and images in one page. It reuses the gallery's
   `DEMOS` recordings, so it is inside the `demo -- check` reference invariant.
 - `docs/demos/*.{gif,png}` — the committed demo recordings referenced by the
   component family pages and, via `raw.githubusercontent.com` URLs, inline on the
@@ -177,7 +177,7 @@ tuika's own suite covers more:
   fork under `target/` with its Ghostty renderer and requires Go 1.26,
   pkg-config, and Zig 0.15.2 in addition to VHS's normal dependencies.
 
-  `tuika-html` has two, one per example — the markdown seam
+  `tuika-html` has two, one per example — the markdown boundary
   (`examples/html_markdown/html.png`) and the standalone `Html` component
   (`examples/html_view/html_view.png`) — both regenerated with
   `scripts/gen-html-demo.sh`. It is a *screenshot* rather than a GIF because the
@@ -537,4 +537,4 @@ tuika was extracted from [yolop](https://github.com/everruns/yolop), whose
 full-screen renderer is built on it, and yolop remains its largest consumer — but
 it depends on tuika from crates.io like any other host and gets no special
 treatment. A change that only makes sense for one host does not belong here;
-give the host a seam (a trait, a state type, a callback) instead.
+give the host a boundary (a trait, a state type, a callback) instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ let several panes in one screen share focus and the mouse.
 
 ![tree list demo](https://raw.githubusercontent.com/everruns/tuika/v0.9.0/docs/demos/tree_list.gif)
 
-- **Runner**: one `FrameSource` seam and one `Signal` replace ten `run*` methods
+- **Runner**: one `FrameSource` boundary and one `Signal` replace ten `run*` methods
   across the two runtimes; the synchronous loop is now drivable from a
   caller-owned terminal, so a whole application can be tested with no tty.
 
@@ -115,7 +115,7 @@ let several panes in one screen share focus and the mouse.
   loop could not be exercised at all, and only its pieces (`RunnerCore`, the
   clock, selection) had coverage. Seven end-to-end tests now cover the initial
   frame, event-driven state, clean updates neither rebuilding nor repainting,
-  the borrowed application seam, redraw requests, deferred resize repaints, and
+  the borrowed application boundary, redraw requests, deferred resize repaints, and
   split-footer publishing.
 - `SelectViewportState` couples index selection to a persistent top row for
   `SelectList` and `Table`. Its resolved `VirtualWindow` is shared with mouse
@@ -130,11 +130,11 @@ let several panes in one screen share focus and the mouse.
 - `AsyncRunner::run_with_messages` delivers a typed application stream beside
   terminal events and ticks, with deterministic completion/error/redraw/exit
   behavior and no shared mutable state or polling.
-- `AsyncApplication` is the borrowed-view application seam for the async runner,
+- `AsyncApplication` is the borrowed-view application boundary for the async runner,
   the counterpart to `Application`: previously a frame could borrow application
   state only on the synchronous runner, so a Tokio host had to clone into an
   owned tree or share through `Rc<RefCell<_>>`.
-- `FrameSource` / `AsyncFrameSource` is the single seam every run method now
+- `FrameSource` / `AsyncFrameSource` is the single boundary every run method now
   takes, with exactly two implementors: `&mut app` for an `Application`, and
   `from_fn(&mut state, view, update)` (`async_from_fn` for the async runner) for
   the closure form. `no_messages()` is the empty application-message stream.
@@ -185,7 +185,7 @@ let several panes in one screen share focus and the mouse.
 
 ### Changed
 
-**Breaking: the runner's `run*` surface is one seam plus two axes.** The methods
+**Breaking: the runner's `run*` surface is one boundary plus two axes.** The methods
 were a cross product of frame source, runtime, terminal ownership, and extra
 input, encoded as names — ten of them on `AsyncRunner` — with arbitrary holes in
 the product. The frame source is now a `FrameSource` argument rather than a
@@ -299,7 +299,7 @@ filtering, and streaming updates.
 ## [0.7.0] - 2026-07-31
 
 Released alongside `tuika-html` 0.1.0, the new companion crate behind the
-block-HTML seam, plus `tuika-codeformatters` 0.4.0 and `tuika-mermaid` 0.2.0.
+block-HTML boundary, plus `tuika-codeformatters` 0.4.0 and `tuika-mermaid` 0.2.0.
 The existing companions adopt tuika 0.7's breaking view-measurement API and
 update their tuika dependency requirement in the same release.
 
@@ -312,7 +312,7 @@ coherent framework for complex terminal applications without retained UI state.
 ![primitives demo](https://raw.githubusercontent.com/everruns/tuika/v0.7.0/docs/demos/primitives.gif)
 
 **Rich HTML in Markdown.** Presentational inline HTML now shares Markdown's
-styles, while the new parser-free `HtmlBlockRenderer` seam lets `tuika-html`
+styles, while the new parser-free `HtmlBlockRenderer` boundary lets `tuika-html`
 render styled block HTML without adding a parser to tuika core.
 
 ![markdown HTML demo](https://raw.githubusercontent.com/everruns/tuika/v0.7.0/docs/demos/markdown_html.png)
@@ -334,7 +334,7 @@ render styled block HTML without adding a parser to tuika core.
 - `render_once` / `write_once` for ANSI-styled ordinary output, and `view!`
   `when(...)` / `for(... in ...)` composition.
 
-- `Clock` and `SystemClock` provide one monotonic time seam.
+- `Clock` and `SystemClock` provide one monotonic time boundary.
   `SelectionState::handle_with_clock` makes double-click gestures deterministic,
   and `Runner::with_clock` lets replayable synchronous hosts own tick time;
   existing `handle` and `Runner::new` behavior remains system-clock backed.
@@ -353,7 +353,7 @@ render styled block HTML without adding a parser to tuika core.
   `OverlaySpec::resolve_target` resolves it directly and
   `SceneOverlay::target` follows a `RectProbe` from the scene root in the same
   frame. Screen-anchored placement remains unchanged.
-- `StyleRole` and `StyleResolver` form an open semantic styling seam for hosts
+- `StyleRole` and `StyleResolver` form an open semantic styling boundary for hosts
   and companion crates. `RenderCtx::style` resolves built-in or namespaced
   application roles, resolver bundles partially overlay stylesheet defaults,
   and resolver revisions invalidate measurement caches. `paint_with_context`
@@ -371,7 +371,7 @@ render styled block HTML without adding a parser to tuika core.
   parser: this is a fixed tag whitelist, so anything outside it — block-level
   HTML, `<script>`, unlisted attributes — is dropped as before, and never echoed
   as literal markup.
-- **One structured markdown block seam.** `MarkdownBlockRenderer` receives a
+- **One structured markdown block boundary.** `MarkdownBlockRenderer` receives a
   non-exhaustive `MarkdownBlock` descriptor (`Fenced` or `Html`) and a shared
   `MarkdownBlockContext` containing width, theme, and the active stylesheet.
   `Markdown::block_renderer` and `MarkdownState::with_block_renderer` append to
@@ -484,7 +484,7 @@ render styled block HTML without adding a parser to tuika core.
   from the component gallery, the markdown guide, and `Markdown`'s rustdoc.
 - `tuika-html` gains an example and a recording for the `Html` *component*
   (`cargo run -p tuika-html --example html_view`); the existing example covers
-  the markdown seam. `<sub>`/`<sup>` now transliterate there too, so one
+  the markdown boundary. `<sub>`/`<sup>` now transliterate there too, so one
   document cannot render `H₂O` through markdown and `H2O` through the crate,
   and `<dd>` hangs directly under its `<dt>` instead of a blank line below.
 - `Table` now windows rows to its assigned render height by default.
@@ -571,7 +571,7 @@ preference:
 
 | Path | Holds |
 | --- | --- |
-| `tuika::` | the framework spine — `View`, `Element`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
+| `tuika::` | the framework spine — `View`, `Element`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host boundary |
 | `tuika::components` | every widget |
 | `tuika::term` | everything out-of-band: `clipboard`, `hyperlink`, `progress`, `pointer`, `image`, `capabilities`, `palette` |
 | `tuika::prelude` | the spine and the components in one glob import |
@@ -635,7 +635,7 @@ without tuika taking on a diagram engine.
 
 ![mermaid demo](https://raw.githubusercontent.com/everruns/tuika/v0.5.0/crates/tuika-mermaid/examples/mermaid_markdown/mermaid.gif)
 
-- **New**: `components::markdown::FencedBlockRenderer` — the seam, plus
+- **New**: `components::markdown::FencedBlockRenderer` — the boundary, plus
   `Markdown::block_renderer`, `MarkdownState::with_block_renderer`, and
   `markdown::{to_lines_with_renderer, to_linked_lines_with_renderer}`.
 - **New crate**: [`tuika-mermaid`](https://crates.io/crates/tuika-mermaid) —
@@ -644,7 +644,7 @@ without tuika taking on a diagram engine.
 
 **Long transcripts scroll by item, not by line.** `ItemScroll` scrolls a list of
 laid-out elements — the shape a chat log or an agent transcript actually has —
-and the text input grew the seams a composer needs.
+and the text input grew the boundaries a composer needs.
 
 - **New**: `components::ItemScroll` — item-granular scrolling with `windowed`
   construction, `gap`, `scrollbar`, and `measure_height`.
@@ -678,7 +678,7 @@ carry.
   in the module list.
   - Before: `tuika::async_runner::{AsyncRunner, Signal}`
   - After: `tuika::runner::{Runner, RunnerConfig, AsyncRunner, Signal}`
-- **Ratatui interop is named for the seam, not for its only type.**
+- **Ratatui interop is named for the boundary, not for its only type.**
   - Before: `tuika::ratatui_view::RatatuiView`
   - After: `tuika::interop::RatatuiView`
 
@@ -688,7 +688,7 @@ carry.
   - Before: `osc52`, `write_clipboard`, `osc8`, `osc8_with`, `encode_pointer_shape`, `write_pointer_shape`
   - After: `term::clipboard::{encode, write}`, `term::hyperlink::{encode, encode_with}`, `term::pointer::{encode, write}`
 - **`tuika::highlight` was a module and a function at once.** The module is the
-  `Highlighter` seam; the function paints a selection.
+  `Highlighter` boundary; the function paints a selection.
   - Before: `tuika::highlight(buffer, area, range, style)`
   - After: `tuika::mouse::paint_selection(buffer, area, range, style)`
 - **Hand-prefixed names get their module back.** The prefixes existed only to
@@ -767,7 +767,7 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 * test: pin the public module layout from outside the crate (`tests/public_api.rs`)
 * docs: add `knowledge/specs/api-surface.md` and a crate-layout section to the README
 * chore(knowledge): split out process concepts and enforce upkeep (#5)
-* feat(components): add `ItemScroll` and the composer token seams, plus the `codex` example
+* feat(components): add `ItemScroll` and the composer token boundaries, plus the `codex` example
 * docs: record the showcases at gallery pixel density and point yolop at its product page
 * fix(docs): stop the demo recordings clipping their own scenes
 * docs: add a showcases page with yolop and LLMSim demos (#3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ scrolling-regions = [
 # — and with them the `time`/`lru`/`line-clipping` transitive weight — from
 # tuika's build. Downstream users keep every ratatui widget: they bring their own
 # `ratatui` and render it through `Surface::render_ratatui`/`RatatuiView`, whose
-# seam is a raw `&mut Buffer` from this same `ratatui-core` (Cargo unifies the
+# boundary is a raw `&mut Buffer` from this same `ratatui-core` (Cargo unifies the
 # version). `underline-color` matches the umbrella default so cell rendering is
 # byte-identical; `std` is required for the terminal I/O loop.
 ratatui-core = { version = "0.1", features = ["std", "underline-color"] }
@@ -159,7 +159,7 @@ vt100 = "0.16"
 # corpora and paint into a `Buffer` directly, and the doc examples demonstrate
 # wrapping real ratatui *widgets* through `RatatuiView`/`Surface::render_ratatui`.
 # Its `ratatui-core` matches the version the library depends on, so the `Buffer`
-# type is shared across the interop seam.
+# type is shared across the interop boundary.
 ratatui = "0.30.2"
 # Benchmark harness. default-features off drops the plotters/rayon HTML-report
 # stack (heavy, and an MSRV liability) while keeping `cargo bench` working;

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Four places, so you can guess where something is:
 
 | Path | Holds |
 | --- | --- |
-| `tuika::` | the framework spine — `View`, `view_fn`, `Element`, `ScopedElement`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host seam |
+| `tuika::` | the framework spine — `View`, `view_fn`, `Element`, `ScopedElement`, `RenderCtx`, layout, events, `Theme`, `Surface`, the host boundary |
 | `tuika::components` | every widget: `Flex`, `Boxed`, `Text`, `Scroll`, `Markdown`, `Table`, … |
 | `tuika::term` | everything out-of-band: `clipboard` (OSC 52), `hyperlink` (OSC 8), `progress` (OSC 9;4), `pointer` (OSC 22), `image`, `capabilities`, `palette` (the terminal's own colors) |
 | `tuika::prelude` | the spine and the components in one glob import |
@@ -442,7 +442,7 @@ before the last stable block boundary, so long transcripts don't re-tokenize and
 settled code blocks aren't re-highlighted every frame. Its `links()` metadata
 keeps OSC 8 targets aligned with the cached lines through streaming and resize.
 
-Highlighting is a seam, not a dependency: `tuika` owns the *presentation* of code
+Highlighting is a boundary, not a dependency: `tuika` owns the *presentation* of code
 (framing, background, language label, wrapping) via `CodeBlock`, and takes token
 colors from any `Highlighter` you supply — keeping the toolkit free of grammar
 crates. The companion crate
@@ -451,7 +451,7 @@ ready-made tree-sitter `Highlighter`.
 
 Structured blocks can replace their source with a different, width-aware
 presentation through `MarkdownBlockRenderer`. The
-[`tuika-mermaid`](crates/tuika-mermaid/) companion uses that seam with mmdflux:
+[`tuika-mermaid`](crates/tuika-mermaid/) companion uses that boundary with mmdflux:
 a `mermaid` fence becomes a Unicode cell diagram inside the surrounding
 Markdown, with no browser, SVG, or image protocol. Unsupported or invalid input
 falls back to the ordinary code block.
@@ -479,7 +479,7 @@ Images use the same host-extension pattern: supply an `ImageResolver` and
 Markdown in the wild carries HTML. The presentational inline tags — `<b>`,
 `<em>`, `<code>`, `<kbd>`, `<mark>`, `<a>`, `<br>`, `<sub>`/`<sup>` — render in
 tuika itself, each through the same `StyleSheet` role as the markdown it
-mirrors. Block-level HTML is a seam, for the same reason highlighting is: an
+mirrors. Block-level HTML is a boundary, for the same reason highlighting is: an
 HTML parser is a dependency tuika will not carry. Attach a
 `MarkdownBlockRenderer` and `<details>`, `<table>`, and `<div>` lay out too. The
 same ordered renderer chain handles fenced diagrams and block HTML with one
@@ -761,7 +761,7 @@ closure form over an owned `Element` tree. The
 that directly borrows a `String` from its application.
 
 `Runner::with_clock` replaces the default `SystemClock` when a replayable host
-or deterministic test owns monotonic time. The same `Clock` seam drives
+or deterministic test owns monotonic time. The same `Clock` boundary drives
 `SelectionState::handle_with_clock`, so double-click timing never has to depend
 on wall-clock sleeps. Frame animation, keymap timeouts, and toast expiry remain
 explicitly host-driven and therefore need no internal clock.
@@ -779,7 +779,7 @@ network or disk I/O — and lets its update closure `.await`. It ties
 single event loop. Its update closure returns the same
 `UpdateResult::{Clean, Consumed, Dirty, Exit}` as `Runner`, so awaited work only
 rebuilds and repaints when it actually changes visible state. `AsyncApplication`
-is its `Application` twin — the same borrowed-view seam, with an awaiting
+is its `Application` twin — the same borrowed-view boundary, with an awaiting
 `update` — and `&mut app` is a `FrameSource` for it just as it is for `Runner`.
 
 `run_with_messages` adds a typed host stream beside terminal events and ticks.
@@ -831,7 +831,7 @@ none show the alt text, so the same view tree renders everywhere.
 <img src="https://raw.githubusercontent.com/everruns/tuika/v0.9.0/docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
 
 Decoding stays in the host — a heavy dependency, kept out like the highlighter
-seam — so you hand in raw RGBA via `ImageData::from_rgba` and `tuika` owns the
+boundary — so you hand in raw RGBA via `ImageData::from_rgba` and `tuika` owns the
 protocol encoding (base64, PNG, and Sixel encoders are inline, so no image-codec
 dependency). `Runner` detects the terminal protocol, collects placements, and
 emits pixels after each cell frame.
@@ -851,7 +851,7 @@ emit and clear the layer after flushing the cell frame.
 
 Markdown `![alt](url)` renders too, in both the one-shot `Markdown` view and the
 streaming `MarkdownState`: attach a host `ImageResolver` (URL → `ImageData`, the
-same seam as the highlighter) and resolved images become real pixels — a
+same boundary as the highlighter) and resolved images become real pixels — a
 link-styled placeholder for the rest, never a dropped URL.
 
 To check support across every terminal feature in one place — `graphics`,
@@ -972,7 +972,7 @@ something on tuika? Open a PR adding it here.
   `ratatui` dependency, not by tuika) and compose through
   [`Surface::render_ratatui`](https://docs.rs/tuika/latest/tuika/surface/struct.Surface.html#method.render_ratatui)
   and [`RatatuiView`](https://docs.rs/tuika/latest/tuika/interop/struct.RatatuiView.html),
-  whose seam is a raw `ratatui-core` `Buffer`.
+  whose boundary is a raw `ratatui-core` `Buffer`.
 
 ## Extending
 
@@ -1006,7 +1006,7 @@ The separately published companion crates live in this repository:
 - [`tuika-mermaid`](crates/tuika-mermaid/) renders Mermaid fences as Unicode
   terminal diagrams through mmdflux.
 - [`tuika-html`](crates/tuika-html/) lays out block-level HTML with html5ever —
-  inside Markdown through the `MarkdownBlockRenderer` seam, or standalone
+  inside Markdown through the `MarkdownBlockRenderer` boundary, or standalone
   through its own [`Html`](https://github.com/everruns/tuika/blob/v0.9.0/docs/components/markdown-code.md#html) component.
 
 All four keep specialized rendering and heavier parsers or grammars out of

--- a/crates/tuika-html/Cargo.toml
+++ b/crates/tuika-html/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "Terminal-native HTML rendering for tuika: a Markdown block seam and a standalone Html view."
+description = "Terminal-native HTML rendering for tuika: a Markdown block boundary and a standalone Html view."
 homepage.workspace = true
 repository.workspace = true
 # The README embeds `examples/html_markdown/html.png` by *relative* path, so the
@@ -19,7 +19,7 @@ categories = ["command-line-interface", "text-processing"]
 
 [dependencies]
 # This requirement tracks the *published* tuika, so it stays at the in-tree
-# version and is bumped by the release that carries the seam this crate
+# version and is bumped by the release that carries the boundary this crate
 # implements — `MarkdownBlockRenderer` does not exist before 0.7.0, so
 # tuika-html cannot be published until then. `publish_order.py` publishes tuika
 # first, and

--- a/crates/tuika-html/README.md
+++ b/crates/tuika-html/README.md
@@ -9,7 +9,7 @@ crate exists separately.
 
 ## In Markdown
 
-`HtmlRenderer` implements tuika's `MarkdownBlockRenderer` seam. One value
+`HtmlRenderer` implements tuika's `MarkdownBlockRenderer` boundary. One value
 handles raw `<details>` / `<table>` / `<div>` blocks and ` ```html ` fences,
 using the same active stylesheet for both.
 
@@ -24,7 +24,7 @@ let document = Markdown::new("<details><summary>Notes</summary>Body</details>")
 ```
 
 Below, the `<details>`, the `<ul>` inside it, and the `<table>` are all raw HTML
-in a markdown document — laid out by the seam, beside markdown the renderer
+in a markdown document — laid out by the boundary, beside markdown the renderer
 never sees:
 
 <img src="examples/html_markdown/html.png" width="880" alt="HTML blocks rendered inside tuika Markdown: a details summary with a bullet list, a box-drawn table, and a quoted line with Unicode subscript and superscript">

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -1,4 +1,4 @@
-//! Markdown with raw HTML blocks in it, rendered through the seam.
+//! Markdown with raw HTML blocks in it, rendered through the boundary.
 //!
 //! ```bash
 //! cargo run -p tuika-html --example html_markdown # a real terminal (q quits)

--- a/crates/tuika-html/examples/html_view/main.rs
+++ b/crates/tuika-html/examples/html_view/main.rs
@@ -4,7 +4,7 @@
 //! cargo run -p tuika-html --example html_view # a real terminal (q quits)
 //! ```
 //!
-//! The companion example, `html_markdown`, shows the *seam* — HTML blocks
+//! The companion example, `html_markdown`, shows the *boundary* — HTML blocks
 //! inside a markdown document. This one shows the **component**: no markdown
 //! anywhere, `Html` placed in a layout exactly like `Markdown` would be, fitting
 //! its content to whatever width the pane gives it.

--- a/crates/tuika-html/src/lib.rs
+++ b/crates/tuika-html/src/lib.rs
@@ -3,7 +3,7 @@
 //! Two ways in, one engine behind both:
 //!
 //! - [`HtmlRenderer`] plugs into markdown through tuika's
-//!   [`MarkdownBlockRenderer`] seam. One implementation handles raw `<details>`,
+//!   [`MarkdownBlockRenderer`] boundary. One implementation handles raw `<details>`,
 //!   `<table>`, and `<div>` blocks as well as ` ```html ` fences.
 //! - [`Html`] is a `View`, the standalone viewer: hand it a fragment, place it
 //!   in a layout, and it paints like [`Markdown`](tuika::components::Markdown)
@@ -99,7 +99,7 @@ impl Default for Limits {
     }
 }
 
-/// Renders HTML for tuika's structured markdown block seam.
+/// Renders HTML for tuika's structured markdown block boundary.
 ///
 /// One value serves both raw block HTML and ` ```html ` fences. Attach it with
 /// [`Markdown::block_renderer`](tuika::components::Markdown::block_renderer).

--- a/crates/tuika-mermaid/README.md
+++ b/crates/tuika-mermaid/README.md
@@ -3,7 +3,7 @@
 Terminal-native Mermaid diagrams inside
 [`tuika`](https://crates.io/crates/tuika) Markdown. The crate adapts
 [`mmdflux`](https://crates.io/crates/mmdflux) to tuika's generic
-`MarkdownBlockRenderer` seam; diagrams are Unicode cells, not images, and
+`MarkdownBlockRenderer` boundary; diagrams are Unicode cells, not images, and
 require no browser or JavaScript runtime.
 
 ```rust

--- a/crates/tuika-mermaid/src/lib.rs
+++ b/crates/tuika-mermaid/src/lib.rs
@@ -2,7 +2,7 @@
 //! [`tuika::components::Markdown`].
 //!
 //! [`MermaidRenderer`] adapts mmdflux's Unicode text output to tuika's generic
-//! [`MarkdownBlockRenderer`] seam. It
+//! [`MarkdownBlockRenderer`] boundary. It
 //! handles `mermaid` fences and returns `None` for every other language or for
 //! Mermaid input mmdflux cannot render, preserving tuika's ordinary code-block
 //! fallback.

--- a/docs/components/markdown-code.md
+++ b/docs/components/markdown-code.md
@@ -23,7 +23,7 @@ highlighting, links, and images.
 
 The presentational inline HTML tags render too — `<b>`, `<em>`, `<code>`,
 `<kbd>`, `<mark>`, `<a>`, `<br>`, `<sub>`/`<sup>` — each resolving the same
-`StyleSheet` role as the markdown it mirrors. Block-level HTML is a seam; see
+`StyleSheet` role as the markdown it mirrors. Block-level HTML is a boundary; see
 [Inline HTML](../markdown.md#inline-html).
 
 <img src="../demos/markdown_html.png" width="880" alt="Inline HTML in markdown: strong, emphasis, struck and underlined text, a highlighted run, keyboard keys, a link, Unicode subscript and superscript, and a line broken by a br tag">

--- a/docs/features.md
+++ b/docs/features.md
@@ -421,7 +421,7 @@ let _image = Image::new(data, 20, 10)      // 20×10 cells on screen
     .alt("a 2×2 swatch");                  // shown where graphics aren't supported
 ```
 
-Custom hosts keep the explicit seam: install `ImageSupport` and an `ImageLayer`
+Custom hosts keep the explicit boundary: install `ImageSupport` and an `ImageLayer`
 with `RenderCtx::with_image_graphics`, call `paint_with_context`, then emit and
 clear the layer after flushing the cell frame.
 
@@ -455,7 +455,7 @@ on a Sixel terminal usually sets `ImageSupport::Sixel` explicitly. See the
 Markdown `![alt](url)` renders too, in both the one-shot `Markdown` view and the
 streaming `MarkdownState`. A host `ImageResolver` decodes each URL to `ImageData`
 (markdown carries only the URL, never pixels, exactly like the code `Highlighter`
-seam); a resolved image reserves a block and is painted with the same `Image`
+boundary); a resolved image reserves a block and is painted with the same `Image`
 machinery — real pixels where supported, alt text otherwise. The view's
 `.images(resolver, support, layer)` overlays them for you; a host driving
 `MarkdownState::lines` reads `MarkdownState::images()` and paints each

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -114,10 +114,10 @@ digits and `+ - = ( )`. `4<sup>th</sup>` renders `4th` rather than half-shifted.
 
 ## Block HTML
 
-`<div>`, `<details>`, `<table>` — block-level HTML is a *seam* rather than a
+`<div>`, `<details>`, `<table>` — block-level HTML is a *boundary* rather than a
 feature, for the same reason syntax highlighting is: an HTML parser is a
 dependency tuika will not carry. Without a renderer attached the block is
-dropped, exactly as before the seam existed, so adding one is purely additive.
+dropped, exactly as before the boundary existed, so adding one is purely additive.
 
 <img src="../crates/tuika-html/examples/html_markdown/html.png" width="880" alt="HTML blocks rendered inside tuika Markdown: a details summary with a bullet list, a box-drawn table, and a quoted line with Unicode subscript and superscript">
 
@@ -140,7 +140,7 @@ A streaming host attaches it once with
 `MarkdownState::with_block_renderer(Box::new(HtmlRenderer::new()))`; a settled
 block is then laid out once per width, like a fenced block.
 
-Implementing the seam yourself means `MarkdownBlockRenderer`: it receives a
+Implementing the boundary yourself means `MarkdownBlockRenderer`: it receives a
 structured `MarkdownBlock` (`Fenced` or `Html`) and one `MarkdownBlockContext`
 with the available width, theme, and active `StyleSheet`. Returning `None`
 passes the block to the next registered renderer; if none handle it, a fence
@@ -334,7 +334,7 @@ opts `mailto:` back in where a host wants it.
 ## Images
 
 `![alt](url)` renders as a real image where the terminal has a graphics protocol.
-Markdown carries only the URL, so — exactly like the highlighter seam — the host
+Markdown carries only the URL, so — exactly like the highlighter boundary — the host
 supplies the decode through an `ImageResolver`; a resolved image reserves a block
 in the layout, an unresolved one stays an inline, link-styled placeholder rather
 than dropping the URL.

--- a/examples/codex/agent.rs
+++ b/examples/codex/agent.rs
@@ -456,7 +456,7 @@ fn explain_script() -> Vec<Step> {
              };\n\
              ```\n\n\
              Nothing in it knows about the application embedding it — highlighting, image \
-             decoding, and data fetching are all seams the host fills.\n",
+             decoding, and data fetching are all boundaries the host fills.\n",
         ),
     ]
 }

--- a/examples/codex/main.rs
+++ b/examples/codex/main.rs
@@ -10,7 +10,7 @@
 //! `Working (12s • Esc to interrupt)` row, and a context meter in the footer —
 //! because that shape is the hardest thing to assemble from single components,
 //! and building it is what surfaced the gaps `ItemScroll` and the composer
-//! token seams now fill.
+//! token boundaries now fill.
 //!
 //! Everything behind the interface is fake: `agent.rs` replays a scripted turn
 //! chosen from the prompt's keywords, revealing it frame by frame, so there is

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -39,7 +39,7 @@ use demo_scenes::*;
 ///
 /// The examples deliberately avoid a grammar dependency (that would drag
 /// tree-sitter into tuika's dev/MSRV builds); this shows how little it takes to
-/// satisfy the [`Highlighter`] seam. For production-grade highlighting across
+/// satisfy the [`Highlighter`] boundary. For production-grade highlighting across
 /// many languages, use the `tuika-codeformatters` crate.
 struct DemoHighlighter;
 

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -42,7 +42,7 @@ use tuika::prelude::*;
 use tuika::term::hyperlink::{HyperlinkBackend, LinkPolicy, apply_buffer_links};
 
 /// A tiny self-contained Rust highlighter — enough to satisfy the
-/// [`Highlighter`] seam without a grammar dependency. Real hosts use the
+/// [`Highlighter`] boundary without a grammar dependency. Real hosts use the
 /// `tuika-codeformatters` crate (tree-sitter, many languages).
 struct DemoHighlighter;
 

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -534,7 +534,7 @@ fn block_of(sym: &str) -> Option<Block> {
 /// Emit one cell's background rect (if any) and glyph (if visible) into `out`.
 fn emit_cell(out: &mut String, p: &Paint, cx: f32, cy: f32) {
     if let Some(bg) = &p.bg {
-        // Slight overdraw removes hairline seams between adjacent filled cells.
+        // Slight overdraw removes hairline gaps between adjacent filled cells.
         out.push_str(&format!(
             "<rect x=\"{cx:.2}\" y=\"{cy:.2}\" width=\"{w:.2}\" height=\"{h:.2}\" fill=\"{bg}\" shape-rendering=\"crispEdges\"/>",
             w = CELL_W + 0.6,

--- a/examples/split_footer_demo.rs
+++ b/examples/split_footer_demo.rs
@@ -491,7 +491,7 @@ fn emit_row(
 fn emit_run(out: &mut String, run: &[Paint], cx: f32, cy: f32) {
     let p = &run[0];
     if let Some(bg) = &p.bg {
-        // Slight overdraw removes hairline seams between adjacent filled cells.
+        // Slight overdraw removes hairline gaps between adjacent filled cells.
         out.push_str(&format!(
             "<rect x=\"{cx:.1}\" y=\"{cy:.1}\" width=\"{w:.1}\" height=\"{h:.1}\" \
 fill=\"{bg}\" shape-rendering=\"crispEdges\"/>",
@@ -531,7 +531,7 @@ textLength=\"{len:.1}\" lengthAdjust=\"spacingAndGlyphs\" xml:space=\"preserve\"
 #[allow(dead_code)]
 fn emit_cell(out: &mut String, p: &Paint, cx: f32, cy: f32) {
     if let Some(bg) = &p.bg {
-        // Slight overdraw removes hairline seams between adjacent filled cells.
+        // Slight overdraw removes hairline gaps between adjacent filled cells.
         out.push_str(&format!(
             "<rect x=\"{cx:.2}\" y=\"{cy:.2}\" width=\"{w:.2}\" height=\"{h:.2}\" \
 fill=\"{bg}\" shape-rendering=\"crispEdges\"/>",

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -38,7 +38,7 @@ the reason for a decision is cheapest to write down while it is still at hand.
 ## Product direction
 
 - [Product goal](specs/goal.md) — what tuika is for, and the boundary it defends.
-- [Architecture](specs/architecture.md) — the view/state/layout/host model and its seams.
+- [Architecture](specs/architecture.md) — the view/state/layout/host model and its boundaries.
 - [Public API surface](specs/api-surface.md) — what the root, `components`, `term`, and the prelude each own.
 
 ## Capabilities

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -79,7 +79,7 @@
 - **A run loop that cannot be driven without a terminal cannot be tested**
   - The synchronous loop had no end-to-end coverage for as long as every entry
     point reached crossterm; only its extracted pieces were testable. Giving it
-    the same caller-owned-terminal seam the async runner already had made the
+    the same caller-owned-terminal boundary the async runner already had made the
     loop itself assertable, and the tests followed immediately.
   - Input is a trait (`EventSource`) rather than a stream on this side, because
     a blocking loop consumes a timeout instead of selecting. An implementation
@@ -87,7 +87,7 @@
 
 ## 2026-08-14
 
-- **One seam, named axes only for what the names must carry**
+- **One boundary, named axes only for what the names must carry**
   - `FrameSource` makes the frame source an argument, and a message type
     parameter on `Signal` makes the message stream a type rather than a method
     name. The `run*` surface collapses to terminal ownership plus the presence
@@ -96,14 +96,14 @@
     callers: existing matches stay exhaustive, so the generalization is a
     compile-time no-op unless a host actually wants messages.
 
-- **The application seam is a runner axis, not a synchronous privilege**
-  - `AsyncApplication` gives the async runner the borrowed-view seam the sync
+- **The application boundary is a runner axis, not a synchronous privilege**
+  - `AsyncApplication` gives the async runner the borrowed-view boundary the sync
     runner already had, and carries its signal type as a parameter so a
-    message-consuming application is the same seam with a different signal
+    message-consuming application is the same boundary with a different signal
     rather than a third trait.
-  - Both frame sources are kept deliberately: the application seam is the more
+  - Both frame sources are kept deliberately: the application boundary is the more
     general in what a frame returns and states render purity in its receiver,
-    while the closure seam's `FnMut` view is the more permissive in what it
+    while the closure boundary's `FnMut` view is the more permissive in what it
     captures. Neither is legacy.
 
 - **A redraw request must reach a parked loop**
@@ -150,7 +150,7 @@
     recognising the shape up front and degrading them to the code block.
   - The shape-recognition guard was scar tissue tied to one upstream release
     window and left with it. The `catch_unwind` around the layout engine did
-    not: it is an unconditional property of the adapter seam, owed to the frame
+    not: it is an unconditional property of the adapter boundary, owed to the frame
     whether or not a reachable panic is known.
   - The regression test inverts with the fix — the same inputs now assert every
     label line lands inside the diamond, so a re-broken upstream is caught by
@@ -508,21 +508,21 @@
   already isolated, so the crate stays a markdown renderer.
 - The markdown non-goal was narrowed rather than deleted. Block-level HTML and
   document layout (DOM, CSS) stay out of core; a host that wants them supplies
-  the parser behind a seam, as `FencedBlockRenderer` already allows for a
+  the parser behind a boundary, as `FencedBlockRenderer` already allows for a
   fenced `html` block.
 - Inline-HTML scopes close at every block end. That is both the sane reading of
   an unclosed tag and what keeps the settled-prefix cache honest — a scope
   outliving a block boundary broke the streamed-equals-one-shot invariant in
   *styles* while the text still matched, which the streaming test now covers.
 
-- **Block HTML renders through a seam, with tuika-html behind it**
+- **Block HTML renders through a boundary, with tuika-html behind it**
 
 - The inline whitelist left `<details>`, `<table>`, and `<div>` blocks dropped,
   which is the majority of the HTML that actually appears in READMEs.
 - `HtmlBlockRenderer` follows `FencedBlockRenderer`'s shape but also carries the
   `StyleSheet`, so an implementation resolves the same roles the surrounding
   markdown does rather than inventing colors. `Renderers` bundles both block
-  seams so the free functions did not grow a second renderer argument each.
+  boundaries so the free functions did not grow a second renderer argument each.
 - `tuika-html` is the implementation: html5ever for the tree, tuika's own
   wrapping and stylesheet for the presentation, plus a standalone `Html` view.
   It is a fourth published crate rather than an optional feature, for the same
@@ -531,7 +531,7 @@
   is half of what the crate does, and a plain-text dump discards all of it. The
   recording is a screenshot, since the scene is settled.
 - **Documentation placement is a rule, not a habit.** HTML landed correctly and
-  was documented by accretion: the block-seam recording sat as an unlabeled hero
+  was documented by accretion: the block-boundary recording sat as an unlabeled hero
   above the crate README's first section, the `Html` component was missing from
   the gallery entirely, and the root README grew code samples and screenshots
   that belong in a guide. Every individual edit looked reasonable; the shape was
@@ -743,7 +743,7 @@
 
 - The component gallery is one entry per component, but markdown's user-facing
   surface is much larger than one entry: streaming, GFM table fitting, the
-  highlighter seam, link policy, and images. The table renderer in particular
+  highlighter boundary, link policy, and images. The table renderer in particular
   had no recording at all, so the feature was documented in prose and ASCII art
   while every other component had a demo.
 - Added `docs/markdown.md` and recorded a `markdown_table` scene. Recorded the
@@ -812,7 +812,7 @@
 
 - **Codegen shifts the instruction-count gate**
 
-- Landing `ItemScroll` and the composer token seams turned the `iai` gate red on
+- Landing `ItemScroll` and the composer token boundaries turned the `iai` gate red on
   `main`: seven of nine benchmarks up 3.7–5.5%, including the markdown ones,
   whose measured path (`markdown.rs`, `text.rs`, `style.rs`, `surface.rs`) was
   byte-identical to the parent commit.
@@ -827,13 +827,13 @@
 
 ## 2026-07-24
 
-- **Element viewports and composer token seams**
+- **Element viewports and composer token boundaries**
 
 - Building a coding-agent TUI as an example (`examples/codex/`) surfaced two
   places where the toolkit forced a host to hand-draw: a transcript could only
   hold pre-wrapped lines, and a composer could only paint one uniform style with
   no notion of the `@`/`/` tokens every such app needs.
-- Closed both as *seams*, not features: `ItemScroll` (a viewport over
+- Closed both as *boundaries*, not features: `ItemScroll` (a viewport over
   `Element`s, scrolled by row) and `Trigger`/`Token`/`TextSpan` (tuika delimits
   tokens and paints host-computed ranges; the meaning of a trigger character
   stays with the application). See [architecture.md](specs/architecture.md).
@@ -849,7 +849,7 @@
   responsive forms, and a closure-backed drawing view. Persistent input and
   control state remains host-owned; the additions are frame descriptions over
   the existing `View`, `Surface`, `OverlaySpec`, `FocusRegistry`, and
-  `ScrollState` seams.
+  `ScrollState` boundaries.
 - Added semantic success/warning/danger/info styles without expanding the
   public `Theme` struct. The roles derive from each theme's existing syntax
   colors, preserving source compatibility for downstream struct literals.

--- a/knowledge/processes/maintenance.md
+++ b/knowledge/processes/maintenance.md
@@ -107,7 +107,7 @@ The small dependency set is a designed property, not an accident
   alerts); duplicate transitive versions reviewed (`cargo tree --duplicates`) and
   either fixed or noted as unfixable.
 - A major-version bump of `ratatui-core` is an interoperability event, not a
-  routine upgrade: it changes the `Buffer` type on the public seam, so hosts must
+  routine upgrade: it changes the `Buffer` type on the public boundary, so hosts must
   move in lockstep. Treat it as a breaking release.
 
 ## Release Readiness Standard
@@ -149,7 +149,7 @@ removing that complexity as real work. The bias is toward deletion.
 Maintenance should look for and collapse:
 
 - single-use abstractions (one-impl traits, forwarding wrappers,
-  single-instantiation generics, builders for trivial structs) — unless the seam
+  single-instantiation generics, builders for trivial structs) — unless the boundary
   is load-bearing
 - premature generalization shaped for hypothetical futures, not current callers
 - indirection with no payoff: helpers that only rename a stdlib call, modules

--- a/knowledge/processes/release.md
+++ b/knowledge/processes/release.md
@@ -30,7 +30,7 @@ changelog with a before/after migration snippet. A patch release may not.
 **Every `pub` item is public API.** Removing one, renaming one, or changing a
 signature is breaking — including in `tuika::testing`, which hosts use to test
 their own views. A `ratatui-core` major bump is also breaking, because the
-`Buffer` on the interoperability seam is part of the contract.
+`Buffer` on the interoperability boundary is part of the contract.
 
 ## Release Targets
 

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -142,7 +142,7 @@ results across every published workspace member.
 benchmark never calls.** rustc partitions a crate into codegen units, so a new
 module changes which functions share a unit and therefore which ones get inlined;
 a hot path whose source did not change can move several percent. Adding
-`ItemScroll` and the composer token seams moved the *markdown* benches — whose
+`ItemScroll` and the composer token boundaries moved the *markdown* benches — whose
 whole measured path was byte-identical — by 3–5%. Before blessing that, confirm
 it is what it looks like: measure the parent commit (it should reproduce the
 committed baseline exactly), then re-add one file at a time until the counts

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`view_fn`/`Element`/`ScopedElement`/`RenderCtx`, `Application`/`AsyncApplication`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host seam, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`view_fn`/`Element`/`ScopedElement`/`RenderCtx`, `Application`/`AsyncApplication`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host boundary, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -1,7 +1,7 @@
 ---
 type: Architecture Specification
 title: Rendering Architecture
-description: Defines tuika's view/state/layout/host model and the seams that keep it host-agnostic.
+description: Defines tuika's view/state/layout/host model and the boundaries that keep it host-agnostic.
 ---
 
 # Rendering Architecture
@@ -99,7 +99,7 @@ rather than beside it.
   `OverlaySpec` while rendering. This removes borrowed compositor plumbing
   without adding identity, lifecycle, or hidden persistent state.
 - **Scoped element trees borrow for one frame.** `Element` remains the owned,
-  `'static` box used by retained host seams, while `ScopedElement<'frame>` may
+  `'static` box used by retained host boundaries, while `ScopedElement<'frame>` may
   hold a borrowed view anywhere in the base component tree. Composition
   containers are generic over their child view type and default to `Element`,
   preserving the ordinary owned path without parallel scoped components.
@@ -122,10 +122,10 @@ rather than beside it.
   counterpart `AsyncApplication`) receives signals through `&mut self` and
   builds a `ScopedElement<'_>` through `&self`, so a frame can borrow
   application data without shared interior mutability. The compatible closure
-  seam renders an owned `Element` from `&State` and updates through
-  `&mut State`. Both seams are kept: the application seam is more general in
+  boundary renders an owned `Element` from `&State` and updates through
+  `&mut State`. Both boundaries are kept: the application boundary is more general in
   what a frame may *return* (`Element` is `ScopedElement<'static>`) and states
-  render purity in its receiver, while the closure seam's `FnMut` view is more
+  render purity in its receiver, while the closure boundary's `FnMut` view is more
   permissive in what it may *capture*. Repaint is an explicit dirty result or an
   external redraw request; terminal resize is the exception because layout
   must be repainted even when application state is unchanged. Rendering stays
@@ -148,7 +148,7 @@ rather than beside it.
   an in-memory backend — the same hermetic principle the view layer already had,
   extended to the run loop. The synchronous side gets its input through an
   `EventSource` because it blocks on a timeout rather than selecting on a
-  stream; that trait is the seam a scripted or custom input implements.
+  stream; that trait is the boundary a scripted or custom input implements.
 - **The frame source is an argument, not a method name.** `FrameSource` has two
   implementors — `&mut app` for an `Application`, and `from_fn` over a state
   value and closures — so a run method never has to name which one it takes.
@@ -176,14 +176,14 @@ max-content availability. Its default adapts to the original `measure`, so old
 views remain source-compatible; the non-exhaustive request and availability
 types can gain future measurement inputs without another trait-wide break.
 
-## Why the `ratatui-core` seam, not the umbrella
+## Why the `ratatui-core` boundary, not the umbrella
 
 tuika renders none of ratatui's own widgets, so it depends on `ratatui-core`
 (plus `ratatui-crossterm` for the backend) directly. This drops
 `ratatui-widgets`, `ratatui-macros`, and their transitive weight from every
 downstream build that does not use them.
 
-It costs nothing in interoperability: the interop seam is a raw
+It costs nothing in interoperability: the interop boundary is a raw
 `&mut Buffer` from that same `ratatui-core`. A host bringing the `ratatui`
 umbrella resolves to one shared `ratatui-core`, so `Surface::render_ratatui` and
 `RatatuiView` accept any real ratatui widget without conversion. The
@@ -283,7 +283,7 @@ math prevents CJK and multi-scalar emoji from drifting apart.
 
 Time-sensitive component state never owns an unreplaceable wall clock. Mouse
 double-click detection and the synchronous runner consume the root `Clock`
-seam, defaulting to `SystemClock`; animation frames, toast expiry, and keymap
+boundary, defaulting to `SystemClock`; animation frames, toast expiry, and keymap
 timeouts remain values or ticks explicitly advanced by the host. The async
 runner uses Tokio time, whose paused-time facility is its deterministic clock.
 
@@ -295,7 +295,7 @@ completion source, the popup, the styling, whether confirming runs a command or
 inserts a path — is the application's, and `TextInput::highlights` paints ranges
 the host computed rather than semantics tuika inferred. A toolkit that shipped
 "mentions" and "slash commands" as features would be encoding one host's product
-decisions; declaring the lexical rule and returning the spans is the seam.
+decisions; declaring the lexical rule and returning the spans is the boundary.
 
 `Viewport` follows the same host-state rule as `Scroll`: offsets live in
 `ScrollState`, while the view owns only an ephemeral child and declared content

--- a/knowledge/specs/charts.md
+++ b/knowledge/specs/charts.md
@@ -30,7 +30,7 @@ edge.
 
 A chart selects smooth RGBA rasterization when its `RenderCtx` provides terminal
 graphics support and an `ImageLayer`. The real-terminal `Runner` detects and
-supplies both automatically; custom hosts retain the explicit context seam. It
+supplies both automatically; custom hosts retain the explicit context boundary. It
 uses core's image machinery for placement and Kitty/iTerm2/Sixel lifecycle.
 Otherwise it draws the same model into terminal cells with Unicode axes and
 marks. The portable renderer uses

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -104,15 +104,15 @@ self-evident. A recording placed above the first section, or on a page whose
 subject it only partly covers, reads as chrome and is skipped — a demo nobody
 connects to a feature is as good as absent.
 
-The same rule decides which page: the seam's demo goes where the seam is
+The same rule decides which page: the boundary's demo goes where the boundary is
 documented, the component's where the component is.
 
 ### rustdoc carries an example and a demo
 
-Every public component and every host-facing seam documents itself twice over:
+Every public component and every host-facing boundary documents itself twice over:
 
 - **An example that compiles** — a doctest, so it cannot rot silently. For a
-  seam, the example shows an *implementation*, not only how to attach one; the
+  boundary, the example shows an *implementation*, not only how to attach one; the
   reader's question is what their `impl` has to do.
 - **The demo**, embedded by absolute `raw.githubusercontent.com` URL so it
   resolves on docs.rs, plus the command that runs the example it came from.
@@ -175,7 +175,7 @@ Generated demos follow the rule that the *scene registry is the source of truth*
   The `tuika-mermaid` and `tuika-html` recordings follow this rule and ship with
   their companion crates so each crates.io README can show what it documents.
   A crate with more than one entry point records more than one scene —
-  `tuika-html` has a demo for the markdown seam and another for its standalone
+  `tuika-html` has a demo for the markdown boundary and another for its standalone
   component, because one recording cannot answer both questions.
 - `tuika-codeformatters` follows the same example-driven rule for its language
   gallery; `scripts/gen-language-demo.sh` records the real `languages` example.

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -49,7 +49,7 @@ The claim is earned by scope and by adoption evidence, never by overstatement:
    `unicode-width`, and `pulldown-cmark`. Anything heavier belongs behind a
    trait the host implements.
 4. **Interoperable, not exclusive.** Existing ratatui widgets compose through a
-   raw-`Buffer` seam; adopting tuika never means giving up ratatui.
+   raw-`Buffer` boundary; adopting tuika never means giving up ratatui.
 5. **Testable without a terminal.** Rendering is observable as cells in memory,
    so behavior is asserted hermetically.
 
@@ -70,13 +70,13 @@ a trait the host implements:
 The companion crates exist because of this rule: `tuika-codeformatters`
 supplies tree-sitter grammars behind `Highlighter`, `tuika-mermaid` supplies
 mmdflux parsing and layout behind `MarkdownBlockRenderer`, and `tuika-html`
-supplies html5ever behind the same structured-block seam. They are separately published
+supplies html5ever behind the same structured-block boundary. They are separately published
 rather than optional tuika features so the core dependency tree cannot grow by
 accident.
 
 `tuika-html` also shows where the line falls *inside* one capability: the
 presentational inline tags need no parser, so they are in the crate, while
-block-level HTML needs a tree builder and is therefore a seam. The test is the
+block-level HTML needs a tree builder and is therefore a boundary. The test is the
 dependency, not the topic.
 
 ## Non-goals

--- a/knowledge/specs/images.md
+++ b/knowledge/specs/images.md
@@ -78,7 +78,7 @@ encoding, cell reservation, fallback), never decoding.
 ### The cell-reservation + out-of-band-emit model
 
 An image cannot be written through `Surface` — `Surface` only writes cells. So
-the model splits placement from emission, using the seam `RectProbe` already
+the model splits placement from emission, using the boundary `RectProbe` already
 established for reading a view's painted rect back out:
 
 1. The `Image` view reserves a `cols × rows` cell footprint via `measure`, so

--- a/knowledge/specs/keymap.md
+++ b/knowledge/specs/keymap.md
@@ -17,7 +17,7 @@ imperative branch and remembering its ordering relative to every modal guard.
 Key routing is a toolkit concern in the same way layout, overlays, and focus
 are — the problem [OpenTUI's keymap](https://opentui.com/docs/keymap/overview/)
 solves for the browser and terminal. tuika owns a declarative binding engine so
-any host declares its shortcuts once and dispatches through a single seam.
+any host declares its shortcuts once and dispatches through a single boundary.
 
 ## What
 

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -1,7 +1,7 @@
 ---
 type: Product Specification
 title: Markdown rendering
-description: Defines tuika's CommonMark rendering, its streaming form, and the highlighter seam that keeps grammars out of the crate.
+description: Defines tuika's CommonMark rendering, its streaming form, and the highlighter boundary that keeps grammars out of the crate.
 ---
 
 # Markdown rendering
@@ -50,7 +50,7 @@ every width change a full re-parse.
 
 The module's files follow the passes rather than the vocabulary, so a change has
 one obvious home: the intermediate form, the parse pass, the flatten pass, table
-layout, the streaming cache, the image seam, and the view.
+layout, the streaming cache, the image boundary, and the view.
 
 ### The settled-prefix cache
 
@@ -74,7 +74,7 @@ in particular — must therefore be threaded *through* the cache: fixed rows for
 settled blocks, re-derived each frame for the in-flight tail. A frame-local
 computation that only looks at the tail would silently lose the settled part.
 
-### Highlighting is a seam, not a dependency
+### Highlighting is a boundary, not a dependency
 
 tuika owns the presentation of code — frame, a background that fills the
 available width, language label, optional line-number gutter, wrapping — and
@@ -88,7 +88,7 @@ means a host that renders no code pays nothing, and a host that renders code can
 choose its own highlighter. `tuika-codeformatters` is the batteries-included
 answer, published separately for exactly that reason.
 
-### Structured blocks share one parsing seam
+### Structured blocks share one parsing boundary
 
 Syntax highlighting must reconstruct the original source line-for-line, so it
 cannot express a fence whose presentation has a different shape than its source.
@@ -164,7 +164,7 @@ text matched*.
 (`4ᵗh`) depends on which characters a word happens to use, which is a worse
 result than leaving the text alone.
 
-### Block HTML reuses the structured-block seam
+### Block HTML reuses the structured-block boundary
 
 The presentational inline tags need no parser. Block HTML does — a tree builder
 that recovers implied end tags, inserts the `<tbody>` nobody wrote, and survives
@@ -173,7 +173,7 @@ HTML is therefore the second `MarkdownBlock` variant, not a second trait. Its
 renderer receives the raw run through the same context as a fence, including
 the active stylesheet: headings and links resolve the same roles as the
 surrounding markdown. With no renderer attached the block is dropped, which is
-what markdown did with all HTML before the seam existed, so attaching one is
+what markdown did with all HTML before the boundary existed, so attaching one is
 purely additive.
 
 `tuika-html` is that implementation, and it is also where the line inside this
@@ -214,7 +214,7 @@ host that restyles headings restyles them in markdown too. See
 
 - No HTML *document* rendering: no DOM, no CSS, no block-level HTML layout.
   Block HTML (`<div>`, `<details>`, `<table>`) is dropped in core; a host that
-  wants it supplies the parser behind `MarkdownBlockRenderer`, the same seam a
+  wants it supplies the parser behind `MarkdownBlockRenderer`, the same boundary a
   ` ```html ` fence uses.
 - No raw-HTML passthrough: unrecognized markup is never echoed as literal text.
 - No markdown *authoring* or round-tripping — rendering only.
@@ -225,7 +225,7 @@ host that restyles headings restyles them in markdown too. See
 
 - [`docs/markdown.md`](../../docs/markdown.md) — the guide. Markdown carries more
   user-facing surface than one gallery entry holds (streaming, table fitting,
-  the highlighter seam, link policy, images), so it gets a page of its own and
+  the highlighter boundary, link policy, images), so it gets a page of its own and
   [`docs/components/markdown-code.md`](../../docs/components/markdown-code.md)
   keeps only the gallery entry and points here.
 - [`docs/components/markdown-code.md`](../../docs/components/markdown-code.md)

--- a/knowledge/specs/screen-modes.md
+++ b/knowledge/specs/screen-modes.md
@@ -128,7 +128,7 @@ completion popup opening — therefore reserves the tallest state it needs and
 lays out inside it, which is what `codex --split-footer` does.
 
 Runtime resizing is a real capability (opentui exposes `footerHeight` as a
-setter) and a plausible follow-up, but it needs a seam for recreating the
+setter) and a plausible follow-up, but it needs a boundary for recreating the
 backend that does not exist on ratatui's `Terminal` today (there is no
 `into_backend`). Reserving the maximum is the honest interim: it costs rows, not
 correctness.

--- a/scripts/gen-html-demo.sh
+++ b/scripts/gen-html-demo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Record the tuika-html examples beside their sources: the markdown seam
+# Record the tuika-html examples beside their sources: the markdown boundary
 # (`html_markdown`) and the standalone `Html` component (`html_view`).
 #
 # Requirements: vhs (https://github.com/charmbracelet/vhs), which needs ttyd
@@ -57,7 +57,7 @@ EOF
   echo "Wrote ${output} ($(du -h "${output}" | cut -f1))."
 }
 
-# The seam: HTML blocks inside a markdown document.
+# The boundary: HTML blocks inside a markdown document.
 record html_markdown 1000 "crates/tuika-html/examples/html_markdown/html.png"
 # The component: a whole HTML fragment as the screen.
 record html_view 1560 "crates/tuika-html/examples/html_view/html_view.png"

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 ///
 /// Returned instants must share one monotonic epoch and must not move backward.
 /// Components use elapsed durations only; wall-clock dates and time zones are
-/// intentionally outside this seam.
+/// intentionally outside this boundary.
 pub trait Clock {
     /// Read the current monotonic instant.
     fn now(&self) -> Instant;

--- a/src/components/markdown/flatten.rs
+++ b/src/components/markdown/flatten.rs
@@ -137,7 +137,7 @@ pub(super) fn flatten_linked_into<R: MarkdownBlockRenderer + ?Sized>(
                 }
             }
             // No renderer means the block is dropped — markdown's behavior for
-            // all HTML before the seam existed.
+            // all HTML before the boundary existed.
             MdItem::Html { source, indent } => {
                 let avail = width.saturating_sub(*indent).max(1);
                 if let Some(rendered) = renderers.render(

--- a/src/components/markdown/image.rs
+++ b/src/components/markdown/image.rs
@@ -1,4 +1,4 @@
-//! The image seam: resolving `![alt](url)` to pixels, and sizing it in cells.
+//! The image boundary: resolving `![alt](url)` to pixels, and sizing it in cells.
 //!
 //! Markdown carries only a URL, and decoding it is the host's job (see
 //! [`ImageResolver`]), so this module owns the boundary between the two: what a

--- a/src/components/markdown/item.rs
+++ b/src/components/markdown/item.rs
@@ -33,7 +33,7 @@ pub(super) enum MdItem {
     /// A raw block-level HTML run, kept verbatim for an
     /// [`MarkdownBlockRenderer`](super::MarkdownBlockRenderer) to lay out at flatten
     /// time. With no renderer attached it renders as nothing, which is what
-    /// markdown did with all HTML before the seam existed.
+    /// markdown did with all HTML before the boundary existed.
     Html { source: String, indent: u16 },
     /// A resolved block image: reserves rows at flatten time and is painted by an
     /// [`Image`](crate::components::Image) overlay in the view (see [`ImageResolver`]).

--- a/src/components/markdown/mod.rs
+++ b/src/components/markdown/mod.rs
@@ -38,7 +38,7 @@
 //! | `flatten` | pass two — `MdItem`s to width-fitted `Line`s: wrapping, indentation, hyperlink runs |
 //! | `table` | table layout, called from `flatten`; big enough to drown the rest of pass two |
 //! | `stream` | [`MarkdownState`] and the settled-prefix cache that makes streaming O(delta) |
-//! | `image` | the [`ImageResolver`] seam and cell sizing for block images |
+//! | `image` | the [`ImageResolver`] boundary and cell sizing for block images |
 //! | `view` | the [`Markdown`] view over either entry point |
 //!
 //! The submodules are private: `components::markdown` is the one path in, and

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -37,7 +37,7 @@ use super::parse::parse_with;
 ///
 /// ![markdown inline HTML demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/markdown_html.png)
 ///
-/// Block-level HTML is a seam handled by [`block_renderer`](Self::block_renderer).
+/// Block-level HTML is a boundary handled by [`block_renderer`](Self::block_renderer).
 ///
 /// GFM tables are laid out to the render width, cells keeping their inline
 /// styles, emoji, and links:

--- a/src/components/qr.rs
+++ b/src/components/qr.rs
@@ -6,7 +6,7 @@
 //! error correction, block interleaving, and penalty-scored data masking. A
 //! payload too large for version 4 returns `None`; a host that needs bigger codes
 //! can encode with its own library and hand the module matrix to
-//! [`QrCode::from_matrix`] — the same present-a-matrix seam as
+//! [`QrCode::from_matrix`] — the same present-a-matrix boundary as
 //! [`Image`](crate::components::Image).
 //!
 //! Rendering packs two module rows into each terminal row with the `▀` half-block

--- a/src/components/slider.rs
+++ b/src/components/slider.rs
@@ -85,7 +85,7 @@ impl SliderState {
         self.value = value.clamp(self.min, self.max);
     }
 
-    /// Set the value from a `0.0..=1.0` position within the range — the seam a
+    /// Set the value from a `0.0..=1.0` position within the range — the boundary a
     /// host uses to map a click/drag on the track to a value.
     pub fn set_ratio(&mut self, ratio: f32) {
         let r = ratio.clamp(0.0, 1.0);

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -1,4 +1,4 @@
-//! The [`Highlighter`] seam — how a host plugs syntax highlighting into
+//! The [`Highlighter`] boundary — how a host plugs syntax highlighting into
 //! [`CodeBlock`](crate::components::CodeBlock) and
 //! [`Markdown`](crate::components::Markdown) without tuika taking on any grammar
 //! dependency.

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,6 +1,6 @@
 //! Terminal host: screen-mode lifecycle, event translation, compositor.
 //!
-//! This is the seam between `tuika` and a real terminal. [`TerminalSession`]
+//! This is the boundary between `tuika` and a real terminal. [`TerminalSession`]
 //! owns the complete lifecycle for either [`ScreenMode`] — the alternate screen
 //! or a split footer on the main screen (see [`screen`](crate::screen)) —
 //! including enhanced keyboard reporting; [`AltScreen`] is the narrower guard
@@ -430,7 +430,7 @@ pub fn paint_with_sheet(
 
 /// Composite a frame with a fully configured render context.
 ///
-/// This is the host seam for an application that installs a
+/// This is the host boundary for an application that installs a
 /// [`StyleResolver`](crate::StyleResolver) in addition to a theme and
 /// stylesheet. Simpler hosts can keep using [`paint`] or [`paint_with_sheet`].
 pub fn paint_with_context(

--- a/src/keymap.rs
+++ b/src/keymap.rs
@@ -4,7 +4,7 @@
 //! This is `tuika`'s answer to the same problem [OpenTUI's keymap][opentui]
 //! solves for the browser/terminal: decouple *what keys do* from the widget
 //! that reacts, so an application can declare its shortcuts once, gate them by
-//! mode, discover them for help UIs, and dispatch through a single seam. It
+//! mode, discover them for help UIs, and dispatch through a single boundary. It
 //! follows OpenTUI's **register → dispatch → query** shape, adapted to idiomatic
 //! Rust and to `tuika`'s own [`Key`] events (so it needs no terminal and stays
 //! unit-testable).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! # Finding things
 //!
 //! The crate root re-exports the **framework**: the view model, layout,
-//! events, styling, and the host seam — the types you compose *with*. The
+//! events, styling, and the host boundary — the types you compose *with*. The
 //! widgets themselves live in [`components`]. Owned [`Element`] trees use
 //! [`Scene`]; [`ScopedElement`] trees may borrow application state at any depth
 //! and use [`ScopedScene`] without cloning it. Everything that talks to the

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,7 +6,7 @@
 //!
 //! This is the framework spine re-exported from the crate root, plus every
 //! component and the handful of per-module types an application reaches for
-//! constantly: focus, keymap, animation, live values, the highlighter seam, and
+//! constantly: focus, keymap, animation, live values, the highlighter boundary, and
 //! the ratatui interop wrapper.
 //!
 //! What is *not* here is as deliberate as what is. Terminal escapes

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -478,7 +478,7 @@ impl AsyncRunner {
     /// Run against a caller-owned terminal and input streams, with no terminal
     /// lifecycle of the runner's own.
     ///
-    /// This is the loop itself, and what [`run`](Self::run) builds on. The seam
+    /// This is the loop itself, and what [`run`](Self::run) builds on. The boundary
     /// tests drive it against a
     /// [`TestBackend`](ratatui_core::backend::TestBackend) with scripted
     /// streams; hosts that already own their terminal and event source (or want
@@ -1596,7 +1596,7 @@ mod tests {
     }
 
     /// An application whose frame borrows its own data, used to prove the
-    /// borrowed seam reaches the async loop unchanged.
+    /// borrowed boundary reaches the async loop unchanged.
     struct Notes {
         title: String,
         hits: Vec<char>,
@@ -1641,7 +1641,7 @@ mod tests {
         }
     }
 
-    // The async runner drives the same `Application`-shaped seam the sync runner
+    // The async runner drives the same `Application`-shaped boundary the sync runner
     // does: events mutate through `&mut self`, and the frame borrows `&self`
     // without cloning into an owned tree.
     #[tokio::test]
@@ -1680,7 +1680,7 @@ mod tests {
         );
     }
 
-    /// The message-carrying twin of `Notes`: the same seam with a different
+    /// The message-carrying twin of `Notes`: the same boundary with a different
     /// signal type rather than a different trait.
     struct Feed {
         items: Vec<u8>,
@@ -1704,7 +1704,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn an_application_receives_messages_through_the_same_seam() {
+    async fn an_application_receives_messages_through_the_same_channel() {
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
             ..RunnerConfig::default()

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! # Choosing a `run` method
 //!
-//! There is one loop and one seam, so the surface is small. Every run method
+//! There is one loop and one boundary, so the surface is small. Every run method
 //! takes a [`FrameSource`] — `&mut app` for an [`Application`], or [`from_fn`]
 //! for the closure form — and the remaining names say only where the terminal
 //! and the input come from:
@@ -237,7 +237,7 @@ pub enum UpdateResult {
 
 /// A data-driven terminal application: what [`Runner::run`] drives.
 ///
-/// [`AsyncApplication`] is the same seam for a host whose `update` awaits;
+/// [`AsyncApplication`] is the same boundary for a host whose `update` awaits;
 /// the split exists because only the runtime differs, not the contract.
 ///
 /// The runner mutably borrows the application only while delivering a
@@ -261,10 +261,10 @@ pub trait Application<M = Infallible> {
 
 /// What a run loop pulls frames and update decisions from.
 ///
-/// This is the runner's single seam, and the reason there is no separate `run`
+/// This is the runner's single boundary, and the reason there is no separate `run`
 /// method per frame source. Two things implement it:
 ///
-/// - `&mut A` where `A: Application` — the borrowed-view seam. Its `view(&self)`
+/// - `&mut A` where `A: Application` — the borrowed-view boundary. Its `view(&self)`
 ///   may return a tree that borrows the application for the frame.
 /// - [`from_fn`] — a `state` value beside `view`/`update` closures, for a host
 ///   that would rather not name a type.
@@ -303,7 +303,7 @@ pub struct FromFn<'state, S, V, U> {
 
 /// Build a [`FrameSource`] from `state` and closures over it.
 ///
-/// The closure form of the seam. State is a separate argument rather than a
+/// The closure form of the boundary. State is a separate argument rather than a
 /// capture because one closure needs `&state` while the other needs
 /// `&mut state`, and a single closure cannot hold both.
 ///
@@ -1195,7 +1195,7 @@ mod tests {
 
     // ---- End-to-end loop coverage, via `run_driven_by`. ----
     //
-    // Before this seam existed the synchronous loop had no test at all: every
+    // Before this boundary existed the synchronous loop had no test at all: every
     // entry point reached crossterm and a real terminal, so only its pieces
     // (`RunnerCore`, the clock, `RunnerSelection`) could be exercised. These
     // drive the whole thing over a `TestBackend`.
@@ -1329,7 +1329,7 @@ mod tests {
         assert_eq!(views.get(), 1, "only the initial frame was built");
     }
 
-    /// The borrowed seam over the synchronous loop: no clone into an owned tree.
+    /// The borrowed boundary over the synchronous loop: no clone into an owned tree.
     struct Notes {
         title: String,
         hits: Vec<char>,

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,4 +1,4 @@
-//! The `View` trait — the extensibility seam for components.
+//! The `View` trait — the extensibility boundary for components.
 //!
 //! Design note (why not a React-style reconciler): `tuika` rebuilds the view
 //! tree from application state every frame, which is cheap because ratatui
@@ -289,7 +289,7 @@ pub trait View {
 /// contains frame-borrowed views.
 pub type ScopedElement<'view> = Box<dyn View + 'view>;
 
-/// Boxed owned view used by retained values and cross-thread host seams.
+/// Boxed owned view used by retained values and cross-thread host boundaries.
 pub type Element = ScopedElement<'static>;
 
 impl View for Box<dyn View + '_> {

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -24,7 +24,7 @@ fn inline_view_is_available_from_the_framework_surface() {
 }
 
 #[test]
-fn semantic_style_resolver_is_a_public_host_seam() {
+fn semantic_style_resolver_is_a_public_host_boundary() {
     const APP_STATUS: StyleRole = StyleRole::new("test.app-status");
 
     struct Styles;
@@ -416,7 +416,7 @@ fn the_former_root_collisions_resolve() {
     use ratatui_core::style::{Color, Style};
     use tuika::mouse::{SelectionRange, paint_selection};
 
-    // `tuika::highlight` is the Highlighter seam, and nothing else.
+    // `tuika::highlight` is the Highlighter boundary, and nothing else.
     let _: &dyn tuika::highlight::Highlighter = &PlainHighlighter;
 
     // Painting a selection is a mouse concern, and says so.


### PR DESCRIPTION
## Summary

- replace the architectural term `seam` with contextual language such as `boundary` and `integration point`
- use domain-specific terms for rendering gaps and the application message channel
- update source comments, test names, contributor guidance, specifications, plans, and historical documentation

## Validation

- repository-wide tracked-text scan confirms no exact `seam` or `seams` occurrences remain
- `git diff --check`
- independent editorial review found no semantic or API issues
- full Rust validation deferred to CI because Cargo is unavailable in the agent environment

Produced by [yolop](https://everruns.com/yolop)
