### PR TITLE
perf!: make graphics encoders and tree-sitter grammars pay-for-use

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -203,12 +203,30 @@ crossterm = "0.29"
 [workspace]
 ```
 
-Use **two** probes, because they answer different questions:
+Use **two** probes for the root crate, because they answer different questions:
 
 - a *minimal* one (`examples/hello.rs` as `main.rs`) — the floor every
   `Runner` host pays, and where a feature that escaped DCE shows up
 - a *realistic* one (`examples/codex/` copied in) — where a full application's
   cost actually sits
+
+Then **one probe per companion crate** — `tuika-charts`, `tuika-codeformatters`,
+`tuika-html`, `tuika-mermaid` — each calling that crate's entry point once.
+This is not optional and not an afterthought: the companions carry the heavy
+dependencies by design, so they are where the megabytes are. Measuring only the
+root crate misses the question almost entirely. Current expected order of
+magnitude, for a host using each:
+
+| crate | host binary |
+|---|---:|
+| `tuika` alone | ~925 KiB |
+| `tuika-charts` | ~730 KiB |
+| `tuika-html` | ~1.7 MiB |
+| `tuika-mermaid` | ~5.5 MiB |
+| `tuika-codeformatters` (default) | ~24 MiB |
+| `tuika-codeformatters` (`rust`, `python`) | ~4.8 MiB |
+
+A member that grew a lot against these is the finding.
 
 Then:
 
@@ -229,6 +247,14 @@ nm -C target/release/sizeprobe | grep -E 'encode_sixel|png_rgba'
 nm -S -C target/release/sizeprobe | grep ' [tT] .*tuika' \
   | python3 -c 'import sys;print(sum(int(l.split()[1],16) for l in sys.stdin))'
 size -A target/release/sizeprobe | grep -E '^\.text|^\.rodata'
+```
+
+When a crate gains per-item cargo features, check the reduced builds too — the
+empty configuration is the one that rots:
+
+```bash
+cargo clippy -p <crate> --all-targets --no-default-features -- -D warnings
+cargo test  -p <crate> --no-default-features --features <one>
 ```
 
 Findings worth acting on:

--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -26,6 +26,7 @@ This skill is outcome-oriented. Choose the smallest set of actions that closes t
 - code simplification / removing over-abstraction and dead code
 - security hygiene review
 - performance review of recently changed code
+- binary-size review: what a host pays for linking tuika
 - AGENTS / skills hygiene
 
 ## Required Outcomes
@@ -170,6 +171,80 @@ the release schedule rather than slipping it into a cleanup PR. When a
 simplification is too large to land inline, defer it to a GitHub issue naming the
 abstraction and why it no longer pays its way.
 
