### PR TITLE
chore(bench): refresh the iai baselines from CI

### DIFF
--- a/benches/iai-baseline.json
+++ b/benches/iai-baseline.json
@@ -2,14 +2,14 @@
   "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
   "tolerance_pct": 2.0,
   "benchmarks": {
-    "frame_full.large": 81473338,
-    "frame_windowed.large": 888796,
-    "one_shot.large": 6451206,
-    "one_shot.small": 267214,
+    "frame_full.large": 81456467,
+    "frame_windowed.large": 871925,
+    "one_shot.large": 6451179,
+    "one_shot.small": 267187,
     "paging.large": 252164,
-    "reflow.mixed": 12337073,
-    "render.large": 869279,
-    "render.small": 869213,
-    "streaming.mixed": 12610354
+    "reflow.mixed": 12404884,
+    "render.large": 852408,
+    "render.small": 852342,
+    "streaming.mixed": 12663222
   }
 }

--- a/crates/tuika-codeformatters/benches/iai-baseline.json
+++ b/crates/tuika-codeformatters/benches/iai-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
   "tolerance_pct": 2.0,
   "benchmarks": {
-    "highlight.python": 94920813,
-    "highlight.rust": 291157409
+    "highlight.python": 94928526,
+    "highlight.rust": 291169013
   }
 }


### PR DESCRIPTION
## What changed

Both committed iai instruction-count baselines are refreshed from CI's own environment. Closes the one follow-up left open by #110.

## Why

#110 shifted instruction counts on three scroll benchmarks by ~1.9% — a codegen/inlining effect, not a change to those code paths. That passed the ±2% gate, so nothing was red, but it left the baseline stale **in the loosening direction**: the effective regression ceiling on `render.large`, `render.small`, and `frame_windowed.large` sat about 2% higher than intended, which would have masked a real regression of up to ~4% on those three.

## How

Not by regenerating on a developer machine. `benches/README.md` already prescribes the right path, which I should have found the first time rather than deferring the question:

> To refresh from CI's exact environment, run the workflow manually (`workflow_dispatch`) and commit the [uploaded baseline].

So: a manual dispatch of `ci.yml` on `main` at `ed28793` ([run 266](https://github.com/everruns/tuika/actions/runs/32524496528)), which runs `check_iai.py --update` on the runner and uploads the result as the `iai-baseline` artifact. These two files are that artifact, unmodified.

That also picks up `crates/tuika-codeformatters/benches/iai-baseline.json`, which a local run of tuika's own benches would have missed — CI benches `highlight_iai` too.

## Before / After

```
                        old baseline    new (CI)      delta
  frame_full.large        81,473,338   81,456,467    -0.021%
  frame_windowed.large       888,796      871,925    -1.898%   ← was stale
  one_shot.large           6,451,206    6,451,179    -0.000%
  one_shot.small             267,214      267,187    -0.010%
  paging.large               252,164      252,164    +0.000%
  reflow.mixed            12,337,073   12,404,884    +0.550%
  render.large               869,279      852,408    -1.941%   ← was stale
  render.small               869,213      852,342    -1.941%   ← was stale
  streaming.mixed         12,610,354   12,663,222    +0.419%

  tuika-codeformatters
  highlight.python        94,920,813   94,928,526    +0.008%
  highlight.rust         291,157,409  291,169,013    +0.004%
```

`tuika-codeformatters` moved only 0.004% — noise, and expected, since highlighting touches neither the wrap solver nor the backend. Its file is included because both come from one atomic regeneration; splitting them would leave it measured against an older snapshot.

**Cross-validated against a second, independent environment.** Ran all three iai targets locally under Valgrind and checked those measurements against this new CI-produced baseline:

```
.  (tolerance ±2%)
  benchmark                          baseline        current      diff
  frame_full.large                 81,456,467     81,456,467   +0.000%  ok
  frame_windowed.large                871,925        871,925   +0.000%  ok
  one_shot.large                    6,451,179      6,457,163   +0.093%  ok
  one_shot.small                      267,187        267,168   -0.007%  ok
  paging.large                        252,164        252,164   +0.000%  ok
  reflow.mixed                     12,404,884     12,383,404   -0.173%  ok
  render.large                        852,408        852,408   +0.000%  ok
  render.small                        852,342        852,342   +0.000%  ok
  streaming.mixed                  12,663,222     12,611,729   -0.407%  ok

crates/tuika-codeformatters  (tolerance ±2%)
  highlight.python                 94,928,526     94,926,619   -0.002%  ok
  highlight.rust                  291,169,013    291,171,734   +0.001%  ok

OK: all benchmarks within tolerance of the committed baseline.
```

Every benchmark agrees within **0.41%**, and five of the nine are identical to the instruction — consistent with the ~0.19% agreement recorded when these baselines were last re-blessed. The gate's own run on this PR is a third measurement.

No behavior change: these files are read only by `benches/check_iai.py`, and both are excluded from the published crates (`tests/packaging.rs` guards that, still passing).

## Risk

- **Low.** Two JSON files, no code. The worst case is a baseline that does not reproduce on CI — which this PR's own iai job would catch by going red, before merge.

## Checklist
- [x] Tests added or updated — n/a, see Knowledge
- [x] Backward compatibility considered — no API or behavior surface
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

No knowledge update required — this refreshes a committed CI measurement input, not durable behavior, architecture, or policy. The procedure and its rationale are already recorded in [`benches/README.md`](benches/README.md) and `processes/maintenance.md`; nothing about them changed.

No changelog entry either: `benches/*.json` is excluded from every published crate and has no effect a consumer can observe.

No new test. The changed files are inputs to `check_iai.py`, which is itself the test — it runs in CI on every Rust-affecting change and is exercised by this PR.

## Security

No security-relevant code changes — two JSON data files containing integer instruction counts, read only by a benchmark-checking script and never shipped to a consumer.

## Follow-ups

No follow-ups. This was the only item left open by #110.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EV6dTPtxsC5G45GeExdmeo)_