### PR TITLE
feat(routing): route every event kind to the surface that owns input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ described in the release process begins with the entry below.
 
 ## [Unreleased]
 
+### Added
+
+- **Input routing**: the new `routing` module (`Router`, `Delivery`,
+  `RouteStage`, `InputTarget`, all re-exported from the crate root and the
+  prelude) delivers an event to the surface that owns input this frame. A host
+  registers each surface once and every `Event` kind follows the same route, so
+  a paste can no longer take a different path from a key and land behind an open
+  overlay. `Router` reads the `FocusRegistry` an overlay-bearing `Scene` already
+  synchronized — and does not hold it, so a stage closure may take `&mut` on the
+  host — resolves stages in a fixed order (global chord, declared exceptions,
+  the active surface, last-chance global), and reports through `Delivery` which
+  surface received what, including the case where nothing did. See the
+  [routing guide](docs/routing.md).
+
 ## [0.10.0] - 2026-08-17
 
 Released alongside `tuika-charts` 0.1.1, `tuika-codeformatters` 0.4.3,

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 [Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](https://github.com/everruns/tuika/blob/v0.10.0/docs/getting-started.md) · [Components](https://github.com/everruns/tuika/blob/v0.10.0/docs/components.md) · [Layout](https://github.com/everruns/tuika/blob/v0.10.0/docs/layout.md) ·
 [Markdown](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md) · [Charts](https://github.com/everruns/tuika/blob/v0.10.0/docs/charts.md) ·
 [Terminal features](https://github.com/everruns/tuika/blob/v0.10.0/docs/features.md) ·
-[Keymap](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md) · [Styling](https://github.com/everruns/tuika/blob/v0.10.0/docs/styling.md) ·
+[Keymap](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md) · [Input routing](https://github.com/everruns/tuika/blob/v0.10.0/docs/routing.md) ·
+[Styling](https://github.com/everruns/tuika/blob/v0.10.0/docs/styling.md) ·
 [Themes](https://github.com/everruns/tuika/blob/v0.10.0/docs/themes.md) \
 [Showcases](https://github.com/everruns/tuika/blob/v0.10.0/docs/showcases.md) · [Examples](#runnable-examples) ·
 [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) ·
@@ -148,6 +149,13 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
   matching; Shift stays explicit for non-character keys such as `Shift+Enter`.
   Host-agnostic, so it unit-tests without a terminal. See the
   [keymap guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md).
+- **Input routing** ([`routing`](https://github.com/everruns/tuika/blob/v0.10.0/docs/routing.md)) delivers an event to the
+  surface that owns input this frame — every event kind through one
+  registration, so a paste cannot take a different path from a key. `Router`
+  reads the focus registry an overlay-bearing `Scene` already synchronized, and
+  reports through `Delivery` which surface received what, including the case
+  where nothing did. See the
+  [routing guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/routing.md).
 - **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
   `term::progress::TerminalProgress`) animates from a host-supplied frame counter and
   can drive the terminal's own OSC 9;4 progress indicator. `anim::Timeline` adds

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -2,7 +2,7 @@
 title: Charts
 description: Define one terminal chart that adapts from portable Unicode cells to smooth terminal graphics.
 sidebar:
-  order: 9
+  order: 10
 ---
 
 # Charts

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,7 +2,7 @@
 title: Terminal features
 description: Images, hyperlinks, clipboard, native progress, terminal palettes, mouse input, and screen modes in tuika.
 sidebar:
-  order: 8
+  order: 9
 ---
 
 # Terminal features

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,173 @@
+---
+title: Input routing
+description: Deliver every event kind to the surface that owns input, with ownership, precedence, and fallthrough declared once.
+sidebar:
+  order: 6
+---
+
+# Input routing
+
+A frame usually has more than one place an event could go: a composer, a
+picker over it, a modal that just opened, a transcript that scrolls behind
+everything. Deciding **which one receives this event** is policy, and tuika owns
+it the way it owns layout and focus.
+
+[`FocusRegistry`](https://docs.rs/tuika/latest/tuika/focus/struct.FocusRegistry.html)
+already answers *who is active* — an overlay owner beats the base focus ring —
+and `Scene::sync_focus` resolves overlay z-order into that owner.
+[`Router`](https://docs.rs/tuika/latest/tuika/routing/struct.Router.html) is the
+step after it: given that state, it hands the event to the right surface's state,
+for **every** event kind at once.
+[API](https://docs.rs/tuika/latest/tuika/routing/index.html)
+
+## Why it is a toolkit concern
+
+Written by hand, the step is one `if focus.is_active("composer")` per surface,
+per event kind. That scales badly in a specific and dangerous way: keys go
+through one function and pastes through another, only the key path learns about
+a new overlay, and a pasted secret lands in the composer *behind* an open
+prompt. The overlay was correct, the registry was correct, and the event still
+went to the wrong place — because the route was host code written twice.
+
+One route removes the second path:
+
+- **Ownership gates delivery.** `target` reaches only the active surface.
+- **One route per event kind.** Stages take the whole `Event`, so a new variant
+  cannot miss a surface.
+- **Precedence is declared, not re-derived.** It comes from the registry the
+  scene already synchronized.
+- **Global chords compose.** They are stages, not a position in an `if` chain.
+- **Fallthrough is observable.** `Delivery` says who received what.
+- **It tests without a terminal**, like layout.
+
+## The stages
+
+A `Router` is built per update, and stages run eagerly in this order. Each is
+skipped once something has consumed the event; calling them out of order trips a
+debug assertion.
+
+| Stage | Reaches | Typical use |
+|---|---|---|
+| `pre_fn` | everything, first | interrupt and quit chords |
+| `always` / `always_fn` | a named surface, focused or not | a transcript that keeps scrolling; a picker that claims its navigation keys and leaves the rest |
+| `target` / `target_fn` | the active surface only | the composer, the open dialog |
+| `fallback_fn` | everything, last | navigation and help, when nothing claimed the event |
+
+`always` is the deliberate hole in ownership. It is a named call rather than an
+implied exception, so "what reaches a surface that does not own input" is
+greppable.
+
+## Routing an event
+
+```rust
+use tuika::prelude::*;
+
+fn update(app: &mut App, event: &Event) {
+    // 1. Declare the frame's ownership. A host whose modal is an overlay gets
+    //    this from `Scene::sync_focus`; declare it directly otherwise.
+    app.focus.begin_frame();
+    app.focus.register("composer");
+    if app.dialog.is_some() {
+        app.focus.set_owner("dialog");
+    } else {
+        app.focus.clear_owner();
+    }
+
+    // 2. Route. One registration per surface, covering every event kind.
+    let mut quit = false;
+    let mut router = Router::new(&app.focus, event);
+    router.pre_fn(|event| match event {
+        Event::Key(key) if key.ctrl && key.code == KeyCode::Char('c') => {
+            quit = true;
+            InputOutcome::Cancelled
+        }
+        _ => InputOutcome::Ignored,
+    });
+    router.always_fn("transcript", |event| {
+        app.scroll.handle(event, app.content_h, app.viewport_h)
+    });
+    router.target_fn("dialog", |event| app.handle_dialog(event));
+    router.target("composer", &mut app.composer);
+    let delivery = router.finish();
+
+    // 3. Apply what the stages decided.
+    if quit { app.quit(); }
+    if !delivery.consumed() {
+        // Nobody claimed it — a state a host can log instead of losing.
+    }
+}
+```
+
+`Router::new` reads the registry and does not hold it, so a stage closure is free
+to take `&mut` on the same host struct the registry lives on.
+
+### Targets
+
+`target` and `always` take any
+[`InputTarget`](https://docs.rs/tuika/latest/tuika/routing/trait.InputTarget.html)
+— implemented for tuika's single-`Event` input states (`TextInputState`,
+`SingleLineInputState`, `CompletionState`, `ConfirmDialogState`,
+`InputDialogState`, `SliderState`). A state whose `handle` needs frame context
+(`ScrollState` wants the content and viewport heights) or a host type that is not
+a tuika state routes through the `*_fn` form instead, so adopting the router
+never requires rewriting a surface first.
+
+### Stages decide, the host applies
+
+Keep a stage closure to the surface it routes to, and apply anything wider — quit,
+submit, opening another surface — after `finish()`. It keeps a stage from needing
+a borrow of the whole application mid-route, and keeps the route readable as a
+list of surfaces.
+
+## What a `Delivery` reports
+
+```rust
+let delivery = router.finish();
+delivery.target;              // Some("dialog") — the last receiver
+delivery.stage;               // RouteStage::Target
+delivery.outcome;             // InputOutcome::Changed
+delivery.consumed();          // true
+delivery.reached("composer"); // false
+```
+
+`RouteStage::Undelivered` with no target means the event reached nothing at all.
+That is the case worth logging: an event that vanishes is how a routing hole
+announces itself.
+
+## Testing a route
+
+Routing asserts like layout does — no terminal, no rendering:
+
+```rust
+let mut composer = SingleLineInputState::new();
+let mut prompt = SingleLineInputState::new();
+
+let mut focus = FocusRegistry::new();
+focus.begin_frame();
+focus.register("composer");
+focus.set_owner("prompt");
+
+let event = Event::Paste("secret".into());
+let mut router = Router::new(&focus, &event);
+router.target("prompt", &mut prompt);
+router.target("composer", &mut composer);
+
+assert!(router.finish().reached("prompt"));
+assert_eq!(prompt.text(), "secret");
+assert!(composer.text().is_empty());
+```
+
+## Mouse
+
+The pointer still resolves by geometry through
+[`HitMap`](https://docs.rs/tuika/latest/tuika/mouse/struct.HitMap.html): keys
+route by ownership, the pointer routes by position. A host that wants a click to
+move focus resolves the id from the hit map, calls `FocusRegistry::focus`, and
+routes from there.
+
+## See also
+
+- [Keymap](keymap.md) — turning key presses into named commands, which a `pre_fn`
+  or `fallback_fn` stage dispatches.
+- [`examples/codex`](https://github.com/everruns/tuika/tree/v0.10.0/examples/codex) —
+  a full host: a modal, a picker, a composer, and a transcript on one route.

--- a/docs/showcases.md
+++ b/docs/showcases.md
@@ -2,7 +2,7 @@
 title: Showcases
 description: See applications and full terminal interfaces built with tuika, including yolop, LLMSim, and the Codex UI replica.
 sidebar:
-  order: 10
+  order: 11
 ---
 
 # Showcases

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -2,7 +2,7 @@
 title: Styling
 description: Style tuika by semantic role with themes, stylesheets, reusable bundles, and host-level policy.
 sidebar:
-  order: 6
+  order: 7
 ---
 
 # Styling

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -2,7 +2,7 @@
 title: Themes
 description: Use tuika's bundled terminal palettes, inherit terminal colors, or define a complete custom theme.
 sidebar:
-  order: 7
+  order: 8
 ---
 
 # Themes

--- a/examples/codex/app.rs
+++ b/examples/codex/app.rs
@@ -22,6 +22,12 @@ pub enum Flow {
     Quit,
 }
 
+/// What a global chord asked for, applied once the route is finished.
+enum Interrupt {
+    Requested,
+    Quit,
+}
+
 /// The slash commands the composer completes, in the order Codex lists them.
 pub const COMMANDS: &[(&str, &str)] = &[
     (
@@ -143,6 +149,8 @@ pub struct App {
     pub cells: Vec<Cell>,
     pub composer: TextInputState,
     pub scroll: ScrollState,
+    /// Which surface owns input this frame; the router reads it.
+    focus: FocusRegistry,
     pub agent: Agent,
     pub popup: Option<Popup>,
     pub approval: Option<Approval>,
@@ -178,6 +186,7 @@ impl App {
             cells: vec![banner],
             composer: TextInputState::new(),
             scroll: ScrollState::new(),
+            focus: FocusRegistry::new(),
             agent: Agent::new(),
             popup: None,
             approval: None,
@@ -250,8 +259,12 @@ impl App {
             .collect()
     }
 
-    /// Route one translated event. The order here *is* the focus model: modal
-    /// surfaces first, then the picker, then the composer.
+    /// Route one translated event.
+    ///
+    /// The order is declared once, for **every** event kind, by [`Router`]: the
+    /// interrupt chords, then the two surfaces that receive regardless of focus
+    /// (the transcript scrolls, the picker claims its own keys), then whichever
+    /// surface owns input this frame.
     pub fn handle(&mut self, event: &Event) -> Flow {
         let flow = self.route(event);
         if self.quit_requested {
@@ -260,42 +273,84 @@ impl App {
         flow
     }
 
+    /// Declare this frame's surfaces and which one owns input.
+    ///
+    /// A host whose modal is a real overlay gets this from
+    /// [`Scene::sync_focus`]; these modes are inline rows, so the app states
+    /// them itself. Either way it is one declaration, not a rule re-derived per
+    /// event kind.
+    fn sync_focus(&mut self) {
+        self.focus.begin_frame();
+        self.focus.register("composer");
+        // Only the approval prompt is *exclusive*. The picker takes precedence
+        // over the composer without owning it, so it routes as a declared
+        // exception below rather than as this frame's owner.
+        match self.approval.is_some() {
+            true => self.focus.set_owner("approval"),
+            false => self.focus.clear_owner(),
+        }
+    }
+
     fn route(&mut self, event: &Event) -> Flow {
-        if self.scrolling(event) {
-            let _ = self.scroll.handle(event, self.content_h, self.viewport_h);
-            return Flow::Continue;
-        }
-        let Event::Key(key) = event else {
-            return Flow::Continue;
-        };
+        self.sync_focus();
 
-        if key.ctrl && key.code == KeyCode::Char('c') {
-            return self.interrupt_or_quit();
-        }
-        if key.ctrl && key.code == KeyCode::Char('d') && self.composer.is_empty() {
-            return Flow::Quit;
-        }
-        if self.approval.is_some() {
-            self.handle_approval(event, *key);
-            return Flow::Continue;
-        }
-        if self.popup.is_some() && self.handle_popup(event, *key) {
-            return Flow::Continue;
-        }
-        if key.plain() && key.code == KeyCode::Esc {
-            if self.agent.interrupt() {
-                self.cells.push(interrupted_notice());
-                self.follow();
+        let mut interrupt = None;
+        let mut router = Router::new(&self.focus, event);
+        // Interrupt and quit outrank whatever owns input.
+        router.pre_fn(|event| {
+            let Event::Key(key) = event else {
+                return InputOutcome::Ignored;
+            };
+            if key.ctrl && key.code == KeyCode::Char('c') {
+                interrupt = Some(Interrupt::Requested);
+                return InputOutcome::Cancelled;
             }
-            return Flow::Continue;
+            if key.ctrl && key.code == KeyCode::Char('d') && self.composer.is_empty() {
+                interrupt = Some(Interrupt::Quit);
+                return InputOutcome::Cancelled;
+            }
+            InputOutcome::Ignored
+        });
+        // The transcript pages and scrolls whether or not it holds focus, and
+        // the picker claims its navigation keys before the composer types them.
+        router.always_fn("transcript", |event| {
+            self.scroll.handle(event, self.content_h, self.viewport_h)
+        });
+        router.always_fn("popup", |event| self.handle_popup(event));
+        router.target_fn("approval", |event| self.handle_approval(event));
+        router.target_fn("composer", |event| self.handle_composer(event));
+        router.finish();
+
+        // Stages decide; the host applies afterwards, so a stage closure never
+        // needs a borrow of the whole application while the route is running.
+        match interrupt {
+            Some(Interrupt::Requested) => self.interrupt_or_quit(),
+            Some(Interrupt::Quit) => Flow::Quit,
+            None => Flow::Continue,
         }
-        // `Up` on an empty composer recalls the previous prompt, as in Codex.
-        if key.plain() && key.code == KeyCode::Up && self.composer.is_empty() {
-            self.recall();
-            return Flow::Continue;
+    }
+
+    /// The composer's own keys: interrupt, prompt recall, then editing.
+    fn handle_composer(&mut self, event: &Event) -> InputOutcome {
+        if let Event::Key(key) = event
+            && key.plain()
+        {
+            if key.code == KeyCode::Esc {
+                if self.agent.interrupt() {
+                    self.cells.push(interrupted_notice());
+                    self.follow();
+                }
+                return InputOutcome::Cancelled;
+            }
+            // `Up` on an empty composer recalls the previous prompt, as in Codex.
+            if key.code == KeyCode::Up && self.composer.is_empty() {
+                self.recall();
+                return InputOutcome::Changed;
+            }
         }
 
-        match self.composer.handle(event) {
+        let outcome = self.composer.handle(event);
+        match outcome {
             InputOutcome::Submitted => {
                 let text = self.composer.text().trim().to_string();
                 self.composer.clear();
@@ -307,16 +362,7 @@ impl App {
             }
             _ => self.sync_popup(),
         }
-        Flow::Continue
-    }
-
-    /// Events that belong to the transcript rather than to any focused surface.
-    fn scrolling(&self, event: &Event) -> bool {
-        match event {
-            Event::Mouse(m) => matches!(m.kind, MouseKind::ScrollUp | MouseKind::ScrollDown),
-            Event::Key(k) => k.plain() && matches!(k.code, KeyCode::PageUp | KeyCode::PageDown),
-            _ => false,
-        }
+        outcome
     }
 
     fn interrupt_or_quit(&mut self) -> Flow {
@@ -332,22 +378,33 @@ impl App {
         Flow::Quit
     }
 
-    fn handle_approval(&mut self, event: &Event, key: Key) {
+    fn handle_approval(&mut self, event: &Event) -> InputOutcome {
         let Some(approval) = &mut self.approval else {
-            return;
+            return InputOutcome::Ignored;
         };
         // Codex accepts the digit shortcuts as well as the caret.
-        let picked = match key.code {
-            KeyCode::Char('1') if key.plain() => Some(0),
-            KeyCode::Char('2') if key.plain() => Some(1),
-            KeyCode::Char('3') if key.plain() => Some(2),
-            _ => match approval.state.handle(event, 3) {
+        let digit = match event {
+            Event::Key(key) if key.plain() => match key.code {
+                KeyCode::Char('1') => Some(0),
+                KeyCode::Char('2') => Some(1),
+                KeyCode::Char('3') => Some(2),
+                _ => None,
+            },
+            _ => None,
+        };
+        let picked = match digit {
+            Some(index) => Some(index),
+            None => match approval.state.handle(event, 3) {
                 InputOutcome::Submitted => approval.state.selected(),
                 InputOutcome::Cancelled => Some(2),
+                // A modal answers for everything it is shown for: nothing
+                // behind it may act on the same event.
                 _ => None,
             },
         };
-        let Some(index) = picked else { return };
+        let Some(index) = picked else {
+            return InputOutcome::Consumed;
+        };
         let decision = match index {
             0 => Decision::Once,
             1 => Decision::Session,
@@ -356,20 +413,29 @@ impl App {
         self.approval = None;
         self.agent.approve(decision, &mut self.cells);
         self.follow();
+        InputOutcome::Submitted
     }
 
-    /// Returns true when the popup consumed the event.
-    fn handle_popup(&mut self, event: &Event, key: Key) -> bool {
+    /// The picker's keys. Anything it does not recognize keeps flowing, so
+    /// typing continues to filter the list in the composer behind it.
+    fn handle_popup(&mut self, event: &Event) -> InputOutcome {
+        // A declared exception still yields to an exclusive owner.
+        if self.approval.is_some() {
+            return InputOutcome::Ignored;
+        }
         let items = self.popup_items();
         let Some(popup) = self.popup.as_mut() else {
-            return false;
+            return InputOutcome::Ignored;
         };
         let is_token = matches!(popup, Popup::Token { .. });
         let state = match popup {
             Popup::Token { state, .. } | Popup::Model(state) | Popup::Approvals(state) => state,
         };
         // Tab completes the highlighted row in place, without running it.
-        if key.plain() && key.code == KeyCode::Tab {
+        if let Event::Key(key) = event
+            && key.plain()
+            && key.code == KeyCode::Tab
+        {
             let completion = state
                 .selected()
                 .and_then(|selected| items.get(selected))
@@ -377,7 +443,7 @@ impl App {
             if is_token && let Some(label) = completion {
                 self.complete(&label);
             }
-            return true;
+            return InputOutcome::Changed;
         }
         match state.handle(event, items.len()) {
             InputOutcome::Submitted => {
@@ -388,13 +454,13 @@ impl App {
                 if let (Some(label), Some(kind)) = (label, self.popup.take()) {
                     self.confirm_popup(kind, &label);
                 }
-                true
+                InputOutcome::Submitted
             }
             InputOutcome::Cancelled => {
                 self.popup = None;
-                true
+                InputOutcome::Cancelled
             }
-            outcome => outcome.consumed(),
+            outcome => outcome,
         }
     }
 

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -47,6 +47,7 @@ the reason for a decision is cheapest to write down while it is still at hand.
 - [Images](specs/images.md) — terminal graphics protocols over reserved cells.
 - [Adaptive charts](specs/charts.md) — portable chart grammar and graphics/cell rendering parity in `tuika-charts`.
 - [Keymap](specs/keymap.md) — declarative key-binding dispatch.
+- [Input routing](specs/input-routing.md) — which surface receives an event, and why delivery is a toolkit concern.
 - [Styling](specs/styling.md) — themes as tokens, stylesheets as rules.
 - [Screen modes](specs/screen-modes.md) — the alternate screen, and a split footer over live scrollback.
 - [Out-of-band escapes](specs/out-of-band.md) — hyperlinks, clipboard, and native progress.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,20 @@
 # Knowledge Log
 
+## 2026-08-19
+
+- **Delivering an event is toolkit policy, not host glue**
+  - The registry knowing who owns input, and the owner's state receiving the
+    event, were separated by host code written per surface *and per event kind*.
+    Two paths for two kinds is how a paste reached the composer behind an open
+    prompt while the key path honored the overlay.
+  - Routing therefore joins layout, focus, and painting: one registration per
+    surface covers every `Event` variant, and reaching a surface that does not
+    own input is a named exception rather than an omitted check.
+  - The router reads the focus registry instead of holding it, so stage closures
+    can still take `&mut` on the host. An API that forced `Rc<RefCell<_>>` on
+    host state would not have been adopted, and an unadopted route is the same
+    hole under a new name.
+
 ## 2026-08-16
 
 - **A chart's geometry is resolved once, before either renderer runs**

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -26,7 +26,7 @@ Four levels, each with one job:
 
 | Level | Owns | Test for belonging |
 | --- | --- | --- |
-| crate root | the framework spine: `View`/`view_fn`/`Element`/`ScopedElement`/`RenderCtx`, `Application`/`AsyncApplication`, owned or scoped scene composition, layout and responsive dock geometry, events, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host boundary, runners | a host touches it on essentially every frame |
+| crate root | the framework spine: `View`/`view_fn`/`Element`/`ScopedElement`/`RenderCtx`, `Application`/`AsyncApplication`, owned or scoped scene composition, layout and responsive dock geometry, events and their routing, `Theme`/`StyleSheet`/`StyleRole`/`StyleResolver`, `Surface`, host boundary, runners | a host touches it on essentially every frame |
 | `components` | every widget | it implements `View` |
 | `term` | escapes outside the cell grid: clipboard, hyperlink, progress, pointer, image, capabilities | it talks to the terminal, not to the buffer |
 | `screen` | which part of the terminal a frame owns, and publishing above a split footer | it decides or manipulates the reserved region |

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -275,6 +275,12 @@ or routes focus. A focused id absent from that ring falls back immediately to
 its first registration; the next frame boundary commits that fallback, so a
 temporarily removed id cannot steal focus if it later returns.
 
+Focus ownership only *decides* the input target; delivering the event to that
+target is [input routing](input-routing.md), which is toolkit-owned for the same
+reason. A host that re-derives delivery per event kind eventually derives it
+differently for one of them, which is how a paste reaches the surface behind an
+open modal.
+
 Text-input positions exposed to hosts remain char indices, matching token and
 highlight spans. Editing nevertheless moves and deletes by grapheme boundary,
 and soft-wrap plus cursor placement use grapheme display width in terminal

--- a/knowledge/specs/input-routing.md
+++ b/knowledge/specs/input-routing.md
@@ -1,0 +1,85 @@
+---
+type: Product Specification
+title: Input routing
+description: Defines how a frame's focus and overlay ownership decide which surface receives an event, and why delivery is a toolkit concern rather than host code.
+---
+
+# Input routing
+
+## Why
+
+tuika already models everything routing needs and stops one step short of it.
+`FocusRegistry` records the base focus ring and an overlay's exclusive input
+ownership; `Scene::sync_focus` resolves overlay z-order into that owner;
+component states consume an `Event` and answer an `InputOutcome`. The step from
+"the registry knows the overlay owns input" to "the overlay's state receives
+this event" was host code — written once per host, per event kind, per surface.
+
+That gap has a characteristic failure. Keys travel one host function and pastes
+another; only the key path knows about a newly added overlay; a paste therefore
+reaches the surface *behind* an open modal. It is not a bug in ownership, focus,
+or the overlay — each was correct — but in the route, which existed twice. The
+same shape recurs for any second event kind, and it pushes hosts toward
+hand-rolled fields, because adopting a tuika input state buys nothing while
+delivery is still hand-written.
+
+Delivery is therefore a toolkit concern, on the same grounds as layout, focus,
+and painting: given a frame's ownership state, tuika decides which state
+receives an event.
+
+## What routing owns
+
+- **Ownership gates delivery.** The active surface — the overlay owner if there
+  is one, else the focus ring's holder — is the only one a `target` stage
+  reaches. `set_owner` stops being advisory for a host that routes.
+- **One route for every event kind.** A stage receives the whole `Event`, so a
+  new variant cannot create a per-host hole.
+- **Precedence is declared, not re-derived.** It comes from the registry a scene
+  already synchronized; the host names surfaces, not an ordering rule per event.
+- **Global chords compose with routing.** A chord that must outrank the active
+  surface, and one that only runs when nothing claimed the event, are distinct
+  declared stages rather than positions in an `if` chain.
+- **Fallthrough is explicit.** A `Delivery` names the receiver, the stage, and
+  the outcome — including "nothing received this", the state that hides a hole.
+- **It is testable without a terminal**, the way layout is.
+
+## Boundaries
+
+- Routing learns no host modes. Which surfaces exist, what owns input, and what
+  a surface then does stay in the host; the toolkit resolves delivery only.
+- It is not a retained widget tree with view-level bubbling. Stages are a flat,
+  ordered list a host writes per update, and views remain ephemeral.
+- The runner boundary is unchanged: routing happens inside `Application::update`
+  and needs no signal, capability, or callback from the loop.
+- A surface reachable while it does *not* own input is a declared exception
+  (`always`), not an implicit one. Making the exception nameable is what keeps
+  ownership meaningful; a transcript that scrolls under a modal, or a picker
+  that claims its navigation keys and leaves typing to the input beneath it, are
+  the cases that earn it. Such a surface refuses first, so it can take the narrow
+  set of events it exists for without swallowing the rest.
+- The pointer keeps resolving by geometry through `HitMap`. Keys route by
+  ownership and the pointer by position; a host that wants a click to change
+  focus resolves the id and calls `FocusRegistry::focus`, which keeps one
+  meaning per mechanism.
+
+## Design consequences
+
+The router reads the registry at construction and does not hold it, so a stage
+closure may take `&mut` on the same host struct the registry lives on. That is
+what keeps host state in plain fields instead of `Rc<RefCell<_>>` — the property
+that decides whether a routing API is adoptable at all.
+
+Stages run eagerly and in a fixed order (global, declared exceptions, the active
+surface, then last-chance globals); calling them out of order is a host bug and
+trips a debug assertion rather than silently reordering precedence.
+
+A stage decides; the host applies afterwards. Quitting, submitting, or opening
+another surface from inside a stage would require a borrow of the whole
+application mid-route, so the recommended shape is a stage that records intent
+and a host that acts on it once the route is finished.
+
+## Related
+
+- [Architecture](architecture.md) — focus registry, overlays, and the host boundary.
+- [Keymap](keymap.md) — what a global stage dispatches.
+- [Public API surface](api-surface.md) — why `routing` sits on the crate root.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@
 //! - **Scene composition** is owned with [`Scene`], or borrows a host-state view
 //!   for one frame with [`ScopedScene`]; both use the same ordered overlay and
 //!   focus semantics.
+//! - **Input routing** ([`routing`]) delivers an event to whichever surface owns
+//!   input this frame, every event kind through one registration.
 //!
 //! # Finding things
 //!
@@ -98,6 +100,7 @@ mod output;
 pub mod overlay;
 pub mod prelude;
 pub mod probe;
+pub mod routing;
 pub mod runner;
 pub mod scene;
 pub mod screen;
@@ -139,6 +142,7 @@ pub use layout::{
 };
 pub use output::{OneShotOptions, render_once, write_once};
 pub use overlay::{Overlay, OverlaySpec, TargetAlign, TargetPlacement, TargetSide};
+pub use routing::{Delivery, InputTarget, RouteStage, Router};
 #[cfg(feature = "async")]
 #[allow(deprecated)]
 pub use runner::AsyncSignal;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,16 +41,16 @@ pub use crate::ui::{Color, Line, Modifier, Rect, Span, Style};
 // `$crate::…` paths, so a glob-importing host needs neither in scope by name.
 pub use crate::view;
 pub use crate::{
-    Align, AlignContent, Application, AvailableSpace, Backdrop, Clock, Dimension, Direction,
-    DockEdge, DockLayout, DockPlacement, DockSpec, DockState, Element, Event, EventFlow,
-    EventSource, FlexItemStyle, FlexWrap, FrameSource, InputOutcome, Justify, Key, KeyCode,
-    LayoutStyle, MeasureRequest, Mouse, MouseButton, MouseCapture, MouseKind, OneShotOptions,
-    Overlay, OverlaySpec, Padding, RenderCtx, Runner, RunnerAction, RunnerConfig, RunnerCore,
-    Scene, SceneOverlay, ScopedElement, ScopedScene, ScreenMode, Scrollback, SemanticRole, Signal,
-    Size, StyleSheet, Surface, SystemClock, TargetAlign, TargetPlacement, TargetSide,
-    TerminalSession, TerminalSessionConfig, Theme, UpdateResult, View, element, from_fn, paint,
-    paint_scene, paint_with_context, paint_with_sheet, render_once, translate_event, view_fn,
-    write_once,
+    Align, AlignContent, Application, AvailableSpace, Backdrop, Clock, Delivery, Dimension,
+    Direction, DockEdge, DockLayout, DockPlacement, DockSpec, DockState, Element, Event, EventFlow,
+    EventSource, FlexItemStyle, FlexWrap, FrameSource, InputOutcome, InputTarget, Justify, Key,
+    KeyCode, LayoutStyle, MeasureRequest, Mouse, MouseButton, MouseCapture, MouseKind,
+    OneShotOptions, Overlay, OverlaySpec, Padding, RenderCtx, RouteStage, Router, Runner,
+    RunnerAction, RunnerConfig, RunnerCore, Scene, SceneOverlay, ScopedElement, ScopedScene,
+    ScreenMode, Scrollback, SemanticRole, Signal, Size, StyleSheet, Surface, SystemClock,
+    TargetAlign, TargetPlacement, TargetSide, TerminalSession, TerminalSessionConfig, Theme,
+    UpdateResult, View, element, from_fn, paint, paint_scene, paint_with_context, paint_with_sheet,
+    render_once, translate_event, view_fn, write_once,
 };
 
 #[cfg(feature = "async")]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,565 @@
+//! Input routing: turn the frame's focus and overlay ownership into delivery.
+//!
+//! [`FocusRegistry`] already answers *who is active* — an overlay owner beats
+//! the base focus ring, and [`Scene::sync_focus`](crate::scene::Scene::sync_focus)
+//! already resolves overlay z-order into that owner. What was missing is the
+//! step after it: handing the event to that surface's state. Written by hand,
+//! that step is one `if focus.is_active(id)` per surface **per event kind**, and
+//! a second event kind added later silently skips the check — a paste reaching
+//! the composer behind an open prompt, for instance.
+//!
+//! [`Router`] is that step, as a value scoped to one `update` call:
+//!
+//! - **Ownership gates delivery.** [`target`](Router::target) delivers only to
+//!   the [`active`](FocusRegistry::active) surface. Reaching a surface that is
+//!   *not* active is [`always`](Router::always) — explicit and greppable.
+//! - **One route for every event kind.** Stages take the whole [`Event`], so a
+//!   new variant reaches every registered surface without a host edit.
+//! - **Precedence is declared, not re-derived.** Ownership comes from the
+//!   registry the scene already synchronized; stages run in one fixed order.
+//! - **Global chords compose.** [`pre_fn`](Router::pre_fn) wins over the active
+//!   surface, [`fallback_fn`](Router::fallback_fn) runs only if nothing consumed
+//!   the event — instead of a chord's position in an `if` chain.
+//! - **Fallthrough is observable.** [`Delivery`] reports which surface received
+//!   the event, at which [`RouteStage`], and what it answered.
+//!
+//! # Stages
+//!
+//! Stages are applied eagerly, in call order, and each is skipped once the event
+//! has been consumed. Calls must follow the canonical order below; a host that
+//! calls them out of order trips a debug assertion.
+//!
+//! | Order | RouteStage | Reaches |
+//! |---|---|---|
+//! | 1 | [`RouteStage::Pre`] | global chords, before any surface |
+//! | 2 | [`RouteStage::Always`] | a named surface regardless of focus |
+//! | 3 | [`RouteStage::Target`] | the active surface only |
+//! | 4 | [`RouteStage::Fallback`] | global chords, only if nothing consumed |
+//!
+//! # Example
+//!
+//! An overlay owns input, so the composer behind it never sees the paste:
+//!
+//! ```
+//! use tuika::prelude::*;
+//! use tuika::routing::{Router, RouteStage};
+//!
+//! let mut composer = SingleLineInputState::new();
+//! let mut prompt = SingleLineInputState::new();
+//!
+//! let mut focus = FocusRegistry::new();
+//! focus.begin_frame();
+//! focus.register("composer");
+//! focus.set_owner("prompt"); // what `Scene::sync_focus` does for an overlay.
+//!
+//! let event = Event::Paste("hunter2".into());
+//! let mut router = Router::new(&focus, &event);
+//! router.target("prompt", &mut prompt);
+//! router.target("composer", &mut composer);
+//! let delivery = router.finish();
+//!
+//! assert_eq!(delivery.target, Some("prompt"));
+//! assert_eq!(delivery.stage, RouteStage::Target);
+//! assert_eq!(prompt.text(), "hunter2");
+//! assert!(composer.text().is_empty());
+//! ```
+//!
+//! Mouse events still resolve by geometry through
+//! [`HitMap`](crate::mouse::HitMap): keys route by ownership, the pointer routes
+//! by position, and a host that wants both feeds the resolved id into
+//! [`FocusRegistry::focus`] before routing.
+
+use crate::event::{Event, InputOutcome};
+use crate::focus::FocusRegistry;
+
+/// Which stage of the route delivered an event.
+///
+/// Ordered: stages must be called in this order, which is also how they are
+/// compared.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RouteStage {
+    /// A global handler that runs before any surface.
+    Pre,
+    /// A surface reached regardless of focus.
+    Always,
+    /// The surface that owns input this frame.
+    Target,
+    /// A global handler that runs only when nothing consumed the event.
+    Fallback,
+    /// Nothing received the event.
+    Undelivered,
+}
+
+/// What a route did with one event.
+///
+/// `target` and `stage` describe the last surface or handler the event was
+/// *delivered* to, whether or not it recognized the event; `outcome` is what
+/// that receiver answered. [`RouteStage::Undelivered`] with `target: None` means the
+/// event reached nothing at all — the state a host wants to log rather than
+/// silently drop.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Delivery<'a> {
+    /// The id of the last receiver, if it had one. Global stages have none.
+    pub target: Option<&'a str>,
+    /// The stage that delivered the event.
+    pub stage: RouteStage,
+    /// What the receiver answered.
+    pub outcome: InputOutcome,
+}
+
+impl Delivery<'_> {
+    /// Whether some receiver consumed the event.
+    pub fn consumed(&self) -> bool {
+        self.outcome.consumed()
+    }
+
+    /// Whether `id` received the event.
+    pub fn reached(&self, id: &str) -> bool {
+        self.target == Some(id)
+    }
+}
+
+/// Host state that can receive a routed event.
+///
+/// Implemented for tuika's own single-`Event` input states. A state whose
+/// `handle` needs frame context (a scroll extent, a viewport height) or a host
+/// type that is not a tuika state routes through the `*_fn` stages instead, so
+/// adopting the router never requires rewriting a surface first.
+pub trait InputTarget {
+    /// Handle one event, reporting whether it was recognized.
+    fn handle(&mut self, event: &Event) -> InputOutcome;
+}
+
+macro_rules! impl_input_target {
+    ($($ty:path),* $(,)?) => {
+        $(impl InputTarget for $ty {
+            fn handle(&mut self, event: &Event) -> InputOutcome {
+                <$ty>::handle(self, event)
+            }
+        })*
+    };
+}
+
+impl_input_target!(
+    crate::components::CompletionState,
+    crate::components::ConfirmDialogState,
+    crate::components::InputDialogState,
+    crate::components::SingleLineInputState,
+    crate::components::SliderState,
+    crate::components::TextInputState,
+);
+
+impl<T: InputTarget + ?Sized> InputTarget for &mut T {
+    fn handle(&mut self, event: &Event) -> InputOutcome {
+        (**self).handle(event)
+    }
+}
+
+/// Routes one event through the frame's focus state.
+///
+/// Built per `update` call: it reads the [`FocusRegistry`] once, then borrows
+/// each surface's state in turn — so a host keeps its state in plain fields
+/// instead of `Rc<RefCell<_>>`, and a stage closure is free to take `&mut self`.
+/// See the [module docs](self) for the model.
+pub struct Router<'a, 'e> {
+    /// The active id, copied at construction so the registry borrow ends there
+    /// and a stage closure may take `&mut self` on the host.
+    active: Option<String>,
+    event: &'e Event,
+    delivery: Delivery<'a>,
+    last_stage: RouteStage,
+}
+
+impl<'a, 'e> Router<'a, 'e> {
+    /// Start routing `event` against the frame's focus state.
+    ///
+    /// The registry is read here and not held, so `focus` may live on the same
+    /// host struct a stage closure then mutates.
+    pub fn new(focus: &FocusRegistry, event: &'e Event) -> Self {
+        Self {
+            active: focus.active().map(str::to_owned),
+            event,
+            delivery: Delivery {
+                target: None,
+                stage: RouteStage::Undelivered,
+                outcome: InputOutcome::Ignored,
+            },
+            last_stage: RouteStage::Pre,
+        }
+    }
+
+    /// The event being routed, for a stage closure that needs it.
+    pub fn event(&self) -> &'e Event {
+        self.event
+    }
+
+    /// What the route has done so far.
+    pub fn delivery(&self) -> Delivery<'a> {
+        self.delivery
+    }
+
+    /// Finish the route and report what happened.
+    pub fn finish(self) -> Delivery<'a> {
+        self.delivery
+    }
+
+    /// A global handler that sees the event before any surface — an interrupt
+    /// or quit chord that must win over whatever owns input.
+    ///
+    /// ```
+    /// use tuika::prelude::*;
+    /// use tuika::keymap::{Dispatch, Keymap, Layer};
+    /// use tuika::routing::{Router, RouteStage};
+    ///
+    /// #[derive(Clone, Debug, PartialEq)]
+    /// enum Action { Quit }
+    ///
+    /// let mut keys = Keymap::new().layer(Layer::new("global").bind("ctrl+d", Action::Quit));
+    /// let mut focus = FocusRegistry::new();
+    /// focus.begin_frame();
+    /// focus.register("composer");
+    /// let mut composer = SingleLineInputState::new();
+    ///
+    /// let event = Event::Key(Key { code: KeyCode::Char('d'), ctrl: true, alt: false, shift: false });
+    /// let mut command = None;
+    /// let mut router = Router::new(&focus, &event);
+    /// router.pre_fn(|event| match event {
+    ///     Event::Key(key) => match keys.dispatch(*key) {
+    ///         Dispatch::Command(action) => {
+    ///             command = Some(action);
+    ///             InputOutcome::Submitted
+    ///         }
+    ///         _ => InputOutcome::Ignored,
+    ///     },
+    ///     _ => InputOutcome::Ignored,
+    /// });
+    /// router.target("composer", &mut composer);
+    ///
+    /// assert_eq!(command, Some(Action::Quit));
+    /// assert_eq!(router.finish().stage, RouteStage::Pre);
+    /// assert!(composer.text().is_empty());
+    /// ```
+    pub fn pre_fn(&mut self, handler: impl FnOnce(&Event) -> InputOutcome) -> &mut Self {
+        self.stage_fn(RouteStage::Pre, None, handler)
+    }
+
+    /// Deliver to `id` when it is the frame's active surface.
+    pub fn target(&mut self, id: &'a str, target: &mut impl InputTarget) -> &mut Self {
+        self.target_fn(id, |event| target.handle(event))
+    }
+
+    /// Deliver to `id` when it is active, through a closure — for a state whose
+    /// `handle` needs frame context, or a host type that is not a tuika state.
+    pub fn target_fn(
+        &mut self,
+        id: &'a str,
+        handler: impl FnOnce(&Event) -> InputOutcome,
+    ) -> &mut Self {
+        if self.active.as_deref() != Some(id) {
+            self.enter(RouteStage::Target);
+            return self;
+        }
+        self.stage_fn(RouteStage::Target, Some(id), handler)
+    }
+
+    /// Deliver to `id` whether or not it is active — a transcript that scrolls
+    /// while a dialog owns the keyboard, or a picker that takes precedence over
+    /// the input under it without owning input outright.
+    ///
+    /// This is the deliberate hole in ownership: name it, so it is greppable
+    /// rather than implied by an event kind that forgot to check focus. Such a
+    /// surface gets its refusal *before* the active one, so it can claim the
+    /// narrow set of events it exists for and leave the rest.
+    pub fn always(&mut self, id: &'a str, target: &mut impl InputTarget) -> &mut Self {
+        self.always_fn(id, |event| target.handle(event))
+    }
+
+    /// [`always`](Self::always) through a closure.
+    pub fn always_fn(
+        &mut self,
+        id: &'a str,
+        handler: impl FnOnce(&Event) -> InputOutcome,
+    ) -> &mut Self {
+        self.stage_fn(RouteStage::Always, Some(id), handler)
+    }
+
+    /// A global handler that runs only when nothing consumed the event.
+    pub fn fallback_fn(&mut self, handler: impl FnOnce(&Event) -> InputOutcome) -> &mut Self {
+        self.stage_fn(RouteStage::Fallback, None, handler)
+    }
+
+    fn stage_fn(
+        &mut self,
+        stage: RouteStage,
+        id: Option<&'a str>,
+        handler: impl FnOnce(&Event) -> InputOutcome,
+    ) -> &mut Self {
+        self.enter(stage);
+        if self.delivery.consumed() {
+            return self;
+        }
+        let outcome = handler(self.event);
+        // A global stage that ignored the event delivered nothing, so it must
+        // not mask a later `Undelivered`; a named surface did receive it.
+        if id.is_some() || outcome.consumed() {
+            self.delivery = Delivery {
+                target: id,
+                stage,
+                outcome,
+            };
+        }
+        self
+    }
+
+    fn enter(&mut self, stage: RouteStage) {
+        debug_assert!(
+            stage >= self.last_stage,
+            "routing stages run in order: {:?} was called after {:?}",
+            stage,
+            self.last_stage
+        );
+        self.last_stage = stage;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::components::SingleLineInputState;
+    use crate::event::{Key, KeyCode};
+
+    fn frame(ids: &[&str]) -> FocusRegistry {
+        let mut focus = FocusRegistry::new();
+        focus.begin_frame();
+        for id in ids {
+            focus.register(*id);
+        }
+        focus
+    }
+
+    fn paste(text: &str) -> Event {
+        Event::Paste(text.to_string())
+    }
+
+    fn ctrl(ch: char) -> Event {
+        Event::Key(Key {
+            code: KeyCode::Char(ch),
+            ctrl: true,
+            alt: false,
+            shift: false,
+        })
+    }
+
+    /// The yolop incident: an extension prompt owns input, and both a paste and
+    /// the paste chord must reach it rather than the composer behind it.
+    #[test]
+    fn overlay_owner_receives_every_event_kind() {
+        for event in [
+            paste("hunter2"),
+            ctrl('v'),
+            Event::Key(Key::new(KeyCode::Char('x'))),
+        ] {
+            let mut composer = SingleLineInputState::new();
+            let mut prompt = SingleLineInputState::new();
+            let mut focus = frame(&["composer"]);
+            focus.set_owner("prompt");
+
+            let mut router = Router::new(&focus, &event);
+            router.target("prompt", &mut prompt);
+            router.target("composer", &mut composer);
+            let delivery = router.finish();
+
+            assert_eq!(delivery.target, Some("prompt"), "{event:?}");
+            assert_eq!(delivery.stage, RouteStage::Target, "{event:?}");
+            assert!(composer.text().is_empty(), "{event:?}");
+        }
+    }
+
+    #[test]
+    fn paste_reaches_the_owning_prompt_intact() {
+        let mut composer = SingleLineInputState::new();
+        let mut prompt = SingleLineInputState::new();
+        let mut focus = frame(&["composer"]);
+        focus.set_owner("prompt");
+
+        let event = paste("secret-token");
+        let mut router = Router::new(&focus, &event);
+        router.target("prompt", &mut prompt);
+        router.target("composer", &mut composer);
+        let delivery = router.finish();
+
+        assert!(delivery.consumed());
+        assert_eq!(delivery.outcome, InputOutcome::Changed);
+        assert_eq!(prompt.text(), "secret-token");
+        assert!(composer.text().is_empty());
+    }
+
+    #[test]
+    fn without_an_owner_the_focused_surface_receives() {
+        let mut composer = SingleLineInputState::new();
+        let mut prompt = SingleLineInputState::new();
+        let focus = frame(&["composer"]);
+
+        let event = paste("draft");
+        let mut router = Router::new(&focus, &event);
+        router.target("prompt", &mut prompt);
+        router.target("composer", &mut composer);
+
+        assert!(router.finish().reached("composer"));
+        assert_eq!(composer.text(), "draft");
+        assert!(prompt.text().is_empty());
+    }
+
+    #[test]
+    fn nothing_recognized_the_event_is_observable() {
+        let mut composer = SingleLineInputState::new();
+        let focus = frame(&["composer"]);
+
+        // A resize is routed like any other kind; no surface claims it.
+        let event = Event::Resize {
+            width: 10,
+            height: 4,
+        };
+        let mut router = Router::new(&focus, &event);
+        router.pre_fn(|_| InputOutcome::Ignored);
+        router.target("composer", &mut composer);
+        let delivery = router.finish();
+
+        assert!(!delivery.consumed());
+        assert_eq!(delivery.target, Some("composer"));
+        assert_eq!(delivery.stage, RouteStage::Target);
+    }
+
+    #[test]
+    fn an_unregistered_route_delivers_nothing() {
+        let focus = frame(&["composer"]);
+        let event = ctrl('v');
+        let mut router = Router::new(&focus, &event);
+        router.pre_fn(|_| InputOutcome::Ignored);
+        router.fallback_fn(|_| InputOutcome::Ignored);
+        let delivery = router.finish();
+
+        assert_eq!(delivery.target, None);
+        assert_eq!(delivery.stage, RouteStage::Undelivered);
+    }
+
+    #[test]
+    fn pre_stage_wins_over_the_owning_surface() {
+        let mut prompt = SingleLineInputState::new();
+        let mut focus = frame(&["composer"]);
+        focus.set_owner("prompt");
+
+        let event = ctrl('c');
+        let mut interrupted = false;
+        let mut router = Router::new(&focus, &event);
+        router.pre_fn(|_| {
+            interrupted = true;
+            InputOutcome::Cancelled
+        });
+        router.target("prompt", &mut prompt);
+        let delivery = router.finish();
+
+        assert!(interrupted);
+        assert_eq!(delivery.stage, RouteStage::Pre);
+        assert_eq!(delivery.target, None);
+        assert!(prompt.text().is_empty());
+    }
+
+    #[test]
+    fn fallback_runs_only_when_nothing_consumed() {
+        let mut composer = SingleLineInputState::new();
+        let focus = frame(&["composer"]);
+
+        // Consumed by the composer: the fallback never runs.
+        let typed = Event::Key(Key::new(KeyCode::Char('a')));
+        let mut fell_through = false;
+        let mut router = Router::new(&focus, &typed);
+        router.target("composer", &mut composer);
+        router.fallback_fn(|_| {
+            fell_through = true;
+            InputOutcome::Consumed
+        });
+        assert_eq!(router.finish().stage, RouteStage::Target);
+        assert!(!fell_through);
+
+        // Ignored by the composer: the fallback gets it.
+        let page = Event::Key(Key::new(KeyCode::PageDown));
+        let mut router = Router::new(&focus, &page);
+        router.target("composer", &mut composer);
+        router.fallback_fn(|_| {
+            fell_through = true;
+            InputOutcome::Consumed
+        });
+        assert_eq!(router.finish().stage, RouteStage::Fallback);
+        assert!(fell_through);
+    }
+
+    #[test]
+    fn always_reaches_a_surface_the_owner_left_inactive() {
+        let mut prompt = SingleLineInputState::new();
+        let mut focus = frame(&["transcript"]);
+        focus.set_owner("prompt");
+
+        let event = Event::Key(Key::new(KeyCode::PageDown));
+        let mut scrolled = false;
+        let mut router = Router::new(&focus, &event);
+        router.always_fn("transcript", |_| {
+            scrolled = true;
+            InputOutcome::Changed
+        });
+        router.target("prompt", &mut prompt);
+        let delivery = router.finish();
+
+        assert!(scrolled);
+        assert_eq!(delivery.target, Some("transcript"));
+        assert_eq!(delivery.stage, RouteStage::Always);
+    }
+
+    #[test]
+    fn a_consumed_event_stops_at_the_first_receiver() {
+        let mut first = SingleLineInputState::new();
+        let mut second = SingleLineInputState::new();
+        let focus = frame(&["first"]);
+
+        let event = paste("once");
+        let mut router = Router::new(&focus, &event);
+        router.always("second", &mut second);
+        router.target("first", &mut first);
+
+        assert!(router.finish().reached("second"));
+        assert_eq!(second.text(), "once");
+        assert!(first.text().is_empty());
+    }
+
+    /// A picker that takes precedence without owning input: it refuses first,
+    /// and what it does not claim still reaches the active surface.
+    #[test]
+    fn an_always_surface_that_ignores_leaves_the_active_one_its_event() {
+        let mut composer = SingleLineInputState::new();
+        let focus = frame(&["composer"]);
+
+        let typed = paste("filter");
+        let mut picker_saw = 0;
+        let mut router = Router::new(&focus, &typed);
+        router.always_fn("picker", |_| {
+            picker_saw += 1;
+            InputOutcome::Ignored
+        });
+        router.target("composer", &mut composer);
+        let delivery = router.finish();
+
+        assert_eq!(picker_saw, 1);
+        assert!(delivery.reached("composer"));
+        assert_eq!(composer.text(), "filter");
+    }
+
+    #[test]
+    #[should_panic(expected = "routing stages run in order")]
+    fn stages_called_out_of_order_are_a_bug() {
+        let focus = frame(&["composer"]);
+        let event = ctrl('v');
+        let mut router = Router::new(&focus, &event);
+        router.fallback_fn(|_| InputOutcome::Ignored);
+        router.pre_fn(|_| InputOutcome::Ignored);
+    }
+}

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -241,3 +241,63 @@ fn a_split_footer_composes_components_over_published_markdown() {
         "the published answer is the user's to keep: {after:?}"
     );
 }
+
+/// The path an overlay's input ownership actually takes: a scene declares the
+/// owner, the registry records it, and the router hands the event to that
+/// surface — for a paste as much as for a key.
+///
+/// This is the incident that motivated routing: a masked prompt was open, and a
+/// paste landed in the composer behind it because pastes travelled a different
+/// path from keys. Here both kinds reach the prompt, and the composer stays
+/// empty.
+#[test]
+fn an_overlay_that_owns_input_receives_pastes_and_keys_alike() {
+    use crate::components::{Dialog, SingleLineInputState};
+    use crate::event::{Event, Key, KeyCode};
+    use crate::focus::FocusRegistry;
+    use crate::routing::{RouteStage, Router};
+    use crate::scene::ScopedScene;
+
+    let mut composer = SingleLineInputState::new();
+    let mut prompt = SingleLineInputState::new();
+
+    // One frame: the base tree plus a dialog that claims input ownership.
+    let root = Text::raw("transcript");
+    let scene = ScopedScene::new(&root)
+        .dialog(Dialog::new("Token", element(Text::raw("paste it"))).focus_owner("prompt"));
+    let mut focus = FocusRegistry::new();
+    focus.begin_frame();
+    focus.register("composer");
+    scene.sync_focus(&mut focus);
+
+    for event in [
+        Event::Paste("sk-secret".to_string()),
+        Event::Key(Key {
+            code: KeyCode::Char('v'),
+            ctrl: true,
+            alt: false,
+            shift: false,
+        }),
+        Event::Key(Key::new(KeyCode::Char('s'))),
+    ] {
+        let mut router = Router::new(&focus, &event);
+        router.target("prompt", &mut prompt);
+        router.target("composer", &mut composer);
+        let delivery = router.finish();
+
+        assert_eq!(delivery.target, Some("prompt"), "{event:?}");
+        assert_eq!(delivery.stage, RouteStage::Target, "{event:?}");
+        assert!(composer.text().is_empty(), "{event:?}");
+    }
+
+    assert_eq!(prompt.text(), "sk-secrets");
+
+    // Closing the overlay hands input back to the base ring.
+    focus.clear_owner();
+    let typed = Event::Key(Key::new(KeyCode::Char('h')));
+    let mut router = Router::new(&focus, &typed);
+    router.target("prompt", &mut prompt);
+    router.target("composer", &mut composer);
+    assert!(router.finish().reached("composer"));
+    assert_eq!(composer.text(), "h");
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -498,3 +498,27 @@ fn the_non_prelude_surface_keeps_its_module_path() {
     let _: fn() -> std::io::Result<tuika::host::AltScreen> =
         tuika::host::AltScreen::enter_with_mouse_capture;
 }
+
+/// Routing is host surface: the prelude alone must be enough to declare a
+/// frame's ownership and deliver an event to the surface that owns it.
+#[test]
+fn the_prelude_routes_an_event_to_the_owning_surface() {
+    let mut composer = SingleLineInputState::new();
+    let mut prompt = SingleLineInputState::new();
+
+    let mut focus = FocusRegistry::new();
+    focus.begin_frame();
+    focus.register("composer");
+    focus.set_owner("prompt");
+
+    let event = Event::Paste("pasted".into());
+    let mut router = Router::new(&focus, &event);
+    router.target("prompt", &mut prompt);
+    router.target("composer", &mut composer);
+    let delivery: Delivery<'_> = router.finish();
+
+    assert_eq!(delivery.stage, RouteStage::Target);
+    assert!(delivery.reached("prompt"));
+    assert_eq!(prompt.text(), "pasted");
+    assert!(composer.text().is_empty());
+}


### PR DESCRIPTION
## What changed

tuika now owns **input routing**, the way it already owns layout, focus, and
painting. A host declares its surfaces once, and every `Event` kind follows the
same route to whichever surface owns input this frame.

New `routing` module (`Router`, `Delivery`, `RouteStage`, `InputTarget`, all
re-exported from the crate root and the prelude). A `Router` is built per
`update`, and stages run eagerly in a fixed order:

| Stage | Reaches | Typical use |
|---|---|---|
| `pre_fn` | everything, first | interrupt and quit chords |
| `always` / `always_fn` | a named surface, focused or not | a transcript that keeps scrolling; a picker that claims its navigation keys and leaves the rest |
| `target` / `target_fn` | the active surface only | the composer, the open dialog |
| `fallback_fn` | everything, last | navigation/help when nothing claimed the event |

- **Ownership gates delivery.** `target` reaches only `FocusRegistry::active` —
  the overlay owner if there is one, else the focus ring's holder. `set_owner`
  stops being advisory for a host that routes.
- **One route per event kind.** Stages take the whole `Event`, so a new variant
  cannot leave an older kind mis-pointed.
- **Reaching a non-active surface is explicit.** `always` is a named,
  greppable exception rather than an event kind that forgot to check focus.
  Such a surface refuses *first*, so it can claim the narrow set of events it
  exists for and leave the rest to the active one.
- **Fallthrough is observable.** `Delivery` names the receiver, the stage, and
  the outcome — including `RouteStage::Undelivered`, the event that reached
  nothing.
- **No `Rc<RefCell<_>>` tax.** `Router::new` reads the registry and does not
  hold it, so a stage closure may take `&mut` on the same host struct the
  registry lives on. Host state stays in plain fields.
- `InputTarget` is implemented for tuika's single-`Event` states
  (`TextInputState`, `SingleLineInputState`, `CompletionState`,
  `ConfirmDialogState`, `InputDialogState`, `SliderState`); the `*_fn` stages
  cover states needing frame context (`ScrollState`) and host types that are
  not tuika states, so adoption never requires rewriting a surface first.

`examples/codex` is converted as the proof: its modal, picker, composer, and
transcript now share one route instead of a hand-ordered `if` chain, and its
`scrolling()` special case is gone.

## Why

tuika had every ingredient and none of the assembly. `FocusRegistry` models
overlay input ownership, `Scene::sync_focus` resolves overlay z-order into an
owner, states answer `InputOutcome` — but the step from "the registry knows the
overlay owns input" to "the overlay's state receives this event" was host code,
written once per host, **per event kind**, per surface.

That gap has a characteristic failure, and it is what motivated this change. In
a host with an extension prompt open, keys went through one function and pastes
through another; only the key path knew about the overlay. Ctrl+V and bracketed
paste both put a pasted secret into the composer *behind* the prompt, where it
was still sitting when the prompt was dismissed. Ownership, focus, and the
overlay were all correct — the route existed twice. Left unfixed, every host
reimplements modal precedence, and each new `Event` variant is a fresh chance to
get one of those copies wrong.

## Before / After

**The incident, as a toolkit test** (`src/tests/integration.rs`): a scene
declares the overlay owner, the registry records it, and a paste, a Ctrl+V, and
a plain key all reach the prompt while the composer stays empty. Clearing the
owner hands input back to the base ring.

**Before** — the host's route, per event kind (`examples/codex/app.rs`):

```rust
if self.scrolling(event) { … return Flow::Continue; }
let Event::Key(key) = event else { return Flow::Continue };  // pastes end here
if key.ctrl && key.code == KeyCode::Char('c') { … }
if self.approval.is_some() { … }
if self.popup.is_some() && self.handle_popup(event, *key) { … }
match self.composer.handle(event) { … }
```

**After** — one route, all kinds:

```rust
let mut router = Router::new(&self.focus, event);
router.pre_fn(|event| { /* interrupt / quit */ });
router.always_fn("transcript", |event| self.scroll.handle(event, self.content_h, self.viewport_h));
router.always_fn("popup", |event| self.handle_popup(event));
router.target_fn("approval", |event| self.handle_approval(event));
router.target_fn("composer", |event| self.handle_composer(event));
router.finish();
```

**Real terminal** (`cargo run --example codex` under tmux, 100×34) — every stage
exercised live:

- typing reaches the composer; `PageUp` scrolls the transcript behind it
- `/` opens the picker, `↓` navigates it, `st` keeps filtering *through* it into
  the composer, `Esc` dismisses
- with the approval modal open, a bracketed paste (`ESC[200~sk-SECRET-TOKEN ESC[201~`)
  **and** Ctrl+V are both swallowed by the modal; after rejecting it the composer
  still shows its placeholder — the incident, no longer reproducible
- a normal bracketed paste with no modal open lands in the composer as expected
- Ctrl+C quits cleanly

## Risk

- Low / Medium
- Additive API; no existing item changed signature or behavior, so existing
  hosts are unaffected until they adopt `Router`. The behavioral surface at risk
  is the codex example, covered by its PTY smoke tests plus the manual sweep
  above.
- Out-of-order stage calls are a host bug and trip a `debug_assert` rather than
  silently reordering precedence — debug builds only, not reachable from event
  content.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation: `cargo fmt --all -- --check`, `cargo clippy --workspace
--all-targets --all-features -- -D warnings`, `cargo test --workspace
--all-features` (918 tests, includes the PTY smoke suite), `cargo run --example
demo -- check` (42 scenes in sync), `cargo +1.88 check -p tuika --all-targets`
(MSRV), plus the real-terminal sweep above.

New tests: 11 unit tests in `src/routing.rs` (ownership gating, every event kind
to the owner, stage precedence, fallthrough, `Undelivered`, out-of-order
stages), the cross-module incident test in `src/tests/integration.rs`, and a
prelude-level route in `tests/public_api.rs`.

## Knowledge

- Added `knowledge/specs/input-routing.md` — why delivery is a toolkit concern,
  what routing owns, and the boundaries it keeps (no host modes, no retained
  widget tree, unchanged runner boundary, pointer stays `HitMap`-driven).
- `knowledge/index.md` lists it; `knowledge/log.md` records the decision;
  `knowledge/specs/architecture.md` links focus ownership to routing;
  `knowledge/specs/api-surface.md` notes routing on the crate root.
- Public docs: new `docs/routing.md` (sidebar order 6, later guides shifted),
  README nav entry and feature bullet, CHANGELOG under Unreleased → Added.
- `scripts/validate_okf.py knowledge --check-links` passes (16 concepts, 0 errors).

## Security

Reviewed against the repository's threat-model categories:

- **TM-ESC** — no escape sequences are produced or forwarded; routing never
  touches the terminal.
- **TM-STATE** — no terminal lifecycle change (no enter/restore path touched).
- **TM-PARSE** — routing does not parse untrusted content. Event payloads are
  passed by reference to the same state handlers as before; the only allocation
  is a copy of the host-supplied active id (bounded by the host's own literal),
  once per routed event.
- **TM-CLIP** — no rendering or geometry change.
- **TM-DEP** — no new dependencies.

Panic surface: the stage-order `debug_assert` is a host-programming check,
unreachable from library input and compiled out in release.

## Follow-ups

- **Masked text input.** The incident's prompt was a masked secret field, and
  `TextInputState` still has no masking — so a host cannot yet adopt a tuika
  state for that surface. Deferred because it lands in the wrapping/cursor math
  (`visual_cursor`, `cursor_screen` must agree with the masked display width)
  and is orthogonal to routing.
- **Mouse through the router.** `Router::hits(&HitMap)` would deliver a mouse
  event to the id it resolves and report a hit *outside* an owning overlay as
  `Undelivered` — the signal a modal needs for click-outside dismissal. Deferred
  until `Scene` records the owner's resolved rect; keys route by ownership and
  the pointer by position in the meantime.
- **Adoption in hosts.** yolop's composer and reverse-history search still route
  by hand; migrating them is a host-side change, tracked there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiSrT3wzfyv12viSaJzrAe)_