### PR TITLE
refactor(deps)!: drop textwrap, ratatui-crossterm, and tokio-stream

### DIFF
--- a/.agents/skills/maintenance/SKILL.md
+++ b/.agents/skills/maintenance/SKILL.md
@@ -62,17 +62,24 @@ This skill is outcome-oriented. Choose the smallest set of actions that closes t
 The small dependency set is a designed property, not an accident. Defend it.
 
 Actions:
-- check for newer `ratatui-core` / `ratatui-crossterm` / `crossterm` releases
-  (`cargo search ratatui-core --limit 1`). These three must stay mutually
-  consistent, and `crossterm` must match what `ratatui-crossterm` pins, or Cargo
-  builds two backends
+- check for newer `ratatui-core` / `crossterm` releases
+  (`cargo search ratatui-core --limit 1`). These must stay consistent with what
+  a host's `ratatui` umbrella resolves to, or Cargo builds two backends and
+  splits the `Buffer` type on the interop boundary
+- when `ratatui-core` moves, re-run the differential backend test
+  (`cargo test --all-features term::backend`): tuika's own `Backend` is held
+  byte-identical to `ratatui-crossterm`'s, and a `Backend` trait change or a
+  new SGR path is exactly what would drift it
 - confirm `ratatui` is still only a **dev**-dependency; under `[dependencies]` it
   means the umbrella crept back in
 - treat a `ratatui-core` major bump as an interoperability event, not a routine
   upgrade: it changes the `Buffer` type on the public boundary, so hosts must move in
   lockstep. It is a breaking release for tuika
-- check `pulldown-cmark`, `textwrap`, `unicode-*` minors; verify
-  `pulldown-cmark` still builds with default features off
+- check `pulldown-cmark` and `unicode-*` minors; verify `pulldown-cmark` still
+  builds with default features off
+- ask of each remaining dependency whether tuika could own its job in a page of
+  code (see maintenance.md § Dependency Discipline) — but leave the Unicode
+  tables, the CommonMark parser, and the grammars where they are
 - for `tuika-codeformatters`, check the tree-sitter grammar crates and
   `tree-sitter-highlight` together — a grammar pinned to an older `tree-sitter`
   duplicates the parser runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,25 @@ described in the release process begins with the entry below.
   behaves exactly like one the crate never supported: `highlight` returns
   `None` and the caller renders plain code.
 
+- **`Paragraph` and dialog copy wrap differently.** Both now use tuika's own
+  wrap solver — the one `Wrap`/`wrap_lines` has always used — instead of
+  `textwrap`. Three visible differences, all of them making `Paragraph` agree
+  with the rest of the toolkit:
+  - Line breaks are chosen **greedily** (first-fit) rather than by textwrap's
+    optimal-fit minimum-raggedness pass, so a paragraph's rows may break at
+    different words than in 0.10.
+  - A run of whitespace between two words is one break opportunity and renders
+    as a single space, instead of being copied through verbatim.
+  - Breaks happen only at whitespace. textwrap also broke at Unicode line-break
+    opportunities such as `/`, which could split a linkified URL after its
+    scheme; a URL now stays on one row unless it is wider than the row.
+
+  Widths are counted in tuika's grapheme-aware display columns, which fixes a
+  latent bug: `Paragraph` wrapped with textwrap's per-`char` width model and
+  then measured the result with `str_cols`, so text containing a ZWJ emoji
+  (a family, a flag, a skin-tone sequence) wrapped earlier than its own
+  measurement said it needed to.
+
 ### Changed
 
 - **`tuika-codeformatters` binary size**: grammars are selected by a runtime
@@ -47,6 +66,29 @@ described in the release process begins with the entry below.
   so a host that places no images no longer carries any of them: about 8.4 KiB
   less tuika code in a minimal host. The emitted bytes are unchanged for all
   three protocols, and no public API changed.
+
+- **Dependencies: 66 crates to 55.** Three runtime dependencies were removed by
+  taking work tuika was already half-doing:
+  - `textwrap` (with `smawk` and `unicode-linebreak`) — replaced by the wrap
+    solver `Wrap` already used. See **Breaking Changes** for the visible
+    difference.
+  - `ratatui-crossterm` (with the `instability`/`darling` proc-macro tree behind
+    it) — tuika now writes to the terminal through its own crossterm `Backend`.
+    It already implemented that whole trait once, in `HyperlinkBackend`, to wrap
+    the one being removed. The emitted byte stream is held **byte-for-byte
+    identical** by a differential test that draws the same cells through both
+    backends. The crate remains an *optional* dependency of the
+    `scrolling-regions` feature, which forwards its matching flag so a host's
+    own copy still compiles.
+  - `tokio-stream` (under `async`) — replaced by `futures-core`, which the
+    build already contained: `async` enables `crossterm/event-stream`, and that
+    pulls it in. `tokio_stream::Stream` *is* `futures_core::Stream`, so a host
+    passing a `ReceiverStream` is unaffected; `tokio-stream` stays a
+    dev-dependency and the doc example still uses it. The `async` graph goes
+    from 71 crates to 59.
+
+  No public API changed, and no rendered output changed outside the wrapping
+  differences above.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,12 +1791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "smawk"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,17 +1983,6 @@ dependencies = [
  "wezterm-dynamic",
  "wezterm-input-types",
  "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width",
 ]
 
 [[package]]