+### Binary Size
+
+What a host binary pays for linking tuika. The standard is **pay-for-use**, not
+a byte target: a host that renders no markdown, places no image, and draws no
+chart should carry none of that code. See
+[Binary Size Discipline](../../../knowledge/processes/maintenance.md#binary-size-discipline)
+for why the reference graph, not the code size, is what decides this.
+
+Analyze with [`cargo-bsize`](https://github.com/Boshen/cargo-bsize)
+(`cargo install cargo-bsize`). It needs a **binary** target, and tuika is a
+library whose examples are not `[[bin]]`s, so point it at a throwaway host crate
+outside the repo that depends on tuika by path:
+
+```toml
+# /tmp/sizeprobe/Cargo.toml
+[package]
+name = "sizeprobe"
+version = "0.0.0"
+edition = "2024"
+
+[[bin]]
+name = "sizeprobe"
+path = "src/main.rs"
+
+[dependencies]
+tuika = { path = "/path/to/tuika" }
+ratatui = "0.30"
+crossterm = "0.29"
+
+[workspace]
+```
+
+Use **two** probes, because they answer different questions:
+
+- a *minimal* one (`examples/hello.rs` as `main.rs`) — the floor every
+  `Runner` host pays, and where a feature that escaped DCE shows up
+- a *realistic* one (`examples/codex/` copied in) — where a full application's
+  cost actually sits
+
+Then:
+
+```bash
+cargo bsize --limit 25                  # the report
+cargo bsize --what-if --levers all      # measure the build levers (slow)
+cargo bsize --baseline path/to/old.bin  # what grew since
+```
+
+Read the report for the pay-for-use question specifically: **Reference graph →
+Removing a function frees**, and any per-frame function that `match`es on a
+capability enum. Confirm a suspected win rather than assuming it:
+
+```bash
+# is the feature actually linked into a host that never uses it?
+nm -C target/release/sizeprobe | grep -E 'encode_sixel|png_rgba'
+# tuika's own code in that host, before and after
+nm -S -C target/release/sizeprobe | grep ' [tT] .*tuika' \
+  | python3 -c 'import sys;print(sum(int(l.split()[1],16) for l in sys.stdin))'
+size -A target/release/sizeprobe | grep -E '^\.text|^\.rodata'
+```
+
+Findings worth acting on:
+
+- an unconditional path that names an optional feature's code (fix the
+  reference, not the code size)
+- a dependency that reaches the binary despite being unused
+- a growth against a prior baseline that no change explains
+
+Findings **not** worth acting on:
+
+- absolute size, or tuika's share of it — hosts differ enormously
+- build-profile levers; those belong to the host's `[profile.release]`, and
+  `--what-if` numbers are for advising a host, not for changing tuika
+- a saving too small to survive codegen noise (compare `.text`, and re-measure)
+
 ### Security And Threat Posture
 
 tuika does no network or filesystem I/O, spawns no processes, and holds no
@@ -207,6 +282,7 @@ content does to it.
 - `cargo publish --dry-run -p tuika`
 - `cargo search ratatui-core --limit 1`
 - `cargo tree --duplicates`
+- `cargo bsize --limit 25` (against a probe host crate; see [Binary Size](#binary-size))
 - `cargo outdated` (when available)
 - `cargo audit` (when available)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ described in the release process begins with the entry below.
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **`tuika-codeformatters`**: every tree-sitter grammar now sits behind its own
+  cargo feature. All fourteen are **on by default**, so a dependant taking the
+  crate normally is unaffected. A dependant that already passes
+  `default-features = false` now gets no grammars until it names them:
+
+  ```toml
+  tuika-codeformatters = { version = "0.4", default-features = false, features = ["rust", "python"] }
+  ```
+
+  Feature names are the language keys lowercased without punctuation — `rust`,
+  `python`, `typescript` (covers TSX/JSX), `go`, `java`, `ruby`, `css`, `html`,
+  `csharp`, `php`, `zig`, `scala`, `sql`. A language whose feature is off
+  behaves exactly like one the crate never supported: `highlight` returns
+  `None` and the caller renders plain code.
+
+### Changed
+
+- **`tuika-codeformatters` binary size**: grammars are selected by a runtime
+  language string, so the config builder named all fourteen and anchored every
+  parse table into any binary that highlighted anything — roughly 21 MiB of
+  read-only data, C# alone about 5 MiB. Selecting grammars by feature lets a
+  host drop the ones it does not use: measured on a probe binary highlighting a
+  single snippet, the default build is ~24.0 MiB and a `rust` + `python` build
+  ~4.8 MiB. Highlighting output under default features is unchanged.
+- **Graphics protocol encoders are now pay-for-use.** `ImageLayer::emit` runs
+  after every frame in every `Runner` host and chose its encoder by matching on
+  `ImageSupport`, which linked the Kitty, iTerm2, and Sixel encoders plus the
+  PNG writer into every binary that used tuika at all. The encoder is now
+  resolved where an image is recorded — reachable only from the `Image` view —
+  so a host that places no images no longer carries any of them: about 8.4 KiB
+  less tuika code in a minimal host. The emitted bytes are unchanged for all
+  three protocols, and no public API changed.
+
 ### Added
 
 - **Input routing**: the new `routing` module (`Router`, `Delivery`,

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -27,24 +27,74 @@ exclude = ["docs/*.gif", "benches/*.json"]
 [lib]
 bench = false
 
+# One feature per grammar, **all on by default** — adding a grammar to a host is
+# the common case, and an existing dependant must not change behavior by
+# upgrading. What the split buys is the opposite direction: a grammar is a
+# multi-megabyte parse table in `.rodata`, and `build_configuration` names every
+# one of them, so nothing the linker can see makes an unused grammar droppable.
+# Bundling all fourteen costs ~21 MiB of read-only data in any binary that
+# highlights *anything*; C# alone is ~5 MiB and Scala ~3.9 MiB.
+#
+# A host that knows its languages turns the rest off:
+#
+#     tuika-codeformatters = { version = "0.4", default-features = false, \
+#                              features = ["rust", "python"] }
+#
+# This is the last-resort lever in
+# `knowledge/processes/maintenance.md#binary-size-discipline` — reached for here
+# because the language is a *runtime* string, so there is no use site to move
+# the choice to, the way `ImageLayer::record` does for graphics protocols.
+#
+# `typescript` covers both TypeScript and TSX: one crate ships both grammars.
+[features]
+default = [
+    "csharp",
+    "css",
+    "go",
+    "html",
+    "java",
+    "php",
+    "python",
+    "ruby",
+    "rust",
+    "scala",
+    "sql",
+    "typescript",
+    "zig",
+]
+
+csharp = ["dep:tree-sitter-c-sharp"]
+css = ["dep:tree-sitter-css"]
+go = ["dep:tree-sitter-go"]
+html = ["dep:tree-sitter-html"]
+java = ["dep:tree-sitter-java"]
+php = ["dep:tree-sitter-php"]
+python = ["dep:tree-sitter-python"]
+ruby = ["dep:tree-sitter-ruby"]
+rust = ["dep:tree-sitter-rust"]
+scala = ["dep:tree-sitter-scala"]
+sql = ["dep:tree-sitter-sequel"]
+typescript = ["dep:tree-sitter-typescript"]
+zig = ["dep:tree-sitter-zig"]
+
 [dependencies]
 tuika = { version = "0.10.0", path = "../.." }
 ratatui = "0.30.2"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"
-tree-sitter-c-sharp = "0.23"
-tree-sitter-css = "0.25"
-tree-sitter-go = "0.25"
-tree-sitter-html = "0.23"
-tree-sitter-java = "0.23"
-tree-sitter-php = "0.24"
-tree-sitter-python = "0.25"
-tree-sitter-ruby = "0.23"
-tree-sitter-rust = "0.24"
-tree-sitter-scala = "0.26"
-tree-sitter-sequel = "0.3"
-tree-sitter-typescript = "0.23"
-tree-sitter-zig = "1"
+tree-sitter-c-sharp = { version = "0.23", optional = true }
+tree-sitter-css = { version = "0.25", optional = true }
+tree-sitter-go = { version = "0.25", optional = true }
+tree-sitter-html = { version = "0.23", optional = true }
+tree-sitter-java = { version = "0.23", optional = true }
+tree-sitter-php = { version = "0.24", optional = true }
+tree-sitter-python = { version = "0.25", optional = true }
+tree-sitter-ruby = { version = "0.23", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
+tree-sitter-scala = { version = "0.26", optional = true }
+tree-sitter-sequel = { version = "0.3", optional = true }
+tree-sitter-typescript = { version = "0.23", optional = true }
+tree-sitter-zig = { version = "1", optional = true }
 
 [dev-dependencies]
 # The runnable examples drive a full-screen loop; tuika owns the rendering,

--- a/crates/tuika-codeformatters/README.md
+++ b/crates/tuika-codeformatters/README.md
@@ -52,6 +52,25 @@ PHP, Zig, Scala, and SQL (with common aliases: `rs`, `py`, `ts`, `js`, `rb`,
 `c#`, …). Unknown languages — or source that fails to parse — return `None`, and
 the caller renders the block as plain, theme-colored code.
 
+### Choosing grammars
+
+Every grammar is on by default, and each has a cargo feature. A grammar is a
+multi-megabyte parse table, so a binary that highlights everything carries
+~21 MiB of them — C# alone is ~5 MiB. A host that knows its languages keeps only
+those:
+
+```toml
+[dependencies]
+tuika-codeformatters = { version = "0.4", default-features = false, features = ["rust", "python"] }
+```
+
+Feature names match the language keys above, lowercased and without punctuation:
+`rust`, `python`, `typescript` (covers TSX/JSX too), `go`, `java`, `ruby`,
+`css`, `html`, `csharp`, `php`, `zig`, `scala`, `sql`.
+
+A language whose feature is off behaves exactly like one this crate never
+supported: it returns `None` and the caller renders plain code.
+
 ## Compatibility
 
 `ratatui` and `tuika` are part of this crate's public interface, so pin the same

--- a/crates/tuika-codeformatters/src/lib.rs
+++ b/crates/tuika-codeformatters/src/lib.rs
@@ -21,6 +21,22 @@
 //! JavaScript, TSX/JSX, Go, Java, Ruby, CSS, HTML, C#, PHP, Zig, Scala, and SQL.
 //! Anything else — or source that fails to parse — returns [`None`], and the
 //! caller renders it as plain code.
+//!
+//! # Choosing grammars
+//!
+//! Each grammar has a cargo feature and **all are on by default**. A grammar is
+//! a multi-megabyte parse table in `.rodata`, so bundling all fourteen costs
+//! ~21 MiB in any binary that highlights anything. A host that knows its
+//! languages keeps only those:
+//!
+//! ```toml
+//! tuika-codeformatters = { version = "0.4", default-features = false, features = ["rust", "python"] }
+//! ```
+//!
+//! Feature names are the language keys lowercased without punctuation: `rust`,
+//! `python`, `typescript` (covers TSX/JSX), `go`, `java`, `ruby`, `css`,
+//! `html`, `csharp`, `php`, `zig`, `scala`, `sql`. A language whose feature is
+//! off behaves exactly like one this crate never supported.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -93,81 +109,133 @@ fn style_for_name(name: &str, code: &CodeTheme) -> Style {
 /// grammar key, or `None` when we don't highlight that language.
 fn canonical_language(lang: &str) -> Option<&'static str> {
     let lang = lang.trim().to_ascii_lowercase();
-    let key = match lang.as_str() {
-        "rust" | "rs" => "rust",
-        "python" | "py" => "python",
+    // Each arm is gated on its grammar's feature, so a disabled language falls
+    // through to `None` and its block renders plain — the same outcome as a
+    // language this crate never supported.
+    match lang.as_str() {
+        #[cfg(feature = "rust")]
+        "rust" | "rs" => Some("rust"),
+        #[cfg(feature = "python")]
+        "python" | "py" => Some("python"),
         // The TypeScript grammar is a superset that parses plain JS cleanly.
-        "typescript" | "ts" | "javascript" | "js" | "mjs" | "cjs" => "typescript",
-        "tsx" | "jsx" => "tsx",
-        "go" | "golang" => "go",
-        "java" => "java",
-        "ruby" | "rb" => "ruby",
-        "css" => "css",
-        "html" | "htm" => "html",
-        "c#" | "cs" | "csharp" | "c_sharp" => "csharp",
-        "php" => "php",
-        "zig" => "zig",
-        "scala" => "scala",
-        "sql" => "sql",
-        _ => return None,
-    };
-    Some(key)
+        #[cfg(feature = "typescript")]
+        "typescript" | "ts" | "javascript" | "js" | "mjs" | "cjs" => Some("typescript"),
+        #[cfg(feature = "typescript")]
+        "tsx" | "jsx" => Some("tsx"),
+        #[cfg(feature = "go")]
+        "go" | "golang" => Some("go"),
+        #[cfg(feature = "java")]
+        "java" => Some("java"),
+        #[cfg(feature = "ruby")]
+        "ruby" | "rb" => Some("ruby"),
+        #[cfg(feature = "css")]
+        "css" => Some("css"),
+        #[cfg(feature = "html")]
+        "html" | "htm" => Some("html"),
+        #[cfg(feature = "csharp")]
+        "c#" | "cs" | "csharp" | "c_sharp" => Some("csharp"),
+        #[cfg(feature = "php")]
+        "php" => Some("php"),
+        #[cfg(feature = "zig")]
+        "zig" => Some("zig"),
+        #[cfg(feature = "scala")]
+        "scala" => Some("scala"),
+        #[cfg(feature = "sql")]
+        "sql" => Some("sql"),
+        _ => None,
+    }
 }
 
+// With every grammar feature off this crate still builds and still implements
+// `Highlighter` — it simply highlights nothing, exactly like tuika's own
+// `NoHighlighter`. The match then reduces to its fallback, so the tail below is
+// genuinely dead in that configuration.
+#[cfg_attr(
+    not(any(
+        feature = "csharp",
+        feature = "css",
+        feature = "go",
+        feature = "html",
+        feature = "java",
+        feature = "php",
+        feature = "python",
+        feature = "ruby",
+        feature = "rust",
+        feature = "scala",
+        feature = "sql",
+        feature = "typescript",
+        feature = "zig"
+    )),
+    allow(unreachable_code, unused_variables)
+)]
 fn build_configuration(key: &str) -> Option<HighlightConfiguration> {
     let (language, query): (tree_sitter::Language, &str) = match key {
+        #[cfg(feature = "rust")]
         "rust" => (
             tree_sitter_rust::LANGUAGE.into(),
             tree_sitter_rust::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "python")]
         "python" => (
             tree_sitter_python::LANGUAGE.into(),
             tree_sitter_python::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "typescript")]
         "typescript" => (
             tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
             tree_sitter_typescript::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "typescript")]
         "tsx" => (
             tree_sitter_typescript::LANGUAGE_TSX.into(),
             tree_sitter_typescript::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "go")]
         "go" => (
             tree_sitter_go::LANGUAGE.into(),
             tree_sitter_go::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "java")]
         "java" => (
             tree_sitter_java::LANGUAGE.into(),
             tree_sitter_java::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "ruby")]
         "ruby" => (
             tree_sitter_ruby::LANGUAGE.into(),
             tree_sitter_ruby::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "css")]
         "css" => (
             tree_sitter_css::LANGUAGE.into(),
             tree_sitter_css::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "html")]
         "html" => (
             tree_sitter_html::LANGUAGE.into(),
             tree_sitter_html::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "csharp")]
         "csharp" => (
             tree_sitter_c_sharp::LANGUAGE.into(),
             tree_sitter_c_sharp::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "php")]
         "php" => (
             tree_sitter_php::LANGUAGE_PHP.into(),
             tree_sitter_php::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "zig")]
         "zig" => (
             tree_sitter_zig::LANGUAGE.into(),
             tree_sitter_zig::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "scala")]
         "scala" => (
             tree_sitter_scala::LANGUAGE.into(),
             tree_sitter_scala::HIGHLIGHTS_QUERY,
         ),