@@ -2306,6 +2289,7 @@ version = "0.10.0"
 dependencies = [
  "criterion",
  "crossterm",
+ "futures-core",
  "iai-callgrind",
  "portable-pty",
  "proptest",
@@ -2313,7 +2297,6 @@ dependencies = [
  "ratatui",
  "ratatui-core",
  "ratatui-crossterm",
- "textwrap",
  "tokio",
  "tokio-stream",
  "unicode-segmentation",
@@ -2405,12 +2388,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ bench = false
 # The async runner (`AsyncRunner`). Off by default so sync-only hosts don't pull
 # in a Tokio runtime. Enabling it adds Tokio (timer + `select!` macro), a
 # `StreamExt` for polling the event stream, and crossterm's async `EventStream`.
-async = ["dep:tokio", "dep:tokio-stream", "crossterm/event-stream"]
+async = ["dep:tokio", "dep:futures-core", "crossterm/event-stream"]
 
 # Mirror of ratatui's `scrolling-regions`, which changes how content is inserted
 # above an inline viewport: DECSTBM region scrolling instead of the portable
@@ -111,8 +111,16 @@ async = ["dep:tokio", "dep:tokio-stream", "crossterm/event-stream"]
 # published output *becomes* scrollback. The portable path costs a viewport
 # repaint per published block and keeps it; the `codex` PTY tests pin the
 # difference. See `knowledge/specs/screen-modes.md`.
+# Turning this on flips a `ratatui-core` feature that adds two required methods
+# to `Backend`. Cargo unifies features one way only, so any *other*
+# `ratatui-crossterm` in the graph — a host's own `ratatui`, most likely — would
+# then fail to compile its `CrosstermBackend` unless its matching feature is on
+# too. tuika no longer depends on that crate (see `term/backend.rs`), so the
+# optional dep below exists purely to forward the flag and keep the graph
+# consistent; it is absent from every build that leaves this feature off.
 scrolling-regions = [
     "ratatui-core/scrolling-regions",
+    "dep:ratatui-crossterm",
     "ratatui-crossterm/scrolling-regions",
 ]
 
@@ -129,17 +137,20 @@ scrolling-regions = [
 # version). `underline-color` matches the umbrella default so cell rendering is
 # byte-identical; `std` is required for the terminal I/O loop.
 ratatui-core = { version = "0.1", features = ["std", "underline-color"] }
-# `CrosstermBackend` (+ `ClearType`/`WindowSize` impls) — the only piece tuika
-# needs that is not in `ratatui-core`. Default features pin the crossterm 0.29
-# backend, matching the direct `crossterm` dep below so Cargo dedups it.
-ratatui-crossterm = "0.1"
 crossterm = "0.29"
+# Not used in any code path: pulled in only by `scrolling-regions`, to forward
+# that feature. See the feature's comment above.
+ratatui-crossterm = { version = "0.1", optional = true }
 # Async runner only (feature = "async"). `time` for the tick interval, `macros`
 # for `tokio::select!`; the host application brings its own runtime, so no `rt`.
 tokio = { version = "1", features = ["time", "macros"], optional = true }
-# `StreamExt::{next, filter_map}` for driving the crossterm `EventStream`.
-tokio-stream = { version = "0.1", optional = true }
-textwrap = "0.16"
+# The `Stream` trait for the runner's event/message bounds. Not a new crate:
+# `async` turns on `crossterm/event-stream`, which already pulls `futures-core`
+# in. The three adapters the runner needs (`next`, `filter_map`, `empty`) are
+# ~80 lines in `runner/stream.rs`, which is what lets `tokio-stream` be a
+# dev-dependency instead of a consumer one — and costs hosts nothing, since
+# `tokio_stream::Stream` *is* this trait.
+futures-core = { version = "0.3", optional = true }
 unicode-segmentation = "1"
 unicode-width = "0.2"
 # CommonMark parsing for the streaming `Markdown` component. `default-features
@@ -175,6 +186,9 @@ iai-callgrind = "0.16.1"
 # event stream; `test-util` gives paused-clock control so ticks are deterministic
 # instead of wall-clock-timed. Reachable only when `--features async` is on.
 tokio = { version = "1", features = ["rt", "macros", "sync", "time", "test-util"] }
+# Dev-only, and deliberately so: the doc example and the mpsc test drive the
+# runner through `tokio_stream::wrappers::ReceiverStream`, which proves a host's
+# `tokio-stream` still satisfies the `futures-core` bounds the runner declares.
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ You write views; tuika owns the rest:
   [UI is unit-tested](#testing-your-ui) against an in-memory buffer with no
   terminal at all.
 - **Small enough to adopt without a second thought** — a self-contained crate
-  depending only on `ratatui-core` (plus `ratatui-crossterm` for the backend),
-  `crossterm`, `textwrap`, `unicode-segmentation`, `unicode-width`, and
-  `pulldown-cmark`. Anything heavy — grammars, diagram layout, image decoding —
-  lives behind a trait in a companion crate or your host.
+  depending only on `ratatui-core`, `crossterm`, `unicode-segmentation`,
+  `unicode-width`, and `pulldown-cmark`. Anything heavy — grammars, diagram
+  layout, image decoding — lives behind a trait in a companion crate or your
+  host.
 
 It is host-agnostic: it knows nothing about the application embedding it, and no
 type, feature, or default exists to serve one host. tuika renders none of
@@ -972,8 +972,7 @@ something on tuika? Open a PR adding it here.
 - Tuika 0.x follows Cargo semver: minor releases may make deliberate breaking
   API changes; patch releases do not.
 - Ratatui and Crossterm are part of Tuika's public interoperability surface.
-  Tuika builds against `ratatui-core` (and `ratatui-crossterm`) directly, not
-  the `ratatui` umbrella; the umbrella re-exports that same `ratatui-core`, so a
+  Tuika builds against `ratatui-core` directly, not the `ratatui` umbrella; the umbrella re-exports that same `ratatui-core`, so a
   matching `ratatui` minor line in your application resolves to one shared
   `ratatui-core` and Cargo deduplicates the core types. Widgets such as
   `Block`/`Paragraph`/`Table` live in `ratatui-widgets` (pulled in by your

--- a/examples/keyed_table.rs
+++ b/examples/keyed_table.rs
@@ -8,8 +8,8 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event;
+use ratatui::backend::CrosstermBackend;
 use ratatui_core::terminal::Terminal;
-use ratatui_crossterm::CrosstermBackend;
 use tuika::prelude::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,51 @@
 # Knowledge Log
 
+## 2026-08-21
+
+- **A dependency whose job tuika can do in a page of code belongs in tuika**
+  - Auditing the dependency set for removals turned up three crates whose job
+    was small *for tuika* even though the crates themselves are not: `textwrap`
+    (two call sites), `ratatui-crossterm` (one `Backend` impl), and
+    `tokio-stream` (three adapters). Removing all three took the default
+    consumer graph from 66 crates to 55, and the `async` graph from 71 to 59,
+    with no public API change.
+  - The test that separates a removable dependency from a load-bearing one is
+    not size. `unicode-width` and `unicode-segmentation` look like the obvious
+    targets and are the worst possible ones: they are Unicode tables tracking a
+    moving standard, and `ratatui-core` depends on both anyway, so dropping them
+    from the manifest would remove nothing from any graph. `pulldown-cmark` is
+    32k lines because CommonMark is 32k lines' worth of specification. What
+    made the three above removable was that tuika already owned the surrounding
+    layer: two in-house wrapping engines beside `textwrap`, a complete
+    `Backend` impl (`HyperlinkBackend`) wrapping `ratatui-crossterm`, and a
+    `Stream` trait already in the graph via `crossterm/event-stream`.
+  - Two of the removals were also correctness work, which is the usual sign the
+    boundary was in the wrong place. `Paragraph` wrapped with textwrap's
+    per-`char` width model and then *measured* the result with tuika's
+    grapheme-aware `str_cols`, so a ZWJ emoji wrapped early; routing it through
+    the same solver as `Wrap` makes wrap and measurement agree by construction,
+    and lets a link's source byte range be carried onto the wrapped row instead
+    of recovered by searching the row's text back through the source. The
+    visible cost is a deliberate behavior change: greedy first-fit instead of
+    textwrap's optimal-fit, whitespace runs collapsed, and no break inside a
+    URL.
+  - Owning terminal-protocol code is only safe with a test that pins what was
+    replaced. tuika's `Backend` is held byte-for-byte identical to
+    `ratatui-crossterm`'s by a differential unit test that draws one corpus
+    through both — `ratatui` is already a dev-dependency, so the crate being
+    removed stays available to prove the removal. Generalized into
+    [Dependency Discipline](processes/maintenance.md#dependency-discipline).
+  - Consolidating two wrap implementations into one solver surfaced a panic
+    neither had been audited for: `Availability::MaxContent` measures at
+    `u16::MAX` columns, and prose long enough to fill a row at that width
+    overflowed the column counter. Untrusted text must degrade, not panic
+    (TM-PARSE) — the arithmetic is saturating now. The lesson is about method:
+    merging two copies of a routine is when its edge cases finally get read.
+  - Cargo's one-way feature unification survives the removal as the one residue:
+    `scrolling-regions` still declares an *optional* `ratatui-crossterm` purely
+    to forward the flag, because turning it on adds two required `Backend`
+    methods and would otherwise break a host's own copy of that crate.
+
 ## 2026-08-19
 
 - **A host pays for a tuika feature only if something references it**

--- a/knowledge/processes/maintenance.md
+++ b/knowledge/processes/maintenance.md
@@ -97,9 +97,17 @@ The small dependency set is a designed property, not an accident
 - **No new runtime dependency without an explicit justification in the PR.** The
   default answer for a heavy concern is a trait the host implements, or a
   separately published companion crate.
-- The `ratatui-core` / `ratatui-crossterm` / `crossterm` versions must stay
-  mutually consistent, and `crossterm` must match what `ratatui-crossterm` pins
-  so Cargo dedups it. A split here silently doubles the backend.
+- The `ratatui-core` and `crossterm` versions must stay mutually consistent
+  with what a host's `ratatui` umbrella resolves to. A split here silently
+  doubles the backend, and splits the `Buffer` type on the interop boundary.
+- **A dependency tuika could own in a page of code is one it should own.** The
+  test is not whether a crate is small but whether its job is small *for tuika*:
+  a crate reached from two call sites, or one supplying a single trait impl over
+  a dependency tuika already has, is carrying transitive weight for work the
+  crate can do itself. Owning it must not mean re-implementing a domain — a
+  Unicode table, a CommonMark parser, a spec-compliant tree builder stays
+  delegated, however tempting — and must come with a test that pins the
+  behavior being replaced, ideally differential against the crate removed.
 - `ratatui` stays a dev-dependency only. If it appears under `[dependencies]`,
   the umbrella has crept back in.
 - Feature flags stay off by default when they add a runtime (`async` adds Tokio).
@@ -120,9 +128,8 @@ places no image, or draws no chart carries none of that code.
 The linker already delivers most of this. Dead-code elimination works at symbol
 granularity, so a feature a host does not reach is dropped even though it is
 compiled into the crate — measurements on a real host confirm the markdown
-stack, `pulldown-cmark` included, costs a non-markdown host nothing, and
-`textwrap`'s `smawk` / `unicode-linebreak` tables likewise never reach the
-binary. **The corollary is what maintenance must watch:** DCE only reaches what
+stack, `pulldown-cmark` included, costs a non-markdown host nothing.
+**The corollary is what maintenance must watch:** DCE only reaches what
 nothing references. A feature stops being pay-for-use the moment code on the
 *unconditional* path names it — most easily by a `match` in a per-frame
 function, which anchors every arm into every binary.

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -179,9 +179,21 @@ types can gain future measurement inputs without another trait-wide break.
 ## Why the `ratatui-core` boundary, not the umbrella
 
 tuika renders none of ratatui's own widgets, so it depends on `ratatui-core`
-(plus `ratatui-crossterm` for the backend) directly. This drops
-`ratatui-widgets`, `ratatui-macros`, and their transitive weight from every
-downstream build that does not use them.
+directly. This drops `ratatui-widgets`, `ratatui-macros`, and their transitive
+weight from every downstream build that does not use them.
+
+It does not take `ratatui-crossterm` either. That crate supplies exactly one
+thing tuika needs — a `Backend` that writes through crossterm — and tuika
+already implemented the whole trait once, in `HyperlinkBackend`, to wrap it.
+Owning the cell-drawing loop as well collapses those two layers into one and
+drops the crate's eight-crate `instability`/`darling` proc-macro tree. The
+emitted byte stream is held byte-identical to `ratatui-crossterm`'s by a
+differential unit test that draws the same cells through both, so the choice
+stays an implementation detail rather than a compatibility claim. tuika keeps an
+*optional* dependency on it under the `scrolling-regions` feature only, to
+forward that flag: enabling `ratatui-core/scrolling-regions` adds two required
+`Backend` methods, and Cargo unifies features one way, so a host's own
+`ratatui-crossterm` would otherwise fail to compile.
 
 It costs nothing in interoperability: the interop boundary is a raw
 `&mut Buffer` from that same `ratatui-core`. A host bringing the `ratatui`

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -45,9 +45,11 @@ The claim is earned by scope and by adoption evidence, never by overstatement:
 2. **Composable over configurable.** Behavior is reached by composing views, not
    by accumulating knobs on a component.
 3. **Dependency-light.** The published crate depends only on `ratatui-core`,
-   `ratatui-crossterm`, `crossterm`, `textwrap`, `unicode-segmentation`,
-   `unicode-width`, and `pulldown-cmark`. Anything heavier belongs behind a
-   trait the host implements.
+   `crossterm`, `unicode-segmentation`, `unicode-width`, and `pulldown-cmark`.
+   Anything heavier belongs behind a trait the host implements — and a
+   dependency tuika could *own* in a page of code, rather than delegate, is one
+   it should: see
+   [Dependency Discipline](../processes/maintenance.md#dependency-discipline).
 4. **Interoperable, not exclusive.** Existing ratatui widgets compose through a
    raw-`Buffer` boundary; adopting tuika never means giving up ratatui.
 5. **Testable without a terminal.** Rendering is observable as cells in memory,

--- a/knowledge/specs/images.md
+++ b/knowledge/specs/images.md
@@ -68,8 +68,8 @@ Scope is deliberately phased:
 
 ### Decoding stays in the host
 
-tuika depends only on ratatui, crossterm, textwrap, unicode-\*, and
-pulldown-cmark, and adds nothing heavy. Image *decoding* (PNG/JPEG → RGBA) is a
+tuika depends only on ratatui-core, crossterm, unicode-\*, and pulldown-cmark,
+and adds nothing heavy. Image *decoding* (PNG/JPEG → RGBA) is a
 heavy dependency, so it stays in the host exactly like syntax highlighting does:
 the host hands tuika an `ImageData` of raw RGBA plus pixel dimensions, the way
 it hands markdown a `Highlighter`. tuika owns *presentation* (protocol

--- a/src/components/dialog_presets.rs
+++ b/src/components/dialog_presets.rs
@@ -4,6 +4,7 @@
 use ratatui_core::layout::Rect;
 use ratatui_core::text::Line;
 
+use crate::components::text::wrap_str;
 use crate::event::{Event, InputOutcome, KeyCode};
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -622,14 +623,9 @@ impl DialogCopy {
         }
         self.text
             .split('\n')
-            .flat_map(|line| {
-                let wrapped = textwrap::wrap(line, usize::from(width));
-                if wrapped.is_empty() {
-                    vec![String::new()]
-                } else {
-                    wrapped.into_iter().map(|line| line.into_owned()).collect()
-                }
-            })
+            // `wrap_str` already yields one empty row for a blank line, so a
+            // deliberate blank between paragraphs survives.
+            .flat_map(|line| wrap_str(line, width).into_iter().map(|row| row.text))
             .collect()
     }
 }

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -14,6 +14,8 @@
 //! every row it reflows to. [`Paragraph`] takes a single alignment for the whole
 //! block via [`Paragraph::alignment`].
 
+use std::ops::Range;
+
 use ratatui_core::layout::{Alignment, Rect};
 use ratatui_core::style::Style;
 use ratatui_core::text::{Line, Span};
@@ -183,43 +185,39 @@ impl Paragraph {
             .split('\n')
             .flat_map(|para| {
                 let links = find_links(para, link_policy);
-                let wrapped = textwrap::wrap(para, width as usize);
-                let mut cursor = 0usize;
-                wrapped.into_iter().map(move |line| {
-                    let text = line.into_owned();
+                wrap_str(para, width).into_iter().map(move |row| {
                     if links.is_empty() {
                         return ParagraphLine {
-                            text,
+                            text: row.text,
                             links: Vec::new(),
                         };
                     }
-                    // textwrap removes boundary whitespace. Searching forward
-                    // maps even repeated words to their source occurrence.
-                    let Some(relative) = para[cursor..].find(text.as_str()) else {
-                        // If the wrapping implementation ever synthesizes text,
-                        // keep rendering but stop inferring source metadata.
-                        cursor = para.len();
-                        return ParagraphLine {
-                            text,
-                            links: Vec::new(),
-                        };
-                    };
-                    let start = cursor + relative;
-                    let end = start.saturating_add(text.len()).min(para.len());
-                    cursor = end;
-                    let links = links
-                        .iter()
-                        .filter_map(|&(link_start, link_end)| {
-                            let visible_start = link_start.max(start);
-                            let visible_end = link_end.min(end);
-                            (visible_start < visible_end).then(|| ParagraphLink {
-                                start: visible_start - start,
-                                end: visible_end - start,
+                    // Each word is copied verbatim, so a source link range
+                    // intersected with a word's range maps onto the row by a
+                    // constant shift — no searching the row's text back through
+                    // the source, and repeated words cannot alias.
+                    let mut out = Vec::new();
+                    for (row_start, src) in &row.words {
+                        for &(link_start, link_end) in &links {
+                            let start = link_start.max(src.start);
+                            let end = link_end.min(src.end);
+                            if start >= end {
+                                continue;
+                            }
+                            out.push(ParagraphLink {
+                                start: row_start + (start - src.start),
+                                end: row_start + (end - src.start),
                                 url: para[link_start..link_end].to_string(),
-                            })
-                        })
-                        .collect();
-                    ParagraphLine { text, links }
+                            });
+                        }
+                    }
+                    // A URL hard-broken across rows contributes one piece per
+                    // word; render walks them in order, so keep them sorted.
+                    out.sort_by_key(|link| link.start);
+                    ParagraphLine {
+                        text: row.text,
+                        links: out,
+                    }
                 })
             })
             .collect()
@@ -323,69 +321,18 @@ fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
         })
         .collect();
     let before = out.len();
-    let mut cur: Vec<(&str, Style)> = Vec::new();
-    let mut cur_w = 0u16;
-    let mut i = 0;
-    let n = cells.len();
-    while i < n {
-        // Collapse a run of whitespace into a single break opportunity.
-        if is_break(cells[i].0) {
-            i += 1;
-            continue;
-        }
-        // Gather one word (a maximal run of non-whitespace).
-        let start = i;
-        let mut word_w = 0u16;
-        while i < n && !is_break(cells[i].0) {
-            word_w = word_w.saturating_add(grapheme_cols(cells[i].0));
-            i += 1;
-        }
-        let word = &cells[start..i];
-        let sep = u16::from(!cur.is_empty());
-        if word_w <= width && cur_w + sep + word_w <= width {
-            // Fits on the current line (with a joining space if needed). The
-            // space inherits the preceding cell's style so a background run
-            // stays continuous across the join.
-            if sep == 1 {
-                let prev = cur.last().map(|c| c.1).unwrap_or_default();
+    let metrics: Vec<CellMetrics> = cells.iter().map(|&(g, _)| CellMetrics::of(g)).collect();
+    for row in wrap_cells(&metrics, width) {
+        let mut cur: Vec<(&str, Style)> = Vec::new();
+        for word in row {
+            // The joining space inherits the preceding cell's style so a
+            // background run stays continuous across the join.
+            if let Some(&(_, prev)) = cur.last() {
                 cur.push((" ", prev));
-                cur_w += 1;
             }
-            cur.extend_from_slice(word);
-            cur_w += word_w;
-        } else if word_w <= width {
-            // Doesn't fit; break to a new line, then place the word.
-            if !cur.is_empty() {
-                out.push(coalesce(&cur));
-                cur.clear();
-            }
-            cur.extend_from_slice(word);
-            cur_w = word_w;
-        } else {
-            // Word wider than the line: hard-break it across lines.
-            if !cur.is_empty() {
-                out.push(coalesce(&cur));
-                cur.clear();
-                cur_w = 0;
-            }
-            for &(g, st) in word {
-                let w = grapheme_cols(g);
-                if cur_w + w > width && !cur.is_empty() {
-                    out.push(coalesce(&cur));
-                    cur.clear();
-                    cur_w = 0;
-                }
-                cur.push((g, st));
-                cur_w += w;
-            }
+            cur.extend_from_slice(&cells[word]);
         }
-    }
-    if !cur.is_empty() {
         out.push(coalesce(&cur));
-    }
-    // Preserve a blank (empty or all-whitespace) input line as one blank row.
-    if out.len() == before {
-        out.push(Line::default());
     }
     // Carry the source line's alignment onto every row it reflowed to, so a
     // centered/right-aligned line stays aligned after wrapping.
@@ -394,6 +341,148 @@ fn wrap_one(line: &Line<'static>, width: u16, out: &mut Vec<Line<'static>>) {
             produced.alignment = Some(align);
         }
     }
+}
+
+/// What the wrap solver needs to know about one grapheme cell: how many columns
+/// it advances, and whether it is a break opportunity.
+#[derive(Clone, Copy)]
+struct CellMetrics {
+    cols: u16,
+    is_break: bool,
+}
+
+impl CellMetrics {
+    fn of(cluster: &str) -> Self {
+        Self {
+            cols: grapheme_cols(cluster),
+            is_break: is_break(cluster),
+        }
+    }
+}
+
+/// The wrap solver, shared by every prose path in tuika.
+///
+/// Greedy and word-oriented over grapheme cells: runs of whitespace collapse to
+/// a single break opportunity, and a word wider than `width` is hard-broken so
+/// no row exceeds it. Each output row is the list of cell-index ranges of the
+/// words on it — callers decide how to join them, which is the only thing
+/// [`wrap_lines`] (a styled space) and [`wrap_str`] (a plain one) disagree
+/// about. Blank (empty or all-whitespace) input yields exactly one empty row, so
+/// a blank source line survives as a blank output line rather than vanishing.
+///
+/// Breaking only at whitespace is deliberate. A Unicode line-break table would
+/// also offer `/` and `-`, which reads better for prose but splits a bare URL
+/// after its scheme — and [`Paragraph`] turns bare URLs into OSC 8 hyperlinks,
+/// so keeping one contiguous is worth more than the ragged edge it costs.
+fn wrap_cells(cells: &[CellMetrics], width: u16) -> Vec<Vec<Range<usize>>> {
+    let mut rows: Vec<Vec<Range<usize>>> = Vec::new();
+    let mut cur: Vec<Range<usize>> = Vec::new();
+    let mut cur_w = 0u16;
+    let mut i = 0;
+    let n = cells.len();
+    while i < n {
+        // Collapse a run of whitespace into a single break opportunity.
+        if cells[i].is_break {
+            i += 1;
+            continue;
+        }
+        // Gather one word (a maximal run of non-whitespace).
+        let start = i;
+        let mut word_w = 0u16;
+        while i < n && !cells[i].is_break {
+            word_w = word_w.saturating_add(cells[i].cols);
+            i += 1;
+        }
+        let sep = u16::from(!cur.is_empty());
+        // Saturating throughout: `width` is `u16::MAX` for a max-content
+        // measurement, so a paragraph long enough to fill a row at that width
+        // would otherwise overflow the column counter and panic. Saturating
+        // keeps the row "still fits", which is the right answer when the caller
+        // asked how wide the text wants to be.
+        if word_w <= width && cur_w.saturating_add(sep).saturating_add(word_w) <= width {
+            // Fits on the current row, with a joining space if it is not first.
+            cur.push(start..i);
+            cur_w = cur_w.saturating_add(sep).saturating_add(word_w);
+        } else if word_w <= width {
+            // Doesn't fit; break to a new row, then place the word.
+            if !cur.is_empty() {
+                rows.push(std::mem::take(&mut cur));
+            }
+            cur.push(start..i);
+            cur_w = word_w;
+        } else {
+            // Word wider than the row: hard-break it across rows. Each piece is
+            // its own word, so no joining space is inserted between them.
+            if !cur.is_empty() {
+                rows.push(std::mem::take(&mut cur));
+                cur_w = 0;
+            }
+            let mut piece = start;
+            for (cell, metrics) in cells.iter().enumerate().take(i).skip(start) {
+                let w = metrics.cols;
+                if cur_w.saturating_add(w) > width && cell > piece {
+                    cur.push(piece..cell);
+                    rows.push(std::mem::take(&mut cur));
+                    piece = cell;
+                    cur_w = 0;
+                }
+                cur_w = cur_w.saturating_add(w);
+            }
+            cur.push(piece..i);
+        }
+    }
+    if !cur.is_empty() {
+        rows.push(cur);
+    }
+    // Preserve a blank (empty or all-whitespace) input line as one blank row.
+    if rows.is_empty() {
+        rows.push(Vec::new());
+    }
+    rows
+}
+
+/// One row of [`wrap_str`]: the wrapped text, plus where each of its pieces came
+/// from in the source.
+pub(crate) struct WrappedRow {
+    /// The row's text, words joined by a single space.
+    pub text: String,
+    /// `(row byte offset, source byte range)` per word, in order. Each word is
+    /// copied verbatim, so the byte at `row_offset + k` is the source byte at
+    /// `src.start + k` — which is what lets a caller carry source metadata (a
+    /// link range, a search hit) onto the wrapped row exactly.
+    pub words: Vec<(usize, Range<usize>)>,
+}
+
+/// Word-wrap plain `text` to `width` columns.
+///
+/// The plain-string counterpart to [`wrap_lines`], on the same solver and so
+/// with the same rules — including tuika's grapheme-aware column widths, which
+/// is what keeps a paragraph's wrap and its measurement from disagreeing about a
+/// ZWJ emoji or a wide glyph. `text` must not contain a newline; callers split
+/// on `\n` first, so a hard break stays a hard break.
+pub(crate) fn wrap_str(text: &str, width: u16) -> Vec<WrappedRow> {
+    let cells: Vec<(usize, &str)> = text.grapheme_indices(true).collect();
+    let metrics: Vec<CellMetrics> = cells.iter().map(|&(_, g)| CellMetrics::of(g)).collect();
+    wrap_cells(&metrics, width)
+        .into_iter()
+        .map(|row| {
+            let mut out = WrappedRow {
+                text: String::new(),
+                words: Vec::new(),
+            };
+            for word in row {
+                if !out.text.is_empty() {
+                    out.text.push(' ');
+                }
+                let (last_offset, last) = cells[word.end - 1];
+                let start = cells[word.start].0;
+                let end = last_offset + last.len();
+                out.words.push((out.text.len(), start..end));
+                out.text.push_str(&text[start..end]);
+            }
+            out
+        })
+        .collect()
 }
 
 /// Merge a run of styled grapheme cells into a [`Line`], coalescing adjacent
@@ -596,6 +685,116 @@ mod tests {
             crate::testing::render_sizes(&paragraph, sizes, &Theme::default()).len(),
             105
         );
+    }
+
+    #[test]
+    fn paragraph_measures_the_width_it_wrapped_to() {
+        // `wrap_str` and `measure` must count columns the same way. A ZWJ family
+        // is one double-width cell to tuika but six scalars wide to a per-`char`
+        // width model, so a wrapper that disagreed would break early and report
+        // a height taller than the text needs.
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+        let text = format!("{family} {family} {family}");
+        let theme = Theme::default();
+        let p = Paragraph::new(text, Style::default());
+        // Three 2-column clusters plus two joining spaces = 8 columns.
+        let size = p.measure(Size::new(8, 4), &RenderCtx::new(&theme));
+        assert_eq!(size, Size::new(8, 1), "all three should fit on one row");
+        let size = p.measure(Size::new(5, 4), &RenderCtx::new(&theme));
+        assert_eq!(size, Size::new(5, 2), "two rows: 2+1+2 columns, then 2");
+    }
+
+    #[test]
+    fn paragraph_breaks_only_at_whitespace_and_collapses_runs() {
+        // `Paragraph` now wraps on the same solver as `Wrap`, so it agrees with
+        // it on two things textwrap decided differently: a run of whitespace is
+        // one break opportunity (not copied through verbatim), and `/` is not
+        // one — which is what keeps a linkified URL contiguous instead of split
+        // after its scheme.
+        let rows = wrap_str("see  https://a.dev  now", 13);
+        assert_eq!(rows[0].text, "see");
+        assert_eq!(rows[1].text, "https://a.dev");
+        assert_eq!(rows[2].text, "now");
+        let buf = crate::testing::render(
+            &Paragraph::new("see  https://a.dev  now", Style::default()),
+            13,
+            3,
+            &Theme::default(),
+        );
+        assert_eq!(
+            link_at(&buf, Rect::new(0, 0, 13, 3), 0, 1).as_deref(),
+            Some("https://a.dev"),
+            "the whole URL stays on one row and resolves as one link"
+        );
+    }
+
+    #[test]
+    fn paragraph_links_each_repeated_url_on_its_own_row() {
+        let buf = crate::testing::render(
+            &Paragraph::new("go https://a.dev go https://b.dev", Style::default()),
+            16,
+            2,
+            &Theme::default(),
+        );
+        let area = Rect::new(0, 0, 16, 2);
+        assert_eq!(link_at(&buf, area, 4, 0).as_deref(), Some("https://a.dev"));
+        assert_eq!(link_at(&buf, area, 4, 1).as_deref(), Some("https://b.dev"));
+    }
+
+    #[test]
+    fn wrap_str_maps_every_word_back_to_its_source_bytes() {
+        let src = "alpha  beta gamma";
+        let rows = wrap_str(src, 11);
+        assert_eq!(rows.len(), 2);
+        // Repeated whitespace collapses in the output text...
+        assert_eq!(rows[0].text, "alpha beta");
+        assert_eq!(rows[1].text, "gamma");
+        // ...but each word still points at the bytes it was copied from.
+        for row in &rows {
+            for (row_start, src_range) in &row.words {
+                let word = &row.text[*row_start..row_start + src_range.len()];
+                assert_eq!(word, &src[src_range.clone()]);
+            }
+        }
+    }
+
+    #[test]
+    fn wrap_str_keeps_a_blank_line_blank() {
+        // One empty row per blank source line is what lets a caller splitting on
+        // '\n' preserve a deliberate gap between paragraphs.
+        assert_eq!(wrap_str("", 10).len(), 1);
+        assert_eq!(wrap_str("", 10)[0].text, "");
+        assert_eq!(wrap_str("   ", 10).len(), 1);
+        assert_eq!(wrap_str("   ", 10)[0].text, "");
+    }
+
+    #[test]
+    fn wrapping_at_max_content_width_does_not_overflow_the_column_counter() {
+        // `Availability::MaxContent` measures at `u16::MAX`, so prose long
+        // enough to exceed 65_535 columns on one row — a pasted log line, a
+        // generated markdown paragraph — reaches the wrap solver's column
+        // arithmetic at its limit. Untrusted text must degrade, never panic.
+        let long = vec!["aaaaaaaa"; 9000].join(" ");
+        let rows = wrap_str(&long, u16::MAX);
+        assert_eq!(rows.len(), 1, "everything fits at max-content width");
+        let one_word_per_gap = long.split(' ').count();
+        assert_eq!(rows[0].words.len(), one_word_per_gap);
+
+        // The styled path shares the solver, so it is covered by the same fix.
+        let out = wrap_lines(&[Line::from(long)], u16::MAX);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn wrap_str_hard_breaks_an_overlong_word_without_exceeding_the_width() {
+        let rows = wrap_str("short supercalifragilistic", 8);
+        assert!(
+            rows.iter().all(|r| str_cols(&r.text) <= 8),
+            "no row may exceed the width: {:?}",
+            rows.iter().map(|r| &r.text).collect::<Vec<_>>()
+        );
+        let joined: String = rows.iter().map(|r| r.text.replace(' ', "")).collect();
+        assert_eq!(joined, "shortsupercalifragilistic");
     }
 
     #[test]

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -3,8 +3,9 @@
 //! [`Markdown`](crate::components::Markdown) without tuika taking on any grammar
 //! dependency.
 //!
-//! tuika deliberately depends only on `ratatui`, `crossterm`, `textwrap`, and
-//! the `unicode-*` crates; a real highlighter (tree-sitter, syntect, …) pulls in
+//! tuika deliberately depends only on `ratatui-core`, `crossterm`, the
+//! `unicode-*` crates, and `pulldown-cmark`; a real highlighter (tree-sitter,
+//! syntect, …) pulls in
 //! far more. So the toolkit owns only this trait and the *presentation* of code
 //! (framing, background, language label, wrapping), while the host supplies the
 //! token colors. The companion crate `tuika-codeformatters` ships a tree-sitter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,12 @@
 //! mode (alternate screen or a split footer over live terminal scrollback),
 //! and a set of components (text, boxes, scroll, select, spinner, progress) —
 //! while letting ratatui keep ownership of the cell buffer and its diff against
-//! the terminal. It builds against `ratatui-core` (and `ratatui-crossterm` for
-//! the backend) directly rather than the `ratatui` umbrella — it renders none of
-//! ratatui's own widgets — so `ratatui-widgets` and `ratatui-macros` stay out of
-//! its dependency tree. It otherwise depends only on `crossterm`, `textwrap`,
-//! `unicode-segmentation`, and `unicode-width`.
+//! the terminal. It builds against `ratatui-core` directly rather than the
+//! `ratatui` umbrella — it renders none of ratatui's own widgets — so
+//! `ratatui-widgets` and `ratatui-macros` stay out of its dependency tree, and
+//! it writes to the terminal through its own crossterm backend rather than
+//! `ratatui-crossterm`. It otherwise depends only on `crossterm`,
+//! `unicode-segmentation`, `unicode-width`, and `pulldown-cmark`.
 //!
 //! It was extracted from the [yolop](https://github.com/everruns/yolop) coding
 //! agent, whose full-screen renderer is built on it, but it knows nothing about

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -61,12 +61,12 @@ use std::convert::Infallible;
 use std::io;
 use std::time::Duration;
 
+use super::stream::{self, Stream};
+use crate::term::backend::CrosstermBackend;
 use crossterm::event::EventStream;
 use ratatui_core::backend::Backend;
 use ratatui_core::terminal::{Terminal, TerminalOptions};
-use ratatui_crossterm::CrosstermBackend;
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior, interval, sleep_until};
-use tokio_stream::{Stream, StreamExt};
 
 use super::{
     FrameGraphics, FrameGraphicsCleanup, PaintRoot, RESIZE_FRAME_INTERVAL, RunnerAction,
@@ -329,7 +329,9 @@ impl AsyncRunner {
     ///
     /// # Mechanics
     ///
-    /// The producer sends through any Tokio [`Stream`], so no shared mutable
+    /// The producer sends through any [`Stream`](futures_core::Stream) — a
+    /// `tokio_stream` wrapper, a `futures` channel, anything implementing the
+    /// trait — so no shared mutable
     /// state, synthetic terminal events, or short polling interval is needed.
     /// The frame source is the one [`run`](Self::run) takes, at `M` instead of
     /// the default [`Infallible`]. A completed message stream disables only
@@ -391,7 +393,7 @@ impl AsyncRunner {
             },
         )?;
         let _graphics_cleanup = FrameGraphicsCleanup(&graphics);
-        let events = EventStream::new().filter_map(|result| match result {
+        let events = stream::filter_map(EventStream::new(), |result| match result {
             Ok(raw) => translate_event(raw).map(Ok),
             Err(error) => Some(Err(error)),
         });
@@ -452,7 +454,7 @@ impl AsyncRunner {
                 viewport: mode.viewport(),
             },
         )?;
-        let events = EventStream::new().filter_map(|result| match result {
+        let events = stream::filter_map(EventStream::new(), |result| match result {
             Ok(raw) => translate_event(raw).map(Ok),
             Err(error) => Some(Err(error)),
         });
@@ -632,7 +634,7 @@ impl AsyncRunner {
                 _ = sleep_until(deadline), if redraw_at.is_some() => Wake::Redraw,
                 () = self.redraw.requested() => Wake::Requested,
                 _ = ticker.tick() => Wake::Tick,
-                item = events.next(), if !events_done => match item {
+                item = stream::next(&mut events), if !events_done => match item {
                     Some(Ok(event)) => Wake::Event(event),
                     Some(Err(error)) => return Err(error),
                     None => {
@@ -640,7 +642,7 @@ impl AsyncRunner {
                         continue;
                     }
                 },
-                item = messages.next(), if !messages_done => match item {
+                item = stream::next(&mut messages), if !messages_done => match item {
                     Some(Ok(message)) => Wake::Message(message),
                     Some(Err(error)) => return Err(error),
                     None => {
@@ -772,7 +774,7 @@ where
 /// The message type is [`Infallible`], so [`Signal::Message`] is uninhabited and
 /// an `update` that handles only ticks and events stays exhaustive.
 pub fn no_messages<Er>() -> impl Stream<Item = Result<Infallible, Er>> + Unpin {
-    tokio_stream::empty()
+    stream::empty()
 }
 
 #[cfg(test)]
@@ -839,7 +841,7 @@ mod tests {
         });
         let mut terminal = terminal(24, 1);
         let mut count = 0u64;
-        let events = tokio_stream::iter([
+        let events = stream::iter([
             key(KeyCode::Char('a')),
             key(KeyCode::Char('a')),
             key(KeyCode::Char('q')),
@@ -886,7 +888,7 @@ mod tests {
         let mut terminal = terminal(16, 1);
         let mut state = 0u8;
         let views = std::cell::Cell::new(0usize);
-        let events = tokio_stream::iter([key(KeyCode::Char('a')), key(KeyCode::Esc)]);
+        let events = stream::iter([key(KeyCode::Char('a')), key(KeyCode::Esc)]);
 
         runner
             .run_driven_by(
@@ -926,7 +928,7 @@ mod tests {
         });
         let mut terminal = terminal(11, 1);
         let mut mouse_events = 0usize;
-        let events = tokio_stream::iter([
+        let events = stream::iter([
             mouse(MouseKind::Down(MouseButton::Left), 0, 0),
             mouse(MouseKind::Drag(MouseButton::Left), 4, 0),
             key(KeyCode::Esc),
@@ -978,7 +980,7 @@ mod tests {
         });
         let mut terminal = terminal(11, 1);
         let mut state = ();
-        let events = tokio_stream::iter([
+        let events = stream::iter([
             mouse(MouseKind::Down(MouseButton::Left), 0, 0),
             mouse(MouseKind::Drag(MouseButton::Left), 4, 0),
             key(KeyCode::Esc),
@@ -1020,7 +1022,7 @@ mod tests {
         });
         let mut terminal = terminal(12, 1);
         let mut scrolled = false;
-        let events = tokio_stream::iter([mouse(MouseKind::ScrollDown, 0, 0), key(KeyCode::Esc)]);
+        let events = stream::iter([mouse(MouseKind::ScrollDown, 0, 0), key(KeyCode::Esc)]);
 
         runner
             .run_driven_by(
@@ -1063,7 +1065,7 @@ mod tests {
         let mut terminal = terminal(16, 1);
         let mut state = ();
         let views = std::cell::Cell::new(0usize);
-        let events = tokio_stream::iter((0..3).map(|_| {
+        let events = stream::iter((0..3).map(|_| {
             Ok(Event::Resize {
                 width: 16,
                 height: 1,
@@ -1105,7 +1107,7 @@ mod tests {
         let runner = AsyncRunner::new(RunnerConfig::default());
         let mut terminal = terminal(16, 1);
         let mut state = "hello";
-        let events = tokio_stream::iter([key(KeyCode::Esc)]);
+        let events = stream::iter([key(KeyCode::Esc)]);
 
         runner
             .run_driven_by(
@@ -1137,7 +1139,7 @@ mod tests {
         });
         let mut terminal = terminal(20, 1);
         let mut ticks = 0u64;
-        let events = tokio_stream::iter(Vec::<Result<Event, Infallible>>::new());
+        let events = stream::iter(Vec::<Result<Event, Infallible>>::new());
 
         runner
             .run_driven_by(
@@ -1200,7 +1202,7 @@ mod tests {
             },
         )
         .expect("inline terminal");
-        let events = tokio_stream::iter([key(KeyCode::Char('a')), key(KeyCode::Char('q'))]);
+        let events = stream::iter([key(KeyCode::Char('a')), key(KeyCode::Char('q'))]);
         let mut state = ();
 
         runner
@@ -1296,7 +1298,7 @@ mod tests {
                         }
                     },
                 ),
-                tokio_stream::iter(Vec::<Result<Event, Infallible>>::new()),
+                stream::iter(Vec::<Result<Event, Infallible>>::new()),
                 no_messages(),
             )
             .await
@@ -1327,7 +1329,7 @@ mod tests {
         let scrollback = runner.scrollback();
         scrollback.write(|_width| element(Text::raw("dropped")));
         let mut terminal = terminal(16, 2);
-        let events = tokio_stream::iter([key(KeyCode::Char('a')), key(KeyCode::Esc)]);
+        let events = stream::iter([key(KeyCode::Char('a')), key(KeyCode::Esc)]);
         let mut state = ();
 
         runner
@@ -1362,8 +1364,8 @@ mod tests {
     // given rect and never touches the terminal.
     #[tokio::test]
     async fn stream_error_propagates() {
+        use crate::term::backend::CrosstermBackend;
         use ratatui_core::layout::Rect;
-        use ratatui_crossterm::CrosstermBackend;
 
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
@@ -1377,7 +1379,7 @@ mod tests {
         )
         .expect("test terminal");
         let mut state = ();
-        let events = tokio_stream::iter([Err::<Event, io::Error>(io::Error::other("boom"))]);
+        let events = stream::iter([Err::<Event, io::Error>(io::Error::other("boom"))]);
 
         let result = runner
             .run_driven_by(
@@ -1421,8 +1423,8 @@ mod tests {
         });
         let mut terminal = terminal(24, 1);
         let mut count = 0u64;
-        let events = tokio_stream::iter([key(KeyCode::Char('a'))]);
-        let messages = tokio_stream::iter([Ok::<_, Infallible>(Message::Add(7))]);
+        let events = stream::iter([key(KeyCode::Char('a'))]);
+        let messages = stream::iter([Ok::<_, Infallible>(Message::Add(7))]);
 
         runner
             .run_driven_by(
@@ -1491,8 +1493,8 @@ mod tests {
                         _ => UpdateResult::Clean,
                     },
                 ),
-                tokio_stream::empty::<Result<Event, Infallible>>(),
-                tokio_stream::empty::<Result<(), Infallible>>(),
+                stream::empty::<Result<Event, Infallible>>(),
+                stream::empty::<Result<(), Infallible>>(),
             )
             .await
             .unwrap();
@@ -1516,7 +1518,7 @@ mod tests {
         let mut terminal = terminal(16, 1);
         let views = std::cell::Cell::new(0usize);
         let mut state = 0u8;
-        let messages = tokio_stream::iter([
+        let messages = stream::iter([
             Ok::<_, Infallible>(Message::Clean),
             Ok(Message::Dirty),
             Ok(Message::Exit),
@@ -1548,7 +1550,7 @@ mod tests {
                         _ => UpdateResult::Clean,
                     },
                 ),
-                tokio_stream::empty::<Result<Event, Infallible>>(),
+                stream::empty::<Result<Event, Infallible>>(),
                 messages,
             )
             .await
@@ -1573,7 +1575,7 @@ mod tests {
         )
         .expect("test terminal");
         let mut state = ();
-        let messages = tokio_stream::iter([Err::<(), io::Error>(io::Error::other("message boom"))]);
+        let messages = stream::iter([Err::<(), io::Error>(io::Error::other("message boom"))]);
 
         let result = runner
             .run_driven_by(
@@ -1584,7 +1586,7 @@ mod tests {
                     |_state, _| element(Text::raw("x")),
                     async |_state, _signal| UpdateResult::Clean,
                 ),
-                tokio_stream::empty::<Result<Event, io::Error>>(),
+                stream::empty::<Result<Event, io::Error>>(),
                 messages,
             )
             .await;
@@ -1655,7 +1657,7 @@ mod tests {
             title: "n".into(),
             hits: Vec::new(),
         };
-        let events = tokio_stream::iter([
+        let events = stream::iter([
             key(KeyCode::Char('a')),
             key(KeyCode::Char('b')),
             key(KeyCode::Esc),
@@ -1711,14 +1713,14 @@ mod tests {
         });
         let mut terminal = terminal(12, 1);
         let mut app = Feed { items: Vec::new() };
-        let messages = tokio_stream::iter([Ok::<u8, Infallible>(7), Ok(9), Ok(0)]);
+        let messages = stream::iter([Ok::<u8, Infallible>(7), Ok(9), Ok(0)]);
 
         runner
             .run_driven_by(
                 &mut terminal,
                 &Theme::default(),
                 &mut app,
-                tokio_stream::empty::<Result<Event, Infallible>>(),
+                stream::empty::<Result<Event, Infallible>>(),
                 messages,
             )
             .await

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -77,6 +77,8 @@
 
 #[cfg(feature = "async")]
 mod asynchronous;
+#[cfg(feature = "async")]
+mod stream;
 
 #[cfg(feature = "async")]
 #[allow(deprecated)]
@@ -91,12 +93,12 @@ use std::io::{self, Write};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::term::backend::CrosstermBackend;
 use crossterm::event;
 use ratatui_core::backend::Backend;
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 use ratatui_core::terminal::{Terminal, TerminalOptions};
-use ratatui_crossterm::CrosstermBackend;
 
 use crate::host::paint_with_context_and_sources;
 use crate::live::RedrawHandle;
@@ -365,7 +367,7 @@ where
 /// [`Runner::run`] uses the real terminal; [`Runner::run_driven_by`] takes one
 /// of these instead, which is what lets a host — or a test — drive the loop
 /// without a tty. The asynchronous runner takes a
-/// [`Stream`](tokio_stream::Stream) for the same reason.
+/// [`Stream`](futures_core::Stream) for the same reason.
 ///
 /// An implementation must **consume the timeout** when it has nothing to
 /// deliver: the loop uses this call as its only sleep, so returning `Ok(None)`

--- a/src/runner/stream.rs
+++ b/src/runner/stream.rs
@@ -1,0 +1,150 @@
+//! The few `Stream` adapters the async runner needs.
+//!
+//! The runner drives two streams (terminal events and application messages) and
+//! nothing else, so it needs exactly three things: the [`Stream`] trait to name
+//! in its bounds, a cancel-safe `next`, and a `filter_map` to turn crossterm's
+//! raw events into tuika's. `tokio-stream` supplies all three, but the trait it
+//! offers *is* `futures_core::Stream` — which the build already contains,
+//! because the `async` feature turns on `crossterm/event-stream` and that pulls
+//! `futures-core` in. Owning the three adapters therefore drops a dependency
+//! without adding one, and keeps the public bounds on
+//! [`run_with_messages`](super::AsyncRunner::run_with_messages) unchanged: a
+//! host still passes a `tokio_stream::wrappers::ReceiverStream` or any other
+//! `futures` stream, because it is the same trait.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pub use futures_core::Stream;
+
+/// Await the stream's next item.
+///
+/// Cancel-safe, which is what lets this be a `tokio::select!` branch: the
+/// returned future only ever observes a `Poll::Ready` item by yielding it, so a
+/// branch that loses the select drops the future without consuming anything.
+pub(crate) fn next<S>(stream: &mut S) -> impl Future<Output = Option<S::Item>> + '_
+where
+    S: Stream + Unpin + ?Sized,
+{
+    std::future::poll_fn(move |cx| Pin::new(&mut *stream).poll_next(cx))
+}
+
+/// Map each item and drop the `None`s, the `StreamExt::filter_map` shape.
+pub(crate) fn filter_map<S, F, T>(stream: S, f: F) -> FilterMap<S, F>
+where
+    S: Stream + Unpin,
+    F: FnMut(S::Item) -> Option<T>,
+{
+    FilterMap { stream, f }
+}
+
+/// The stream returned by [`filter_map`].
+pub(crate) struct FilterMap<S, F> {
+    stream: S,
+    f: F,
+}
+
+// `Unpin` on the source is required by the constructor, so this adapter is
+// `Unpin` too and can be projected with `Pin::new` instead of a pin-projection
+// dependency.
+impl<S, F, T> Stream for FilterMap<S, F>
+where
+    S: Stream + Unpin,
+    F: FnMut(S::Item) -> Option<T> + Unpin,
+{
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        let this = self.get_mut();
+        loop {
+            match Pin::new(&mut this.stream).poll_next(cx) {
+                // A filtered-out item is not a wake-up: keep polling the source
+                // until it yields a kept item or reports pending/end itself.
+                Poll::Ready(Some(item)) => match (this.f)(item) {
+                    Some(mapped) => return Poll::Ready(Some(mapped)),
+                    None => continue,
+                },
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+/// A stream that is immediately and permanently exhausted.
+pub(crate) fn empty<T>() -> Empty<T> {
+    Empty(std::marker::PhantomData)
+}
+
+/// The stream returned by [`empty`].
+pub(crate) struct Empty<T>(std::marker::PhantomData<fn() -> T>);
+
+impl<T> Stream for Empty<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<T>> {
+        Poll::Ready(None)
+    }
+}
+
+/// A stream that yields an iterator's items and then ends.
+#[cfg(test)]
+pub(crate) fn iter<I>(items: I) -> Iter<I::IntoIter>
+where
+    I: IntoIterator,
+{
+    Iter(items.into_iter())
+}
+
+/// The stream returned by [`iter`].
+#[cfg(test)]
+pub(crate) struct Iter<I>(I);
+
+#[cfg(test)]
+impl<I: Iterator + Unpin> Stream for Iter<I> {
+    type Item = I::Item;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<I::Item>> {
+        Poll::Ready(self.get_mut().0.next())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn iter_yields_then_ends() {
+        let mut s = iter([1, 2, 3]);
+        assert_eq!(next(&mut s).await, Some(1));
+        assert_eq!(next(&mut s).await, Some(2));
+        assert_eq!(next(&mut s).await, Some(3));
+        assert_eq!(next(&mut s).await, None);
+        // Exhaustion is permanent, so a select branch gated on "not done" can
+        // rely on one `None` meaning the source is finished.
+        assert_eq!(next(&mut s).await, None);
+    }
+
+    #[tokio::test]
+    async fn empty_ends_immediately() {
+        let mut s = empty::<u8>();
+        assert_eq!(next(&mut s).await, None);
+    }
+
+    #[tokio::test]
+    async fn filter_map_drops_and_maps() {
+        let mut s = filter_map(iter([1, 2, 3, 4]), |n| (n % 2 == 0).then(|| n * 10));
+        assert_eq!(next(&mut s).await, Some(20));
+        assert_eq!(next(&mut s).await, Some(40));
+        assert_eq!(next(&mut s).await, None);
+    }
+
+    #[tokio::test]
+    async fn filter_map_skips_a_leading_run_without_stalling() {
+        // Every item before the first kept one is filtered out; the adapter must
+        // keep polling rather than return `Pending` with no waker registered.
+        let mut s = filter_map(iter([1, 1, 1, 2]), |n| (n % 2 == 0).then_some(n));
+        assert_eq!(next(&mut s).await, Some(2));
+        assert_eq!(next(&mut s).await, None);
+    }
+}

--- a/src/term/backend.rs
+++ b/src/term/backend.rs
@@ -1,0 +1,502 @@
+//! tuika's ratatui [`Backend`], written directly against crossterm.
+//!
+//! This is the only piece tuika needs from `ratatui-crossterm`, and taking it
+//! in-house drops that crate and the eight-crate `instability`/`darling`
+//! proc-macro tree behind it from every consumer's graph. The trade is small
+//! because tuika already owned the other half of this boundary:
+//! [`HyperlinkBackend`](super::hyperlink::HyperlinkBackend) already implements
+//! `Backend` end to end and already maps ratatui colors and styles onto
+//! crossterm commands for `write_line`. What was left was the cell-drawing loop
+//! and a handful of one-line command wrappers.
+//!
+//! The emitted byte stream is deliberately identical to `ratatui-crossterm`'s:
+//! same cursor-move elision for a contiguous run, same attribute-diff order,
+//! same trailing reset. `tests/pty_smoke.rs` asserts the result through a
+//! reference terminal parser, which is what makes owning this safe rather than
+//! brave.
+
+use std::io::{self, Write};
+
+use crossterm::cursor::{Hide, MoveTo, Show};
+use crossterm::queue;
+use crossterm::style::{
+    Attribute as CtAttribute, Color as CtColor, Colors as CtColors, Print, SetAttribute,
+    SetBackgroundColor, SetColors, SetForegroundColor, SetUnderlineColor,
+};
+use crossterm::terminal::{self, Clear};
+use ratatui_core::backend::{Backend, ClearType, WindowSize};
+use ratatui_core::buffer::Cell;
+use ratatui_core::layout::{Position, Size};
+use ratatui_core::style::{Color, Modifier};
+
+use super::hyperlink::to_ct_color;
+
+/// A ratatui [`Backend`] that draws through crossterm.
+///
+/// Internal: hosts reach the terminal through
+/// [`Runner`](crate::Runner)/[`AsyncRunner`](crate::AsyncRunner), or wrap their
+/// own writer in [`HyperlinkBackend`](super::hyperlink::HyperlinkBackend). A
+/// host that wants a bare backend still has ratatui's own.
+pub(crate) struct CrosstermBackend<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> CrosstermBackend<W> {
+    /// Draw into `writer` — in production the process's stdout, in tests a
+    /// `Vec<u8>` the assertions read back.
+    pub(crate) const fn new(writer: W) -> Self {
+        Self { writer }
+    }
+}
+
+impl<W: Write> Write for CrosstermBackend<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+impl<W: Write> Backend for CrosstermBackend<W> {
+    type Error = io::Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        // ratatui hands over only the cells that changed, so the stream is
+        // sparse. Everything here exists to keep it small: the cursor moves only
+        // when the next cell is not adjacent to the last, and colors and
+        // attributes are re-emitted only on a change.
+        let mut fg = Color::Reset;
+        let mut bg = Color::Reset;
+        let mut underline_color = Color::Reset;
+        let mut modifier = Modifier::empty();
+        let mut last_pos: Option<Position> = None;
+        for (x, y, cell) in content {
+            if !matches!(last_pos, Some(p) if x == p.x + 1 && y == p.y) {
+                queue!(self.writer, MoveTo(x, y))?;
+            }
+            last_pos = Some(Position { x, y });
+            if cell.modifier != modifier {
+                queue_modifier_diff(&mut self.writer, modifier, cell.modifier)?;
+                modifier = cell.modifier;
+            }
+            if cell.fg != fg || cell.bg != bg {
+                queue!(
+                    self.writer,
+                    SetColors(CtColors::new(to_ct_color(cell.fg), to_ct_color(cell.bg)))
+                )?;
+                fg = cell.fg;
+                bg = cell.bg;
+            }
+            if cell.underline_color != underline_color {
+                queue!(
+                    self.writer,
+                    SetUnderlineColor(to_ct_color(cell.underline_color))
+                )?;
+                underline_color = cell.underline_color;
+            }
+            queue!(self.writer, Print(cell.symbol()))?;
+        }
+        // Leave the terminal in a neutral state: whatever the host prints next
+        // — a published scrollback block, its own shell prompt after exit — must
+        // not inherit the last cell's color or attributes.
+        queue!(
+            self.writer,
+            SetForegroundColor(CtColor::Reset),
+            SetBackgroundColor(CtColor::Reset),
+            SetUnderlineColor(CtColor::Reset),
+            SetAttribute(CtAttribute::Reset),
+        )
+    }
+
+    fn hide_cursor(&mut self) -> io::Result<()> {
+        queue!(self.writer, Hide)?;
+        self.writer.flush()
+    }
+
+    fn show_cursor(&mut self) -> io::Result<()> {
+        queue!(self.writer, Show)?;
+        self.writer.flush()
+    }
+
+    fn get_cursor_position(&mut self) -> io::Result<Position> {
+        crossterm::cursor::position()
+            .map(|(x, y)| Position { x, y })
+            .map_err(io::Error::other)
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
+        let Position { x, y } = position.into();
+        queue!(self.writer, MoveTo(x, y))?;
+        self.writer.flush()
+    }
+
+    fn clear(&mut self) -> io::Result<()> {
+        self.clear_region(ClearType::All)
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
+        queue!(
+            self.writer,
+            Clear(match clear_type {
+                ClearType::All => terminal::ClearType::All,
+                ClearType::AfterCursor => terminal::ClearType::FromCursorDown,
+                ClearType::BeforeCursor => terminal::ClearType::FromCursorUp,
+                ClearType::CurrentLine => terminal::ClearType::CurrentLine,
+                ClearType::UntilNewLine => terminal::ClearType::UntilNewLine,
+            })
+        )?;
+        self.writer.flush()
+    }
+
+    fn append_lines(&mut self, n: u16) -> io::Result<()> {
+        for _ in 0..n {
+            queue!(self.writer, Print("\n"))?;
+        }
+        self.writer.flush()
+    }
+
+    fn size(&self) -> io::Result<Size> {
+        let (width, height) = terminal::size()?;
+        Ok(Size { width, height })
+    }
+
+    fn window_size(&mut self) -> io::Result<WindowSize> {
+        let terminal::WindowSize {
+            columns,
+            rows,
+            width,
+            height,
+        } = terminal::window_size()?;
+        Ok(WindowSize {
+            columns_rows: Size {
+                width: columns,
+                height: rows,
+            },
+            pixels: Size { width, height },
+        })
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        queue!(self.writer, ScrollInRegion::up(region, amount))?;
+        self.writer.flush()
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(&mut self, region: std::ops::Range<u16>, amount: u16) -> io::Result<()> {
+        queue!(self.writer, ScrollInRegion::down(region, amount))?;
+        self.writer.flush()
+    }
+}
+
+/// Emit the attribute changes that turn `from` into `to`.
+///
+/// Order matters and is not arbitrary. Bold and dim share one SGR intensity
+/// slot, so dropping either has to reset the slot and then re-apply whichever
+/// of the two survives — which is why the intensity reset is decided first and
+/// the `added` pass skips bold/dim when it already ran. Slow and rapid blink
+/// share a slot the same way.
+fn queue_modifier_diff<W: Write>(w: &mut W, from: Modifier, to: Modifier) -> io::Result<()> {
+    let removed = from - to;
+    if removed.contains(Modifier::REVERSED) {
+        queue!(w, SetAttribute(CtAttribute::NoReverse))?;
+    }
+    let reset_intensity = removed.contains(Modifier::BOLD) || removed.contains(Modifier::DIM);
+    if reset_intensity {
+        queue!(w, SetAttribute(CtAttribute::NormalIntensity))?;
+        if to.contains(Modifier::DIM) {
+            queue!(w, SetAttribute(CtAttribute::Dim))?;
+        }
+        if to.contains(Modifier::BOLD) {
+            queue!(w, SetAttribute(CtAttribute::Bold))?;
+        }
+    }
+    if removed.contains(Modifier::ITALIC) {
+        queue!(w, SetAttribute(CtAttribute::NoItalic))?;
+    }
+    if removed.contains(Modifier::UNDERLINED) {
+        queue!(w, SetAttribute(CtAttribute::NoUnderline))?;
+    }
+    if removed.contains(Modifier::CROSSED_OUT) {
+        queue!(w, SetAttribute(CtAttribute::NotCrossedOut))?;
+    }
+    if removed.contains(Modifier::HIDDEN) {
+        queue!(w, SetAttribute(CtAttribute::NoHidden))?;
+    }
+    if removed.contains(Modifier::SLOW_BLINK) || removed.contains(Modifier::RAPID_BLINK) {
+        queue!(w, SetAttribute(CtAttribute::NoBlink))?;
+    }
+
+    let added = to - from;
+    if added.contains(Modifier::REVERSED) {
+        queue!(w, SetAttribute(CtAttribute::Reverse))?;
+    }
+    if added.contains(Modifier::BOLD) && !reset_intensity {
+        queue!(w, SetAttribute(CtAttribute::Bold))?;
+    }
+    if added.contains(Modifier::ITALIC) {
+        queue!(w, SetAttribute(CtAttribute::Italic))?;
+    }
+    if added.contains(Modifier::UNDERLINED) {
+        queue!(w, SetAttribute(CtAttribute::Underlined))?;
+    }
+    if added.contains(Modifier::DIM) && !reset_intensity {
+        queue!(w, SetAttribute(CtAttribute::Dim))?;
+    }
+    if added.contains(Modifier::CROSSED_OUT) {
+        queue!(w, SetAttribute(CtAttribute::CrossedOut))?;
+    }
+    if added.contains(Modifier::HIDDEN) {
+        queue!(w, SetAttribute(CtAttribute::Hidden))?;
+    }
+    if added.contains(Modifier::SLOW_BLINK) {
+        queue!(w, SetAttribute(CtAttribute::SlowBlink))?;
+    }
+    if added.contains(Modifier::RAPID_BLINK) {
+        queue!(w, SetAttribute(CtAttribute::RapidBlink))?;
+    }
+    Ok(())
+}
+
+/// Scroll a DECSTBM region, the command crossterm itself does not expose.
+///
+/// Reached only under the `scrolling-regions` feature. The region is set,
+/// scrolled, and reset in one command so no other writer can observe a
+/// half-configured terminal — a leaked scrolling region would confine every
+/// later write to those rows.
+#[cfg(feature = "scrolling-regions")]
+struct ScrollInRegion {
+    first_row: u16,
+    last_row: u16,
+    lines: u16,
+    /// `S` scrolls the region's content up, `T` down.
+    verb: char,
+}
+
+#[cfg(feature = "scrolling-regions")]
+impl ScrollInRegion {
+    fn up(region: std::ops::Range<u16>, lines: u16) -> Self {
+        Self::new(region, lines, 'S')
+    }
+
+    fn down(region: std::ops::Range<u16>, lines: u16) -> Self {
+        Self::new(region, lines, 'T')
+    }
+
+    fn new(region: std::ops::Range<u16>, lines: u16, verb: char) -> Self {
+        Self {
+            first_row: region.start,
+            last_row: region.end.saturating_sub(1),
+            lines,
+            verb,
+        }
+    }
+}
+
+#[cfg(feature = "scrolling-regions")]
+impl crossterm::Command for ScrollInRegion {
+    fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
+        if self.lines == 0 {
+            return Ok(());
+        }
+        // DECSTBM rows are 1-based.
+        write!(
+            f,
+            "\x1b[{};{}r\x1b[{}{}\x1b[r",
+            self.first_row.saturating_add(1),
+            self.last_row.saturating_add(1),
+            self.lines,
+            self.verb,
+        )
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "scrolling regions are not supported through the Windows console API",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui_core::style::Style;
+
+    /// Draw `cells` at consecutive columns on row 0 and return the byte stream.
+    fn drawn(cells: &[(&'static str, Style)]) -> String {
+        let owned: Vec<Cell> = cells
+            .iter()
+            .map(|&(symbol, style)| {
+                let mut cell = Cell::new(symbol);
+                cell.set_style(style);
+                cell
+            })
+            .collect();
+        let mut backend = CrosstermBackend::new(Vec::<u8>::new());
+        backend
+            .draw(
+                owned
+                    .iter()
+                    .enumerate()
+                    .map(|(i, cell)| (i as u16, 0u16, cell)),
+            )
+            .expect("draw");
+        String::from_utf8(backend.writer).expect("utf8")
+    }
+
+    #[test]
+    fn a_contiguous_run_moves_the_cursor_once() {
+        let out = drawn(&[
+            ("a", Style::default()),
+            ("b", Style::default()),
+            ("c", Style::default()),
+        ]);
+        assert_eq!(out.matches("\x1b[1;1H").count(), 1);
+        assert_eq!(
+            out.matches('H').count(),
+            1,
+            "no second cursor move: {out:?}"
+        );
+        assert!(out.contains('a') && out.contains('b') && out.contains('c'));
+    }
+
+    #[test]
+    fn a_gap_in_the_run_re_emits_a_cursor_move() {
+        let a = Cell::new("a");
+        let b = Cell::new("b");
+        let mut backend = CrosstermBackend::new(Vec::<u8>::new());
+        backend
+            .draw([(0u16, 0u16, &a), (5u16, 0u16, &b)].into_iter())
+            .expect("draw");
+        let out = String::from_utf8(backend.writer).expect("utf8");
+        assert!(out.contains("\x1b[1;1H"), "{out:?}");
+        assert!(out.contains("\x1b[1;6H"), "{out:?}");
+    }
+
+    #[test]
+    fn colors_are_emitted_once_per_change_and_reset_at_the_end() {
+        let red = Style::default().fg(Color::Rgb(255, 0, 0));
+        let out = drawn(&[("a", red), ("b", red), ("c", Style::default())]);
+        assert_eq!(
+            out,
+            // Move once, set the pair once for "ab", set it once more for "c",
+            // then reset fg/bg/underline/attributes. Not one color run per cell.
+            "\x1b[1;1H\x1b[38;2;255;0;0;49mab\x1b[39;49mc\x1b[39m\x1b[49m\x1b[59m\x1b[0m"
+        );
+    }
+
+    #[test]
+    fn dropping_bold_while_keeping_dim_reapplies_dim() {
+        // Bold and dim share the SGR intensity slot, so clearing bold clears dim
+        // too — the diff has to put it back or the run silently brightens.
+        let mut out = Vec::new();
+        queue_modifier_diff(&mut out, Modifier::BOLD | Modifier::DIM, Modifier::DIM).expect("diff");
+        let out = String::from_utf8(out).expect("utf8");
+        assert_eq!(out, "\x1b[22m\x1b[2m", "normal intensity, then dim again");
+    }
+
+    #[test]
+    fn adding_an_attribute_does_not_reset_the_others() {
+        let mut out = Vec::new();
+        queue_modifier_diff(&mut out, Modifier::BOLD, Modifier::BOLD | Modifier::ITALIC)
+            .expect("diff");
+        let out = String::from_utf8(out).expect("utf8");
+        assert_eq!(out, "\x1b[3m", "italic only: {out:?}");
+    }
+
+    /// Byte-for-byte parity with the crate this backend replaced.
+    ///
+    /// `ratatui-crossterm` is still reachable from tests through the `ratatui`
+    /// dev-dependency, so the removal can be *proved* rather than asserted:
+    /// every terminal tuika supports already agrees on what that byte stream
+    /// means. The corpus below is chosen to hit the paths where a hand-written
+    /// backend would plausibly drift — cursor elision, the shared
+    /// intensity/blink SGR slots, indexed and truecolor pairs, underline color,
+    /// and wide/zero-width symbols.
+    #[test]
+    fn the_byte_stream_matches_ratatui_crossterm_exactly() {
+        use ratatui::backend::CrosstermBackend as Reference;
+
+        let styles = [
+            Style::default(),
+            Style::default().fg(Color::Rgb(1, 2, 3)),
+            Style::default().fg(Color::Indexed(200)).bg(Color::Reset),
+            Style::default().add_modifier(Modifier::BOLD | Modifier::DIM),
+            Style::default().add_modifier(Modifier::DIM),
+            Style::default().add_modifier(Modifier::ITALIC | Modifier::UNDERLINED),
+            Style::default()
+                .add_modifier(Modifier::SLOW_BLINK)
+                .underline_color(Color::LightRed),
+            Style::default().add_modifier(Modifier::RAPID_BLINK),
+            Style::default().add_modifier(Modifier::REVERSED | Modifier::CROSSED_OUT),
+            Style::default().add_modifier(Modifier::HIDDEN),
+            Style::default().bg(Color::Rgb(9, 9, 9)).fg(Color::White),
+        ];
+        let symbols = ["a", "世", "\u{301}", " ", "▁"];
+
+        let cells: Vec<(u16, u16, Cell)> = styles
+            .iter()
+            .enumerate()
+            .map(|(i, style)| {
+                let mut cell = Cell::new(symbols[i % symbols.len()]);
+                cell.set_style(*style);
+                // Every third cell jumps a column and a row, so both the
+                // contiguous-run path and the cursor-move path are exercised.
+                let x = if i % 3 == 0 { i as u16 + 1 } else { i as u16 };
+                (x, (i / 4) as u16, cell)
+            })
+            .collect();
+
+        let mut ours = CrosstermBackend::new(Vec::<u8>::new());
+        ours.draw(cells.iter().map(|(x, y, cell)| (*x, *y, cell)))
+            .expect("draw");
+        let mut expected = Vec::<u8>::new();
+        let mut reference = Reference::new(&mut expected);
+        ratatui::backend::Backend::draw(
+            &mut reference,
+            cells.iter().map(|(x, y, cell)| (*x, *y, cell)),
+        )
+        .expect("draw");
+
+        assert_eq!(
+            String::from_utf8_lossy(&ours.writer),
+            String::from_utf8_lossy(&expected),
+        );
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    #[test]
+    fn scrolling_a_region_sets_scrolls_and_resets_it() {
+        use crossterm::Command;
+
+        let mut out = String::new();
+        ScrollInRegion::up(2..6, 3)
+            .write_ansi(&mut out)
+            .expect("up");
+        assert_eq!(out, "\x1b[3;6r\x1b[3S\x1b[r");
+
+        let mut out = String::new();
+        ScrollInRegion::down(2..6, 1)
+            .write_ansi(&mut out)
+            .expect("down");
+        assert_eq!(out, "\x1b[3;6r\x1b[1T\x1b[r");
+
+        // A zero-line scroll must not leave a region set behind.
+        let mut out = String::new();
+        ScrollInRegion::up(2..6, 0)
+            .write_ansi(&mut out)
+            .expect("up");
+        assert_eq!(out, "");
+    }
+}

--- a/src/term/hyperlink.rs
+++ b/src/term/hyperlink.rs
@@ -24,6 +24,7 @@
 use std::io::{self, Write};
 use std::num::NonZeroU16;
 
+use super::backend::CrosstermBackend;
 use crossterm::queue;
 use crossterm::style::{
     Attribute, Color as CtColor, Print, ResetColor, SetAttribute, SetBackgroundColor,
@@ -34,7 +35,6 @@ use ratatui_core::buffer::{Buffer, Cell, CellDiffOption};
 use ratatui_core::layout::{Position, Rect, Size};
 use ratatui_core::style::{Color, Modifier};
 use ratatui_core::text::{Line, Span};
-use ratatui_crossterm::CrosstermBackend;
 
 /// String terminator for an OSC sequence: `ESC \`.
 const ST: &str = "\x1b\\";
@@ -488,7 +488,7 @@ fn apply_style(out: &mut impl Write, span: &Span<'_>) -> io::Result<()> {
 /// Map a ratatui color to the crossterm equivalent. `Rgb`/`Indexed` (what the
 /// host's transcript actually uses) map exactly; the named ANSI colors map to
 /// their crossterm counterparts.
-fn to_ct_color(color: Color) -> CtColor {
+pub(crate) fn to_ct_color(color: Color) -> CtColor {
     match color {
         Color::Reset => CtColor::Reset,
         Color::Black => CtColor::Black,
@@ -512,11 +512,11 @@ fn to_ct_color(color: Color) -> CtColor {
     }
 }
 
-/// A ratatui [`Backend`] that wraps [`CrosstermBackend`] and makes `http(s)`
-/// URLs in rendered output real OSC 8 hyperlinks.
+/// A ratatui [`Backend`] that makes `http(s)` URLs in rendered output real
+/// OSC 8 hyperlinks.
 ///
 /// This is the only place OSC 8 can be emitted while staying inside ratatui's
-/// model: every method delegates to the inner [`CrosstermBackend`] — so cursor,
+/// model: every method delegates to tuika's crossterm backend — so cursor,
 /// scroll-region, and `insert_before` bookkeeping stay consistent — except
 /// [`draw`](Backend::draw), which scans each contiguous run of cells for URLs
 /// and wraps just those cells in the OSC 8 sequence. Non-URL text is forwarded
@@ -551,8 +551,8 @@ impl<W: Write> HyperlinkBackend<W> {
     }
 
     /// Emit one maximal contiguous run of cells, wrapping any URL sub-runs in
-    /// OSC 8. Reuses the inner backend's `draw` for all SGR/cursor logic so we
-    /// never reimplement styling.
+    /// OSC 8. Reuses the inner backend's `draw` for all SGR/cursor logic so
+    /// styling is never written twice.
     fn emit_run(&mut self, run: &[(u16, u16, &Cell)]) -> io::Result<()> {
         // Reconstruct the run's visible text (OSC 8 wrappers stripped so an
         // already-linked markdown label is not mistaken for a bare URL) and

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -32,6 +32,7 @@
 //! host-initiated, run once at startup in raw mode, and share a single fenced
 //! round-trip — see [`capabilities::Capabilities::query_with_palette`].
 
+pub(crate) mod backend;
 pub mod capabilities;
 pub mod clipboard;
 pub mod hyperlink;


### PR DESCRIPTION
## What changed

Three runtime dependencies are gone. **The default consumer graph goes from 66 crates to 55, and the `async` graph from 71 to 59, with no public API change.**

- **`textwrap`** (with `smawk` and `unicode-linebreak`) — `Paragraph` and dialog copy now wrap on the solver `Wrap`/`wrap_lines` already used. **Breaking**, three visible differences: greedy first-fit instead of textwrap's optimal-fit, whitespace runs collapse to a single space, and breaks happen only at whitespace (textwrap also broke at `/`, splitting a linkified URL after its scheme).
- **`ratatui-crossterm`** (with the eight-crate `instability`/`darling` proc-macro tree) — tuika writes to the terminal through its own crossterm `Backend`. It remains an *optional* dependency of `scrolling-regions`, purely to forward that flag.
- **`tokio-stream`** (under `async`) — replaced by `futures-core`, which the build already contained. It stays a dev-dependency.

Also fixes a panic found while consolidating the two wrap implementations: `Availability::MaxContent` measures at `u16::MAX` columns, and prose long enough to fill a row at that width overflowed the wrap solver's column counter.

## Why

The dependency set is a stated design goal, and these three were carrying transitive weight for work tuika was already half-doing:

- `textwrap` had **two call sites**, sitting beside two in-house wrapping engines (`wrap_lines` and markdown's `wrap_rich`).
- `ratatui-crossterm` supplied **one `Backend` impl** — and `HyperlinkBackend` already implemented that entire trait, end to end, in order to wrap it. Two layers where one was needed.
- `tokio-stream` supplied **three adapters** (`next`, `filter_map`, `empty`) over a trait already in the graph: `async` enables `crossterm/event-stream`, which pulls `futures-core`, and `tokio_stream::Stream` *is* `futures_core::Stream`.

The `textwrap` removal is also correctness work, which is the usual sign the boundary was in the wrong place. `Paragraph` wrapped with textwrap's per-`char` width model and then *measured* the result with tuika's grapheme-aware `str_cols`, so text containing a ZWJ emoji wrapped earlier than its own measurement said it needed to. Routing it through the same solver makes wrap and measurement agree by construction, and lets a link's source byte range be carried onto the wrapped row instead of recovered by searching the row's text back through the source.

Deliberately **not** touched, for the record: `unicode-width` and `unicode-segmentation` are Unicode tables tracking a moving standard, and `ratatui-core` depends on both anyway — dropping them from the manifest would remove nothing from any graph. `pulldown-cmark` is large because CommonMark is large.

## Before / After

**Dependency graph**

```
                 before   after
default             66      55
--features async    71      59
```

**Rendering — unchanged.** `cargo run --example demo -- <scene> --dump` is byte-identical before and after for every scene, and `demo -- check` passes (42 scenes in sync), so no recording needs regenerating:

```
 Dialog presets  confirm, choice, multi-choice, and input flows
 ────────────────────────────────────────────────────────────────

 Agent workspace · host content remains independent

       ╭ Apply changes? ──────────────────────────────────╮
       │ This will update three files in the workspace.   │
       │                                                  │
       │  Cancel  Apply                                   │
       ╰──────────────────────────────────────────────────╯
```

**Wrapping — the breaking difference.** Same inputs, `textwrap::wrap` vs. the new `wrap_str`:

```
width 13, "see  https://a.dev  now"
  before            after
  |see  https://|   |see|
  |a.dev  now|      |https://a.dev|
                    |now|

width 20, "read https://example.com/a-very-long-path for the details"
  before                  after
  |read https://|         |read|
  |example.com/a-very-|   |https://example.com/|
  |long-path for the|     |a-very-long-path for|
  |details|               |the details|
```

The URL is now one contiguous run, which is what `Paragraph`'s OSC 8 linkification wants. Prose at the widths the gallery actually uses breaks identically (see the dump above).

**Backend — byte-identical, and proved.** `the_byte_stream_matches_ratatui_crossterm_exactly` draws one corpus (cursor elision, the shared intensity/blink SGR slots, indexed and truecolor pairs, underline color, wide and zero-width symbols) through both backends and asserts the streams are equal. Verified non-vacuous by perturbing one branch of the attribute diff and watching it fail. `tests/pty_smoke.rs` (14 tests, real pseudo-terminal, reference terminal parser) is green unchanged.

**The panic fix:**

```
before: thread '…' panicked at src/components/text.rs:397: attempt to add with overflow
after:  test wrapping_at_max_content_width_does_not_overflow_the_column_counter ... ok
```

**Instruction counts** — all nine within the ±2% gate (see Follow-ups for one note):

```
  frame_full.large      81,473,338 → 81,456,467   -0.021%
  frame_windowed.large     888,796 →    871,925   -1.898%
  one_shot.large         6,451,206 →  6,457,163   +0.092%
  one_shot.small           267,214 →    267,168   -0.017%
  paging.large             252,164 →    252,164   +0.000%
  reflow.mixed          12,337,073 → 12,383,404   +0.376%
  render.large             869,279 →    852,408   -1.941%
  render.small             869,213 →    852,342   -1.941%
  streaming.mixed       12,610,354 → 12,611,729   +0.011%
```

## Risk

- **Medium**, concentrated in the backend.
- **What can break:** the backend is terminal-protocol code tuika now owns, so a future `ratatui-core` `Backend` change lands here instead of upstream. Mitigated by the differential test, which fails the moment the two drift — and by the PTY suite, which asserts the protocol through a real terminal. A maintenance-skill step now says to re-run it when `ratatui-core` moves.
- Wrapping changes are visible but bounded: `Paragraph` and dialog copy only. `Wrap`, `Text`, `Markdown`, and `TextInput` already used this solver and are unaffected.
- `futures-core` is not a new crate in the graph; if a host somehow enabled `async` without `crossterm/event-stream` it would be, but the feature enables it.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

Updated: `specs/goal.md` (design goal 3 states the dependency set literally), `specs/architecture.md` (why the `ratatui-core` boundary — now covering why not `ratatui-crossterm`, and the Cargo feature-unification residue), `specs/images.md` (repeats the dependency list), `processes/maintenance.md` (Dependency Discipline gains the rule this PR is an instance of; Binary Size Discipline loses its textwrap example), `.agents/skills/maintenance/SKILL.md` (the dependency-health actions), and `log.md`. Validated with `python3 scripts/validate_okf.py knowledge --check-links` — 16 concepts, 0 errors.

## Security

Reviewed against all five categories.

- **TM-ESC** — the new backend emits SGR/cursor/clear through crossterm's own `Command` types from `Cell` data, byte-identical to what `ratatui-crossterm` emitted (asserted by test). The one hand-written sequence is `ScrollInRegion`; its parameters are `u16` row indices and a line count from ratatui's `insert_before` bookkeeping, never a host-supplied string, so there is no injection surface. No new out-of-band feature, so no capability detection is owed. The OSC 8 layer above it is untouched.
- **TM-STATE** — `draw` still ends with an unconditional fg/bg/underline/attribute reset, so nothing the host prints next inherits a cell's styling. `ScrollInRegion` sets, scrolls, and resets the DECSTBM region within a single command, so a failure between writes cannot leak a scrolling region that would confine every later write to those rows. Terminal enter/leave lifecycle is not touched.
- **TM-PARSE** — **found and fixed a reachable panic.** The wrap solver runs on untrusted prose (markdown, pasted text). Consolidating the two implementations exposed that `cur_w + sep + word_w` overflows `u16` when `width` is `u16::MAX`, which is exactly what `Availability::MaxContent` passes — so a paragraph over 65,535 columns wide panicked in a debug build. The arithmetic is saturating now, with a test at that width. Otherwise the solver has no recursion, and allocates O(input), not O(nesting).
- **TM-CLIP** — no change to clipping. `Paragraph`'s existing degenerate-size sweep (0–20 × 0–4) still passes, and the wrap solver's own contract (no row exceeds `width`) is asserted directly, including for hard-broken overlong words.
- **TM-DEP** — this PR removes three dependencies and adds none. `futures-core` was already in the graph via `crossterm/event-stream`. `ratatui` remains a dev-dependency (it is now also what the differential test compares against). No new heavy transitive tree.

## Follow-ups

**The committed iai baseline is now ~1.9% stale on three benchmarks** (`render.large`, `render.small`, `frame_windowed.large` — see the table above; the shift is a codegen/inlining effect, those paths are not touched by this change). It passes the gate in both directions, so nothing is red. I deliberately did **not** regenerate it: the baseline is machine- and libc-sensitive, and rewriting it from this container risks making CI red for reasons unrelated to the diff, which is worse than the drift. The cost of leaving it is that the effective regression ceiling on those three is loosened by about 2% until someone regenerates it on a machine that matches CI (`python3 benches/check_iai.py --update`). Flagging it as the maintainer's call rather than deciding it here.

Nothing else deferred. The two candidates found during the audit were resolved in-scope: the max-content overflow is fixed here, and the `scrolling-regions` feature keeps its optional `ratatui-crossterm` forward deliberately — removing it would break a host's own copy of that crate through Cargo's one-way feature unification.