+        #[cfg(feature = "sql")]
         "sql" => (
             tree_sitter_sequel::LANGUAGE.into(),
             tree_sitter_sequel::HIGHLIGHTS_QUERY,
@@ -295,6 +363,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rust")]
     fn highlights_rust_keywords_distinctly() {
         let theme = Theme::default();
         let hl = TreeSitterHighlighter::new();
@@ -314,6 +383,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "rust")]
     fn follows_the_host_theme() {
         // A different palette restyles the same token.
         let mut theme = Theme::default();
@@ -329,14 +399,38 @@ mod tests {
         assert_eq!(fn_span.style.fg, Some(ratatui::style::Color::Indexed(200)));
     }
 
+    // Aliases are per-grammar, so each assertion is gated on the feature that
+    // supplies it — a reduced build must still be able to run its own suite.
     #[test]
-    fn aliases_resolve_and_js_uses_typescript_grammar() {
+    #[cfg(feature = "typescript")]
+    fn js_alias_uses_the_typescript_grammar() {
         let theme = Theme::default();
         let hl = TreeSitterHighlighter::new();
-        assert_eq!(canonical_language("py"), Some("python"));
         assert_eq!(canonical_language("js"), Some("typescript"));
-        assert_eq!(canonical_language("c#"), Some("csharp"));
         assert!(hl.highlight("js", &["const x = 1;"], &theme).is_some());
+    }
+
+    #[test]
+    #[cfg(feature = "python")]
+    fn py_alias_resolves() {
+        assert_eq!(canonical_language("py"), Some("python"));
+    }
+
+    #[test]
+    #[cfg(feature = "csharp")]
+    fn csharp_aliases_resolve() {
+        assert_eq!(canonical_language("c#"), Some("csharp"));
+    }
+
+    /// A grammar compiled out is indistinguishable from one never supported:
+    /// the fence falls back to plain text rather than failing.
+    #[test]
+    #[cfg(not(feature = "zig"))]
+    fn a_disabled_grammar_falls_back_to_plain() {
+        let theme = Theme::default();
+        let hl = TreeSitterHighlighter::new();
+        assert_eq!(canonical_language("zig"), None);
+        assert!(hl.highlight("zig", &["const x = 1;"], &theme).is_none());
     }
 
     #[test]
@@ -348,6 +442,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "python")]
     fn blank_lines_inside_a_block_are_preserved() {
         let theme = Theme::default();
         let hl = TreeSitterHighlighter::new();

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,25 @@
 
 ## 2026-08-19
 
+- **A host pays for a tuika feature only if something references it**
+  - Binary size for a library is not the crate's size; it is what a host binary
+    links. Measured on real hosts, the linker already makes most of tuika
+    pay-for-use: the markdown stack and `pulldown-cmark` cost a non-markdown
+    host nothing, and `textwrap`'s `smawk` / `unicode-linebreak` tables never
+    reach the binary at all. Two of the three most plausible size levers
+    measured at exactly zero, so the measurement, not the intuition, decides.
+  - What defeats dead-code elimination is a reference on the always-linked path.
+    `ImageLayer::emit` runs every frame in every `Runner` host and matched on
+    `ImageSupport`, which anchored the Kitty, iTerm2, and Sixel encoders plus
+    the PNG writer into binaries that place no image. Resolving the encoder in
+    `record` — reachable only from the `Image` view — and carrying it as a
+    function pointer moved all four behind actual use.
+  - Generalized as [Binary Size Discipline](processes/maintenance.md#binary-size-discipline):
+    prefer resolving a capability where it is *used* over matching on it in a
+    per-frame function, and treat a cargo feature as the last resort. Build
+    levers (`opt-level="z"`, `panic="abort"`, `lto`) belong to the host's
+    profile, not to tuika.
+
 - **Delivering an event is toolkit policy, not host glue**
   - The registry knowing who owns input, and the owner's state receiving the
     event, were separated by host code written per surface *and per event kind*.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -15,6 +15,15 @@
     the PNG writer into binaries that place no image. Resolving the encoder in
     `record` — reachable only from the `Image` view — and carrying it as a
     function pointer moved all four behind actual use.
+  - The root crate turned out to be the *smallest* part of the question. Probing
+    every published member showed tuika core costs a minimal host ~64 KiB while
+    `tuika-codeformatters` cost 24 MiB — fourteen tree-sitter parse tables, all
+    of them linked because grammars are chosen by a runtime language string, so
+    `build_configuration` must name every one. That is the case with no use site
+    to move the choice to, and therefore the case that justifies the last-resort
+    lever: one cargo feature per grammar, all default-on, taking a
+    Rust-and-Python host from 24.0 MiB to 4.8 MiB. A disabled grammar is
+    indistinguishable from an unsupported one, so no new failure mode appears.
   - Generalized as [Binary Size Discipline](processes/maintenance.md#binary-size-discipline):
     prefer resolving a capability where it is *used* over matching on it in a
     per-frame function, and treat a cargo feature as the last resort. Build

--- a/knowledge/processes/maintenance.md
+++ b/knowledge/processes/maintenance.md
@@ -144,6 +144,47 @@ So the rule is about the shape of the reference, not the size of the code:
   reference graph decides. Two of the three most plausible size levers here
   measured at exactly zero. Measure first, change second.
 
+### Every published member, not just the root
+
+The root crate is the *smallest* part of this question. tuika core costs a
+minimal host ~64 KiB; the companion crates exist precisely because they carry
+the heavy dependencies, so that is where the megabytes are. Measured per crate,
+for a host that uses each one:
+
+| crate | host binary | dominated by |
+|---|---:|---|
+| `tuika` alone | 925 KiB | — |
+| `tuika-charts` | 730 KiB | nothing heavy; it depends only on tuika |
+| `tuika-html` | 1.7 MiB | html5ever's tree builder |
+| `tuika-mermaid` | 5.5 MiB | mmdflux's layout engine (`.text`, not data) |
+| `tuika-codeformatters` | 24.0 MiB | fourteen tree-sitter parse tables |
+
+The first four are the cost of the thing the crate exists to do, and the
+boundary is already drawn correctly — that weight is in a companion crate rather
+than in tuika, which is the whole point of
+[the dependency rule](../specs/goal.md). `tuika-mermaid` already takes mmdflux
+with `default-features = false`; there is nothing left to trim.
+
+`tuika-codeformatters` was the outlier, and it is the case that justifies the
+last-resort lever. Grammars are selected by a **runtime** language string, so
+unlike graphics protocols there is no use site to move the choice to:
+`build_configuration` must name every grammar, which anchored ~21 MiB of parse
+tables into any binary that highlighted anything at all — C# ~5 MiB, Scala
+~3.9 MiB, TypeScript ~2.9 MiB, and so on down to HTML at ~19 KiB. One cargo
+feature per grammar, **all on by default**, leaves existing dependants
+unchanged while letting a host that knows its languages drop the rest: a
+Rust-and-Python host goes from 24.0 MiB to 4.8 MiB.
+
+Two properties make that acceptable rather than a support burden, and both are
+worth preserving in any similar split:
+
+- **Default-on**, so no existing dependant changes behavior by upgrading.
+- **A disabled grammar is indistinguishable from an unsupported one** — it
+  returns `None` and the block renders plain. No new failure mode, and the empty
+  configuration still builds, lints, and tests clean.
+
+### Build levers belong to the host
+
 Build-level levers — `opt-level="z"`, `panic="abort"`, `lto="fat"`,
 `codegen-units=1` — belong to the host's profile, not to tuika. They are worth
 knowing (each is worth roughly 7-10% of a shipped binary) so a host asking about

--- a/knowledge/processes/maintenance.md
+++ b/knowledge/processes/maintenance.md
@@ -110,6 +110,51 @@ The small dependency set is a designed property, not an accident
   routine upgrade: it changes the `Buffer` type on the public boundary, so hosts must
   move in lockstep. Treat it as a breaking release.
 
+## Binary Size Discipline
+
+tuika is a library, so its size cost is not a number it owns — it is what a
+*host binary* pays for linking it. That reframes the goal: the target is not a
+smaller `.rlib` but **pay-for-use**, so a host that never renders markdown,
+places no image, or draws no chart carries none of that code.
+
+The linker already delivers most of this. Dead-code elimination works at symbol
+granularity, so a feature a host does not reach is dropped even though it is
+compiled into the crate — measurements on a real host confirm the markdown
+stack, `pulldown-cmark` included, costs a non-markdown host nothing, and
+`textwrap`'s `smawk` / `unicode-linebreak` tables likewise never reach the
+binary. **The corollary is what maintenance must watch:** DCE only reaches what
+nothing references. A feature stops being pay-for-use the moment code on the
+*unconditional* path names it — most easily by a `match` in a per-frame
+function, which anchors every arm into every binary.
+
+So the rule is about the shape of the reference, not the size of the code:
+
+- **Runtime dispatch on the always-linked path anchors every arm.** Prefer
+  resolving the choice where the feature is *used* and carrying the result
+  forward — a function pointer stored at record time, a trait object the host
+  supplies — over matching on a capability enum inside the per-frame emitter.
+  `ImageLayer::emit` is the worked example: it once matched `ImageSupport` and
+  so linked the Kitty, iTerm2, and Sixel encoders plus the PNG writer into every
+  binary; storing the encoder chosen in `record` (whose only caller is the
+  `Image` view) made all four pay-for-use.
+- **A cargo feature is the last resort, not the first.** It splits the build
+  matrix and the support burden. Reach for one only when the cost is genuinely
+  unconditional and no reference-graph change can make it optional.
+- **Verify before believing.** "This must be costing hosts" is a hypothesis; the
+  reference graph decides. Two of the three most plausible size levers here
+  measured at exactly zero. Measure first, change second.
+
+Build-level levers — `opt-level="z"`, `panic="abort"`, `lto="fat"`,
+`codegen-units=1` — belong to the host's profile, not to tuika. They are worth
+knowing (each is worth roughly 7-10% of a shipped binary) so a host asking about
+size can be pointed at its own `[profile.release]`, but tuika neither sets nor
+recommends them for anyone else's build.
+
+Binary size is **not** a CI gate. It is a periodic maintenance check and a
+review question for changes that add an unconditional code path, in the spirit
+of [Dependency Discipline](#dependency-discipline): the point is to notice the
+regression, not to defend a byte count.
+
 ## Release Readiness Standard
 
 Before tagging a release:

--- a/knowledge/specs/images.md
+++ b/knowledge/specs/images.md
@@ -91,6 +91,10 @@ established for reading a view's painted rect back out:
 3. **After** `terminal.draw()` returns, `Runner` calls `ImageLayer::emit`, which
    writes each image's graphics escape positioned at its cell origin, then
    clears the layer. A custom host performs those same two calls itself.
+   The protocol encoder is resolved in step 2 and carried on the placement, not
+   matched on in `emit`: `emit` runs in every host, so choosing there would link
+   all three encoders into binaries that place no image. See
+   [Binary Size Discipline](../processes/maintenance.md#binary-size-discipline).
 
 Emission happens after the frame because the graphics escape paints pixels the
 cell buffer knows nothing about; doing it inside the paint pass would fight

--- a/src/term/image.rs
+++ b/src/term/image.rs
@@ -173,8 +173,43 @@ impl ImageSupport {
 struct Placement {
     rect: Rect,
     data: ImageData,
-    support: ImageSupport,
+    /// The protocol encoder chosen when this placement was recorded.
+    ///
+    /// Holding the encoder here rather than matching on [`ImageSupport`] inside
+    /// [`ImageLayer::emit`] is what keeps graphics encoding **pay-for-use**:
+    /// `emit` runs on every frame of every host, so naming the three encoders
+    /// there anchored all of them — Kitty, iTerm2, Sixel, and the PNG writer
+    /// behind iTerm2 — into any binary that links tuika at all. Reaching them
+    /// only through `record`, whose sole caller is
+    /// [`Image`](crate::components::Image)'s `render`, lets the linker drop the
+    /// whole set for a host that places no images.
+    encode: Encoder,
     kitty_image_number: Option<u32>,
+}
+
+/// A protocol encoder: writes one recorded placement's graphics escape.
+///
+/// `&mut dyn Write` rather than a generic sink, because a function pointer
+/// cannot be generic — and the indirection costs nothing measurable next to
+/// transmitting the pixels themselves.
+type Encoder = fn(&mut dyn Write, &Placement) -> io::Result<()>;
+
+fn place_kitty(mut out: &mut dyn Write, p: &Placement) -> io::Result<()> {
+    write_kitty(
+        &mut out,
+        &p.data,
+        p.rect.width,
+        p.rect.height,
+        p.kitty_image_number,
+    )
+}
+
+fn place_iterm2(mut out: &mut dyn Write, p: &Placement) -> io::Result<()> {
+    write_iterm2(&mut out, &p.data, p.rect.width, p.rect.height)
+}
+
+fn place_sixel(out: &mut dyn Write, p: &Placement) -> io::Result<()> {
+    out.write_all(encode_sixel(&p.data, p.rect.width, p.rect.height).as_bytes())
 }
 
 #[derive(Debug, Default)]
@@ -218,10 +253,16 @@ impl ImageLayer {
         if rect.width == 0 || rect.height == 0 {
             return;
         }
+        // `None` shouldn't record, but Kitty is the safe default encoding.
+        let encode: Encoder = match support {
+            ImageSupport::ITerm2 => place_iterm2,
+            ImageSupport::Sixel => place_sixel,
+            _ => place_kitty,
+        };
         self.0.borrow_mut().placements.push(Placement {
             rect,
             data,
-            support,
+            encode,
             kitty_image_number: (support == ImageSupport::Kitty).then(next_kitty_image_number),
         });
     }
@@ -262,22 +303,7 @@ impl ImageLayer {
             // CUP is 1-based; the reserved rect is 0-based screen coordinates.
             let (row, col) = (p.rect.y + 1, p.rect.x + 1);
             write!(out, "\x1b[{row};{col}H")?;
-            match p.support {
-                ImageSupport::ITerm2 => {
-                    write_iterm2(out, &p.data, p.rect.width, p.rect.height)?;
-                }
-                ImageSupport::Sixel => {
-                    out.write_all(encode_sixel(&p.data, p.rect.width, p.rect.height).as_bytes())?;
-                }
-                // None shouldn't record, but Kitty is the safe default encoding.
-                _ => write_kitty(
-                    out,
-                    &p.data,
-                    p.rect.width,
-                    p.rect.height,
-                    p.kitty_image_number,
-                )?,
-            }
+            (p.encode)(out, p)?;
         }
         // Cell redraws do not erase Kitty placements. Retire the previous
         // frame only after its replacements are visible, avoiding both stale


### PR DESCRIPTION
## What changed

Two code paths that forced every host to carry code it never used, plus the maintenance spec that makes the check repeatable.

**`tuika-codeformatters`: one cargo feature per grammar, all on by default.** Grammars are chosen by a *runtime* language string, so `build_configuration` had to name all fourteen — which anchored every parse table into any binary that highlighted anything at all. A host that only ever renders Rust still paid ~21 MiB of read-only data (C# ~5 MiB, Scala ~3.9 MiB, TypeScript ~2.9 MiB, down to HTML at ~19 KiB).

A dependant taking the crate normally is unaffected. One that knows its languages drops the rest:

```toml
tuika-codeformatters = { version = "0.4", default-features = false, features = ["rust", "python"] }
```

**tuika: graphics protocol encoders are pay-for-use.** `ImageLayer::emit` runs after every frame in every `Runner` host and picked its encoder by matching on `ImageSupport`. That single reference linked the Kitty, iTerm2, and Sixel encoders — plus the PNG writer behind iTerm2 — into every binary using tuika, image or no image. The encoder is now resolved in `record`, reachable only from the `Image` view, and carried on the placement.

**Maintenance spec**: a Binary Size Discipline section and the `cargo-bsize` procedure, including the probe-crate recipe (tuika has no `[[bin]]`, so the tool needs one) and one probe per published member.

## Why

[`cargo-bsize`](https://github.com/Boshen/cargo-bsize) was run across the workspace. For a library the question is not what the crate weighs but what a *host binary* pays, and the linker already delivers most of that: the markdown stack and `pulldown-cmark` cost a non-markdown host nothing, and `textwrap`'s `smawk` / `unicode-linebreak` tables never reach the binary — verified, not assumed. Two of the three most plausible levers measured at exactly zero.

What defeats dead-code elimination is a reference on the always-linked path. These were the two places that had one.

## Before / After

Measured on probe host crates depending on tuika by path, `--release`.

**`tuika-codeformatters`** — a binary highlighting one Rust snippet:

| | total | `.rodata` |
|---|---:|---:|
| default (all 14 grammars) | 24,053,928 | 20,409,160 |
| `rust`, `python` | 4,784,272 | 1,858,504 |
| | **−80%** | **−91%** |

All eleven unused grammars leave the binary (`nm` finds zero `tree_sitter_*` symbols for them).

**tuika** — a minimal `Runner` host (`examples/hello.rs`) that places no images:

| | before | after |
|---|---:|---:|
| tuika's own code | 72,472 B | 64,091 B (**−11.6%**) |
| binary `.text` | 478,208 | 473,888 |
| binary `.rodata` | 76,352 | 75,088 |

**No observable behavior change**, proven rather than asserted:

- Graphics: a probe drove the real `Image::render` → `ImageLayer::emit` path for all three protocols against `origin/main` and this branch. Byte-identical — Kitty `len=400 sum=32919`, iTerm2 `len=524 sum=43872`, Sixel `len=3477 sum=179981` on both.
- Highlighting: the same comparison over all fourteen languages plus an unsupported one, under default features. Identical span content and foreground styles for every case.

## Risk

- **Medium**, concentrated in the feature split rather than the code.
- The grammar change is breaking for a dependant already passing `default-features = false` — recorded under Breaking Changes in the changelog. Everyone else is unaffected because all features are default-on.
- A disabled grammar is indistinguishable from one never supported: `canonical_language` returns `None` and the block renders plain. No new failure mode, and no path where a missing grammar can panic.
- The graphics change swaps a `match` for a function pointer held in a private struct. The pointer is set only from a match over tuika's own enum, never from host data.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated

## Knowledge

- `knowledge/processes/maintenance.md` — new **Binary Size Discipline**: pay-for-use as the standard, the reference graph as what decides it, per-crate figures for all five published crates, why four of five are already correct, and why the grammar bundle justifies feature-gating as the last resort. Build levers belong to the host's profile.
- `knowledge/specs/images.md` — why the encoder is resolved at record time rather than in `emit`.
- `knowledge/log.md` — entry for the durable finding.
- `.agents/skills/maintenance/SKILL.md` — the operational `cargo-bsize` procedure.

`python3 scripts/validate_okf.py knowledge --check-links` → 16 concepts, 0 errors.

## Testing

- `a_disabled_grammar_falls_back_to_plain` is new and exercises the new behavior directly: a grammar compiled out returns `None` and renders plain.
- Per-language tests are now gated on their own feature, so a reduced build can run its own suite. The all-language alias test was split into per-grammar tests for the same reason.
- The graphics change has **no new behavior to test** — it moves where an existing choice is made. The existing `emit_dispatches_the_recorded_protocol` and `emit_dispatches_sixel` tests cover exactly the dispatch path it touches, and the byte-identity comparison above is the evidence that output is unchanged. Flagging this rather than claiming a new test.

Evidence, all green:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` — 25 test binaries, no failures
- Reduced configurations: clippy and tests for `--no-default-features` and `--no-default-features --features rust` on `tuika-codeformatters`, both clean — the empty configuration is the one that rots
- `cargo +1.88 check` on `tuika` and on `tuika-codeformatters` in both configurations (MSRV)
- `cargo check --locked --workspace --all-targets` — `Cargo.lock` is unchanged
- `cargo run --example demo -- check` — 42 scenes in sync
- `cargo bench -p tuika-codeformatters --bench highlight -- --test`
- `cargo package --list -p tuika-codeformatters`, and `tests/packaging.rs` green
- `scripts/validate_okf.py`, `test_validate_okf.py`, `test_publish_order.py`, and the public-docs boundary grep

Smoke: no interactive terminal in this environment, so the surfaces were exercised through the recorder-free paths the repo provides — `cargo run --example image_demo` renders the real transmitted `ImageData` and the placeholder, and the byte-level emit comparison above stands in for driving a graphics-capable emulator.

## Security

Reviewed against all five categories.

- **TM-ESC** — the graphics change alters *which function is called*, not what it writes; output is byte-identical for all three protocols. The encoder is chosen from tuika's own `ImageSupport` enum inside `record`, never from host-supplied data, so no caller string reaches the terminal anywhere new. No new out-of-band feature, so no new capability detection is needed.
- **TM-STATE** — untouched. No enter/restore path changed.
- **TM-PARSE** — the grammar split strictly *reduces* parsing surface: a disabled grammar means untrusted source in that language is never parsed at all. No new parsing, no new `unwrap` on parsed input.
- **TM-CLIP** — no rendering geometry changed; `Image::render` is untouched.
- **TM-DEP** — no dependency added. Thirteen existing ones became optional. `ratatui` remains a dev-dependency of the root crate.

## Follow-ups

- Mouse selection (`selected_text_from_sources`, `paint_selection`, `selected_grid_text`, ~5.5 KiB) links unconditionally into every `Runner` host, the same shape the graphics encoders had. The fix is not as clean: the gate is a runtime `Option<SelectionSources>` rather than a component-owned record path, so making it pay-for-use looks like it touches public API. Deferred rather than bundled into a PR that otherwise changes no tuika API.
- `tuika-mermaid` (~5.5 MiB) and `tuika-html` (~1.7 MiB) are dominated by the engine each crate exists to wrap, already taken with `default-features = false` where applicable. No lever found; recorded in the spec as expected magnitudes so future drift is visible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U95dyTFJ1vc3QWHtpaDHj5)_