### PR TITLE
test: fuzz and black-box sweeps, fixing three bugs they found

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -1,0 +1,75 @@
+name: Nightly Fuzz
+
+# Deep randomized runs of the suites that hunt for panics and cross-path
+# divergence (see knowledge/processes/testing.md § Why fuzzing is a layer).
+#
+# Every PR runs these at proptest's default case count, which is tuned to keep
+# the suite fast. That is enough to catch a regression on a known counterexample
+# (the regression files are committed and replayed first) but not enough to
+# *find* a new one: the streaming-markdown divergences fixed alongside the suite
+# needed thousands of cases to surface. This job buys those cases nightly,
+# where minutes are free.
+#
+# A failure prints the shrunk counterexample and appends its seed to a
+# `proptest-regressions/` file; copy that line into the repository so every
+# later run replays it, then fix the component.
+
+on:
+  schedule:
+    # 05:00 UTC daily, an hour before the terminal matrix.
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      cases:
+        description: "proptest cases per property"
+        required: false
+        default: "20000"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  fuzz:
+    name: deep fuzz (${{ github.event.inputs.cases || '20000' }} cases)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.94.0
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "debug"
+
+      # Debug assertions are the point: release builds wrap on integer overflow
+      # instead of panicking, which is exactly the class this hunts for.
+      - name: Fuzz and property suites
+        env:
+          PROPTEST_CASES: ${{ github.event.inputs.cases || '20000' }}
+        run: cargo test --locked --all-features --lib -- tests::fuzz tests::proptests
+
+      - name: Black-box robustness sweep
+        run: cargo test --locked --all-features --test robustness
+
+      # A new counterexample is written here; keep it even when the job fails so
+      # the seed can be committed without reproducing the run locally first.
+      - name: Upload any new regression seeds
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: proptest-regressions
+          path: proptest-regressions/
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,9 @@ tuika's own suite covers more:
   solver, composed trees, the stateful components, and the parsers that read
   untrusted bytes; plus differential properties (streamed markdown vs one-shot,
   styled wrap vs plain). Raise the case count when hunting: `PROPTEST_CASES=5000`.
+  CI runs the default count per PR and a deep run nightly
+  (`.github/workflows/nightly-fuzz.yml`); commit any new `proptest-regressions/`
+  seed with the fix.
 - **Black-box sweep** (`tests/robustness.rs`) — every component × adversarial
   corpus × degenerate size through the published API only, asserting no panic,
   no paint outside the component's rect, and no control byte in a cell.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,14 @@ tuika's own suite covers more:
   tiny/degenerate screens where scroll and overlay resolution interact.
 - **Property tests** (`src/tests/proptests.rs`, `proptest`) — solver and overlay
   invariants for *any* input (children stay in bounds, flex fills exactly).
+- **Fuzz** (`src/tests/fuzz.rs`) — adversarial text (wide CJK, ZWJ emoji,
+  combining marks, control bytes) and arbitrary event streams through the wrap
+  solver, composed trees, the stateful components, and the parsers that read
+  untrusted bytes; plus differential properties (streamed markdown vs one-shot,
+  styled wrap vs plain). Raise the case count when hunting: `PROPTEST_CASES=5000`.
+- **Black-box sweep** (`tests/robustness.rs`) — every component × adversarial
+  corpus × degenerate size through the published API only, asserting no panic,
+  no paint outside the component's rect, and no control byte in a cell.
 - **Golden snapshots** (`src/tests/snapshots.rs`) — whole screens diffed against
   checked-in glyph grids; refresh with `UPDATE_SNAPSHOTS=1`. The grids are
   LF-only (`.gitattributes`), so a CRLF checkout cannot fail them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,46 @@ described in the release process begins with the entry below.
   surface received what, including the case where nothing did. See the
   [routing guide](docs/routing.md).
 
+- **`term::hyperlink::apply_buffer_links_in`**: the area-clipped counterpart to
+  `apply_buffer_links`, for a component embedding OSC 8 runs into a sub-rect of
+  a shared buffer. `apply_buffer_links` is unchanged and still clips to the
+  whole buffer.
+
+- **Fuzz and black-box robustness suites** (`src/tests/fuzz.rs`,
+  `tests/robustness.rs`): adversarial text and event streams through the wrap
+  solver, composed view trees, the stateful components, and the parsers that
+  read untrusted terminal replies; plus a sweep of every component against every
+  corpus at every degenerate size, asserting no panic, no paint outside the
+  component's own rect, and no control byte in a cell. Both fixes below came out
+  of them. Test-only — no API change.
+
+### Fixed
+
+- **A component no longer stamps hyperlink markers outside its own rect.**
+  `Paragraph` and `Markdown` embed OSC 8 runs into the cells of a linked label
+  after painting, and the placement was clipped to the *buffer* rather than to
+  the rect the component was laid out in. A markdown block whose links ran past
+  the rows or columns it was given wrote an escape onto a neighbouring
+  component's cell — visible as a stray link, or an orphaned escape once the
+  neighbour repainted. Placements outside the area are now dropped.
+
+- **Streamed markdown renders identically to a one-shot render.** The settled
+  prefix is cached at the last blank line that ends a block, and two constructs
+  were mistaken for one:
+  - A fence line carrying an info string (`` ```rust `` inside an already-open
+    block) was treated as a closer, so a later blank line settled a boundary
+    *inside* a code block; everything after it rendered as markdown while a
+    re-render of the same source rendered it as code.
+  - A blank line between list items settled the prefix, so the rest of the list
+    was parsed in isolation and its numbering restarted — a streamed
+    `1. … 2. … 3. …` rendered as `1. … 1. … 1. …`. A blank line inside a list is
+    a boundary only once a following top-level block proves the list ended, and
+    never on the strength of an in-flight partial line (`1` before it becomes
+    `1.`).
+
+  Both were found by a new streaming/one-shot fuzz differential, and both
+  depended on where the stream's chunk boundaries happened to fall.
+
 ## [0.10.0] - 2026-08-17
 
 Released alongside `tuika-charts` 0.1.1, `tuika-codeformatters` 0.4.3,

--- a/benches/iai-baseline.json
+++ b/benches/iai-baseline.json
@@ -2,14 +2,14 @@
   "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
   "tolerance_pct": 2.0,
   "benchmarks": {
-    "frame_full.large": 81456467,
-    "frame_windowed.large": 871925,
-    "one_shot.large": 6451179,
-    "one_shot.small": 267187,
+    "frame_full.large": 81465395,
+    "frame_windowed.large": 880853,
+    "one_shot.large": 6455060,
+    "one_shot.small": 267089,
     "paging.large": 252164,
-    "reflow.mixed": 12404884,
-    "render.large": 852408,
-    "render.small": 852342,
-    "streaming.mixed": 12663222
+    "reflow.mixed": 12383908,
+    "render.large": 861336,
+    "render.small": 861270,
+    "streaming.mixed": 12885320
   }
 }

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,26 @@
 
 ## 2026-08-21
 
+- **Fuzzing is where the streaming markdown cache's rules actually came from**
+  - A wrap-solver panic at max-content width prompted a dedicated fuzz layer
+    (`src/tests/fuzz.rs`) and a black-box sweep of every component against
+    adversarial corpora at degenerate sizes (`tests/robustness.rs`). Both are
+    recorded in [Testing](processes/testing.md).
+  - The panic-hunting found no further panics. What it found instead were three
+    correctness bugs no example-based test could have reached, because each
+    depended on a *combination*: an OSC 8 link marker written outside the
+    component's own rect (clipped to the buffer instead of the area), and two
+    streaming markdown boundaries that diverged from a one-shot render depending
+    on where the chunk boundaries fell — a fence line with an info string read as
+    a closer, and a blank line between list items settling the prefix and
+    restarting the numbering.
+  - The general lesson worth keeping: a *differential* property (two paths that
+    claim to agree) is worth more than any number of "does not panic" assertions
+    on a component whose whole contract is that streaming looks like not
+    streaming. The markdown spec had already written down the intended rule
+    ("a list that may still gain items stays in the re-parsed tail"); only the
+    differential proved the implementation did not follow it.
+
 - **A dependency whose job tuika can do in a page of code belongs in tuika**
   - Auditing the dependency set for removals turned up three crates whose job
     was small *for tuika* even though the crates themselves are not: `textwrap`

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -83,6 +83,15 @@ the black-box sweep enumerates fixed combinations, and the storms use a seeded
 PRNG. A failure is replayable from the seed printed with it, and case counts can
 be raised locally (`PROPTEST_CASES=…`) when hunting.
 
+PR runs use proptest's default case count, which keeps the suite fast enough to
+run on every change and is enough to *replay* a known counterexample — the
+regression files are committed and replayed first. It is not enough to *find* a
+new one: both streaming divergences needed thousands of cases to surface. The
+depth is bought nightly instead, by `.github/workflows/nightly-fuzz.yml`, which
+re-runs the fuzz, property, and black-box suites at a much higher case count and
+uploads any new regression seed as an artifact. Commit that seed with the fix,
+so the cheap PR run guards it from then on.
+
 A counterexample is a bug report about the *component*, not about the test. The
 fix belongs beside the code with a focused regression test; narrowing the
 property is a last resort, and when it happens the reason belongs in the

--- a/knowledge/processes/testing.md
+++ b/knowledge/processes/testing.md
@@ -30,6 +30,8 @@ terminal encoder, not the component, and belongs in the PTY layer.
 | Unit | each module's `#[cfg(test)] mod tests` | layout math, component rendering, interactive state, keymap dispatch, compositor, easing, OSC encoders, palette slots |
 | Cross-module | `src/tests/integration.rs` | behavior spanning several modules with no single owner: composed trees, degenerate screens where scroll and overlay interact |
 | Property | `src/tests/proptests.rs` | solver and overlay invariants for *any* input — children stay in bounds, flex fills exactly |
+| Fuzz | `src/tests/fuzz.rs` | adversarial text and event streams through the wrap solver, composed trees, stateful components, and the parsers that read untrusted bytes |
+| Black-box sweep | `tests/robustness.rs` | every component × adversarial corpus × degenerate size, through the published API only |
 | Golden snapshot | `src/tests/snapshots.rs` | whole screens diffed against checked-in glyph grids |
 | Size sweep | unit | no panic and no out-of-clip writes from `0×0` upward |
 | PTY smoke | `tests/pty_smoke.rs` | the terminal-facing protocol in both screen modes: alt-screen and cursor/mouse lifecycle pairs, runner selection through OSC 52, OSC 9;4, OSC 8, truecolor and Braille cells through a reference terminal parser, resize survival, clean exit; and for a split footer, that it stays off the alternate screen, pins to the bottom, publishes above itself, and releases its rows |
@@ -51,6 +53,41 @@ hosts test their views and full state/update/view applications with the same
 signals, theme, and stylesheet contexts used in production. The harness owns
 no terminal or runtime; a dirty update returns an in-memory frame. Changes to
 this surface are API changes.
+
+## Why fuzzing is a layer, not a mood
+
+A property test asks whether a solver's *answer* is right. The fuzz layer asks
+whether a component survives input it was never designed for, because that is
+the failure mode a user experiences as a crash rather than a wrong pixel: text a
+host pasted, a screen dragged to one column, a terminal reply from a mangled
+`ssh` session, a list that shrank while someone was scrolling it.
+
+Three kinds of assertion carry it, and none of them require knowing what the
+right output is:
+
+- **It must not panic.** Untrusted text and degenerate geometry degrade, never
+  crash the host. This is the class the wrap solver's column-counter overflow at
+  `AvailableSpace::MaxContent` belonged to.
+- **It must stay inside its rect.** Views are rendered into an inset area of a
+  larger buffer, so a write past the rect lands on a margin the test owns rather
+  than on a neighbour that would have repainted it.
+- **Two paths that claim to agree must agree.** Differential properties are
+  where the subtle bugs live: streamed markdown against a one-shot render, the
+  styled wrap against the plain one, a re-wrap after a resize against a fresh
+  state. Both of the streaming/one-shot divergences fixed alongside this layer
+  were invisible to every example-based test, because they depended on *where
+  the chunk boundaries fell*.
+
+Fuzzing stays deterministic: proptest seeds from its committed regression files,
+the black-box sweep enumerates fixed combinations, and the storms use a seeded
+PRNG. A failure is replayable from the seed printed with it, and case counts can
+be raised locally (`PROPTEST_CASES=…`) when hunting.
+
+A counterexample is a bug report about the *component*, not about the test. The
+fix belongs beside the code with a focused regression test; narrowing the
+property is a last resort, and when it happens the reason belongs in the
+property's own comment (a stale index a host reconciles with `clamp`, a
+2-column grapheme that cannot fit a 1-column row).
 
 ## Why a PTY layer exists at all
 

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -60,14 +60,31 @@ unterminated code fence or a list that may still gain items stays in the
 re-parsed tail. Everything before the boundary is retained as computed lines and
 is never re-tokenized or re-highlighted.
 
+Two constructs decide whether a blank line is a boundary at all, and both are
+easy to get subtly wrong because the mistake only shows under *some* chunk
+boundaries:
+
+- **An open code fence.** CommonMark closes a fence only on a bare run of at
+  least as many of the same delimiter, so a fence line carrying an info string
+  inside an already-open block is code content, not a closer. Treating it as one
+  settles a boundary the one-shot parse puts *inside* the block, and the rest of
+  the document then renders as markdown in the stream and as code on a re-render.
+- **An open list.** A list continues across a blank line, so a blank between
+  items is a boundary only once a following *top-level* block proves the list
+  ended — and never on the strength of an in-flight partial line, since `1` is
+  not yet the marker `1.` the next delta makes it. Settling early parses the
+  rest in isolation, which restarts the numbering.
+
 The boundary is also only a boundary once the line that carries it is
 *terminated*. A stream arrives token by token, so the buffer routinely ends
 mid-line — and a nested item's indent, or an indented block's, is a
 whitespace-only line until its content lands. Committing there splits a list
 between two independently parsed segments, and the cache makes that permanent:
 the halves become unrelated top-level blocks for the rest of the transcript. The
-invariant that catches this class is that a streamed render must equal the
-one-shot render of the same source, delta size notwithstanding.
+invariant that catches this whole class is that a streamed render must equal the
+one-shot render of the same source, delta size notwithstanding — asserted as a
+fuzz differential over generated markdown, chunk sizes, and widths (see
+[Testing](../processes/testing.md)), which is how both rules above were found.
 
 Anything positional that the host reads back per frame — block-image placements
 in particular — must therefore be threaded *through* the cache: fixed rows for

--- a/proptest-regressions/tests/fuzz.txt
+++ b/proptest-regressions/tests/fuzz.txt
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3a0ca8c9df0ae0a682bc965620e44fa673663f89c093c9408fdb1362c698b2a2 # shrinks to text = "日本語", width = 1
+cc 6d3b5c71e8f7b996679217cb142a1978b89ab136059ca4385962c7dfe75f86ba # shrinks to events = [Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Backspace, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Backspace, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: BackTab, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false }), Key(Key { code: Up, ctrl: false, alt: false, shift: false })], counts = [5, 1]
+cc 718f2c2e96b5590847afea2ff5c4cb6c62bb2fbfdec7f1ca6be712e14af7012e # shrinks to events = [Key(Key { code: Up, ctrl: false, alt: false, shift: false })], len = 0
+cc e87eb4d7657d0976954172d6822b4578dad8e5c02063afdb453a58b68aa8a43c # shrinks to source = "1. item\nfn main() {}\nfn main() {}\n\n1. item\n", chunk = 1, width = 8
+cc 75610c8f3cefd6c34eeaeaa56a57c0645bd529f1831d636d182d556b25a29480 # shrinks to source = "1. item\n| a | b |\n1. item\n1. item\n\n1. item\n", chunk = 1, width = 8

--- a/src/components/markdown/stream.rs
+++ b/src/components/markdown/stream.rs
@@ -17,27 +17,109 @@ use super::image::{ImageResolver, MarkdownImage};
 use super::item::MdItem;
 use super::parse::parse_with;
 
+/// Whether `trimmed` (a line with its indentation removed) starts a list item.
+///
+/// Bullet (`-`, `*`, `+`) or ordered (`1.`, `1)`) markers only — a thematic
+/// break (`---`) or emphasis (`*text*`) is not one, which is what the
+/// delimiter-must-be-followed-by-a-space rule rules out.
+fn is_list_marker(trimmed: &str) -> bool {
+    let mut chars = trimmed.chars();
+    match chars.next() {
+        Some('-' | '*' | '+') => matches!(chars.next(), None | Some(' ')),
+        Some(digit) if digit.is_ascii_digit() => {
+            let mut rest = trimmed
+                .trim_start_matches(|c: char| c.is_ascii_digit())
+                .chars();
+            matches!(rest.next(), Some('.' | ')')) && matches!(rest.next(), None | Some(' '))
+        }
+        _ => false,
+    }
+}
+
+/// The delimiter and run length of a fence opened by `trimmed`, if it opens one.
+fn fence_opener(trimmed: &str) -> Option<(char, usize)> {
+    let delimiter = trimmed.chars().next().filter(|c| matches!(c, '`' | '~'))?;
+    let run = trimmed.chars().take_while(|c| *c == delimiter).count();
+    (run >= 3).then_some((delimiter, run))
+}
+
 /// Byte offset of the last *stable block boundary* in `source[from..]`, in
-/// absolute bytes: the position just past the last blank line that sits outside
-/// an open code fence. Blocks before it are complete and safe to cache; the tail
-/// after it is still in flight.
+/// absolute bytes: the position just past the last blank line that ends a block
+/// outright. Blocks before it are complete and safe to cache; the tail after it
+/// is still in flight.
+///
+/// Two constructs make a blank line *not* a block boundary, and both were found
+/// by the streaming/one-shot fuzz differential:
+///
+/// - **An open code fence.** Everything up to the closing fence is one block, so
+///   a blank inside it settles nothing. CommonMark closes a fence only on a bare
+///   run of at least as many of the *same* delimiter, so `` ```rust `` inside an
+///   open block is code content, not a closer.
+/// - **An open list.** A blank line between items keeps one list going, so
+///   settling there would parse the rest in isolation and restart the numbering
+///   — a streamed `1. … 2. …` would render as `1. … 1. …`. The blank becomes a
+///   boundary only once a following top-level block proves the list ended.
 fn stable_boundary(source: &str, from: usize) -> usize {
-    let mut fence_open = false;
+    let mut fence: Option<(char, usize)> = None;
     let mut boundary = from;
     let mut pos = from;
+    // Whether the prefix is inside a list, and the blank line that will become a
+    // boundary if a top-level block turns out to follow it.
+    let mut in_list = false;
+    let mut pending_blank: Option<usize> = None;
     for line in source[from..].split_inclusive('\n') {
         let trimmed = line.trim();
-        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-            fence_open = !fence_open;
-        } else if trimmed.is_empty() && !fence_open && line.ends_with('\n') {
+        let end = pos + line.len();
+        pos = end;
+
+        if let Some((delimiter, opened)) = fence {
+            let run = trimmed.chars().take_while(|c| *c == delimiter).count();
+            if run >= opened && trimmed.len() == run {
+                fence = None;
+            }
+            continue;
+        }
+
+        if trimmed.is_empty() {
             // Only a *terminated* blank line settles the prefix. A trailing line
             // with no newline yet is still in flight, and mid-stream it is often
             // whitespace-only for a few deltas — the indent of a nested list item
             // or an indented block — so treating it as blank would cut the list
             // in half and cache the halves as separate blocks.
-            boundary = pos + line.len();
+            if line.ends_with('\n') {
+                if in_list {
+                    pending_blank = Some(end);
+                } else {
+                    boundary = end;
+                }
+            }
+            continue;
         }
-        pos += line.len();
+
+        let indented = line.starts_with("  ") || line.starts_with('\t');
+        if is_list_marker(trimmed) {
+            in_list = true;
+            pending_blank = None;
+        } else if in_list && (indented || pending_blank.is_none()) {
+            // An indented continuation, or a lazy one with no blank in between:
+            // either way the list item is still open.
+            pending_blank = None;
+        } else if line.ends_with('\n') {
+            // A top-level block. It ends any open list, which makes the blank
+            // line before it a real boundary.
+            //
+            // Only a *terminated* line may do this: mid-stream the last line is
+            // a prefix of itself, and "1" is not yet the list marker "1." that
+            // the next delta makes it. Settling on the partial line would cache
+            // a boundary the finished document does not have.
+            if let Some(blank) = pending_blank.take() {
+                boundary = blank;
+            }
+            in_list = false;
+        }
+        if let Some(opener) = fence_opener(trimmed) {
+            fence = Some(opener);
+        }
     }
     boundary
 }
@@ -666,6 +748,80 @@ mod tests {
         // Once the fence closes, the trailing blank becomes a boundary.
         let closed = "```\ncode\n```\n\nafter";
         assert!(stable_boundary(closed, 0) > 0);
+    }
+
+    #[test]
+    fn a_fence_line_with_an_info_string_does_not_close_a_fence() {
+        // CommonMark closes a fence only on a bare run of the same delimiter, so
+        // a "```rust" *inside* an open block is code content. Toggling on it
+        // settled a boundary the one-shot parse puts inside the block, and every
+        // paragraph after it then rendered as markdown in a streamed transcript
+        // but as code in a re-render. Found by the streaming/one-shot fuzz
+        // differential.
+        assert_eq!(stable_boundary("```\n```rust\ncode\n\nmore", 0), 0);
+        // A shorter run cannot close a longer fence, either.
+        assert_eq!(stable_boundary("````\n```\ncode\n\nmore", 0), 0);
+        // A longer run closes a shorter fence, and the blank after it settles.
+        assert!(stable_boundary("```\ncode\n`````\n\nafter", 0) > 0);
+        // Tildes and backticks do not close each other.
+        assert_eq!(stable_boundary("~~~\n```\ncode\n\nmore", 0), 0);
+    }
+
+    #[test]
+    fn a_blank_line_between_list_items_does_not_settle_the_prefix() {
+        // A list continues across a blank line, so settling there parses the
+        // rest in isolation and restarts the numbering. Found by the
+        // streaming/one-shot fuzz differential, where a streamed "1. … 2. …"
+        // rendered as "1. … 1. …".
+        assert_eq!(stable_boundary("1. one\n\n2. two\n", 0), 0);
+        assert_eq!(stable_boundary("- one\nlazy continuation\n\n- two\n", 0), 0);
+        // A top-level block after the blank proves the list ended there.
+        let ended = "- one\n\nparagraph\n";
+        assert_eq!(stable_boundary(ended, 0), "- one\n\n".len());
+        // An indented continuation keeps the item open.
+        assert_eq!(stable_boundary("- one\n\n  still the item\n", 0), 0);
+    }
+
+    #[test]
+    fn an_in_flight_line_does_not_end_a_list() {
+        // Mid-stream the last line is a prefix of itself: "1" before "1." makes
+        // it a marker. Settling the blank before it would cache a boundary the
+        // finished document does not have, and the rest of the list would then
+        // be parsed in isolation.
+        let settled = "1. one\n\n";
+        assert_eq!(stable_boundary(&format!("{settled}1"), 0), 0);
+        assert_eq!(stable_boundary(&format!("{settled}1. two\n"), 0), 0);
+        // A *terminated* top-level line still ends the list at that blank.
+        assert_eq!(
+            stable_boundary(&format!("{settled}paragraph\n"), 0),
+            settled.len()
+        );
+    }
+
+    #[test]
+    fn streaming_a_list_across_a_blank_line_keeps_its_numbering() {
+        let theme = Theme::default();
+        let sheet = StyleSheet::from_theme(&theme);
+        let doc = "1. first\n\n2. second\n\n3. third\n";
+        let mut state = MarkdownState::new();
+        for delta in doc.split_inclusive('\n') {
+            state.push_str(delta);
+            let _ = state.lines(40, &theme, &sheet, CodeHighlighter::Plain);
+        }
+        let streamed: Vec<String> = state
+            .lines(40, &theme, &sheet, CodeHighlighter::Plain)
+            .iter()
+            .map(text)
+            .collect();
+        let one_shot: Vec<String> = to_lines(doc, 40, &theme, &sheet, CodeHighlighter::Plain)
+            .iter()
+            .map(text)
+            .collect();
+        assert_eq!(streamed, one_shot);
+        assert!(
+            streamed.iter().any(|line| line.contains("2.")),
+            "the second item keeps its number: {streamed:?}"
+        );
     }
 
     #[test]

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -12,7 +12,7 @@ use crate::geometry::Size;
 use crate::highlight::{CodeHighlighter, Highlighter};
 use crate::style::{StyleSheet, Theme};
 use crate::surface::Surface;
-use crate::term::hyperlink::{BufferLink, LinkPolicy, apply_buffer_links};
+use crate::term::hyperlink::{BufferLink, LinkPolicy, apply_buffer_links_in};
 use crate::term::image::{ImageLayer, ImageSupport};
 use crate::view::{RenderCtx, View};
 
@@ -179,15 +179,7 @@ impl View for Markdown<'_> {
         }
         // Embed OSC 8 for labeled links (and bare URLs) so Ctrl+click / Ghostty
         // open the destination even when the visible text is not the URL.
-        apply_buffer_links(
-            surface.buffer_mut(),
-            ratatui_core::layout::Position {
-                x: area.x,
-                y: area.y,
-            },
-            &links,
-            self.link_policy,
-        );
+        apply_buffer_links_in(surface.buffer_mut(), area, &links, self.link_policy);
         // Overlay each block image on the rows it reserved, reusing the standalone
         // `Image` component for pixel emission and the alt fallback alike.
         for img in images {

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -24,7 +24,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::geometry::Size;
 use crate::style::Role;
 use crate::surface::Surface;
-use crate::term::hyperlink::{BufferLink, LinkPolicy, apply_buffer_links, find_links};
+use crate::term::hyperlink::{BufferLink, LinkPolicy, apply_buffer_links_in, find_links};
 use crate::view::{RenderCtx, View};
 use crate::width::{grapheme_cols, str_cols};
 
@@ -269,15 +269,7 @@ impl View for Paragraph {
             }
             surface.set_string(col, y, &line.text[byte..], self.style);
         }
-        apply_buffer_links(
-            surface.buffer_mut(),
-            ratatui_core::layout::Position {
-                x: area.x,
-                y: area.y,
-            },
-            &buffer_links,
-            self.link_policy,
-        );
+        apply_buffer_links_in(surface.buffer_mut(), area, &buffer_links, self.link_policy);
     }
 }
 

--- a/src/term/hyperlink.rs
+++ b/src/term/hyperlink.rs
@@ -196,9 +196,34 @@ pub fn apply_buffer_links(
     links: &[BufferLink],
     policy: LinkPolicy,
 ) {
+    let area = Rect {
+        x: origin.x,
+        y: origin.y,
+        width: buf.area.right().saturating_sub(origin.x),
+        height: buf.area.bottom().saturating_sub(origin.y),
+    };
+    apply_buffer_links_in(buf, area, links, policy);
+}
+
+/// [`apply_buffer_links`] confined to `area` instead of the whole buffer.
+///
+/// A component laid out into a sub-rect must clip its own link markers: a run
+/// that ran past the rows or columns it was given would otherwise stamp an OSC 8
+/// escape onto a *neighbour's* cell, which the neighbour then repaints around —
+/// an escape orphaned in the middle of the screen. Placements are relative to
+/// `area`'s top-left, and anything outside it (or outside the buffer) is
+/// dropped rather than clamped, since a clamped link would point at the wrong
+/// glyph.
+pub fn apply_buffer_links_in(
+    buf: &mut Buffer,
+    area: Rect,
+    links: &[BufferLink],
+    policy: LinkPolicy,
+) {
     if !policy.links_any() {
         return;
     }
+    let clip = area.intersection(buf.area);
     for link in links {
         let Some(url) = sanitize_url(&link.url, policy) else {
             continue;
@@ -206,10 +231,19 @@ pub fn apply_buffer_links(
         if link.end_col <= link.start_col {
             continue;
         }
-        let y = origin.y.saturating_add(link.line);
-        let xs = origin.x.saturating_add(link.start_col);
-        let xe = origin.x.saturating_add(link.end_col.saturating_sub(1));
-        if y >= buf.area.bottom() || xs >= buf.area.right() || xe >= buf.area.right() || xe < xs {
+        let y = area.y.saturating_add(link.line);
+        let xs = area.x.saturating_add(link.start_col);
+        let xe = area.x.saturating_add(link.end_col.saturating_sub(1));
+        // Both bounds, both axes: an `area` that starts above or left of the
+        // buffer (a caller compositing into a sub-buffer) would otherwise index
+        // a cell the buffer does not hold.
+        if y < clip.top()
+            || y >= clip.bottom()
+            || xs < clip.left()
+            || xs >= clip.right()
+            || xe >= clip.right()
+            || xe < xs
+        {
             continue;
         }
         wrap_cell_osc8(&mut buf[(xs, y)], &url, true);
@@ -698,6 +732,63 @@ mod tests {
         let mut out: Vec<u8> = Vec::new();
         write_line(&mut out, line).expect("write");
         String::from_utf8(out).expect("utf8")
+    }
+
+    #[test]
+    fn buffer_links_are_clipped_to_the_area_they_were_painted_in() {
+        // A component laid out into a sub-rect must not stamp its link markers
+        // on a neighbour: a run whose row or column ran past the rect is
+        // dropped, not written one row down. Found by the black-box robustness
+        // sweep, where `Markdown` in an inset rect linked a cell below itself.
+        let mut buf = Buffer::empty(Rect::new(0, 0, 8, 4));
+        let area = Rect::new(1, 1, 4, 2);
+        let links = [
+            BufferLink {
+                line: 0,
+                start_col: 0,
+                end_col: 2,
+                url: "https://in.dev".into(),
+            },
+            BufferLink {
+                line: 2,
+                start_col: 0,
+                end_col: 2,
+                url: "https://below.dev".into(),
+            },
+            BufferLink {
+                line: 0,
+                start_col: 4,
+                end_col: 6,
+                url: "https://right.dev".into(),
+            },
+        ];
+        apply_buffer_links_in(&mut buf, area, &links, LinkPolicy::WEB);
+
+        assert!(
+            buf[(1, 1)].symbol().contains("https://in.dev"),
+            "the in-rect link is embedded"
+        );
+        for (x, y) in [(1, 3), (5, 1)] {
+            assert_eq!(
+                buf[(x, y)],
+                Cell::default(),
+                "cell ({x}, {y}) is outside {area:?} and must stay untouched"
+            );
+        }
+
+        // An area that starts outside the buffer entirely places nothing.
+        let mut detached = Buffer::empty(Rect::new(4, 4, 2, 2));
+        apply_buffer_links_in(
+            &mut detached,
+            Rect::new(0, 0, 8, 8),
+            &links,
+            LinkPolicy::WEB,
+        );
+        for y in 4..6 {
+            for x in 4..6 {
+                assert_eq!(detached[(x, y)], Cell::default());
+            }
+        }
     }
 
     #[test]

--- a/src/tests/fuzz.rs
+++ b/src/tests/fuzz.rs
@@ -1,0 +1,918 @@
+//! Randomized robustness tests: the same code paths, hammered with adversarial
+//! input instead of curated examples.
+//!
+//! [`proptests`](super::proptests) pins *invariants of the solvers* — a child
+//! rect stays in bounds, a flex line fills exactly. This module is aimed one
+//! level lower, at the class of defect that reaches users as a crash rather
+//! than a wrong pixel: an arithmetic edge (the wrap solver's column counter
+//! overflowing at `AvailableSpace::MaxContent`), a byte offset that is not a
+//! char boundary, an index derived from a width that just went to zero.
+//!
+//! Five families live here, and they are deliberately different:
+//!
+//! - **Text** — strings built from an adversarial alphabet (wide CJK, ZWJ
+//!   emoji, combining marks, zero-width and control characters, whitespace
+//!   runs) through the wrap solver and the prose components, at every
+//!   interesting width including `0` and `u16::MAX`.
+//! - **Event streams** — arbitrary key/mouse sequences into the stateful
+//!   components, asserting that persistent state stays within the bounds the
+//!   caller declared (which is what a host indexes with on the next frame).
+//! - **Streaming markdown** — a differential against the one-shot render, over
+//!   generated documents, chunk sizes, and widths. Two settled-prefix bugs came
+//!   out of this one; both depended on where the chunk boundaries fell.
+//! - **Composed trees and overlays** — nested flex, boxes, and clamps rendered
+//!   into an inset area of a larger buffer, so a write past the rect is caught
+//!   as a scribble on the margin instead of landing in a neighbour.
+//! - **Parsers on untrusted bytes** — terminal replies, bare-URL detection, QR
+//!   payloads, image buffers: input tuika does not author and cannot trust.
+//!
+//! The per-component black-box sweep — every component × corpus × degenerate
+//! size, through the published API only — is its peer in `tests/robustness.rs`.
+//!
+//! Everything here is deterministic: proptest is seeded from its own regression
+//! file, and the sweeps enumerate fixed combinations.
+
+use proptest::prelude::*;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use ratatui_core::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::components::text::{wrap_lines, wrap_str};
+use crate::components::{Paragraph, Wrap};
+use crate::geometry::Size;
+use crate::style::Theme;
+use crate::view::{RenderCtx, View};
+use crate::width::{grapheme_cols, str_cols};
+
+/// Column width of a string as `usize`, so an assertion can *see* an overflow
+/// instead of inheriting [`str_cols`]'s saturation.
+fn cols(s: &str) -> usize {
+    s.graphemes(true).map(|g| grapheme_cols(g) as usize).sum()
+}
+
+/// Text fragments chosen to break naive column arithmetic and byte slicing.
+///
+/// Each entry is one *grapheme* concern: a wide CJK cell, a ZWJ sequence that
+/// must stay intact, a base + combining mark that must not be split, a
+/// zero-width space that advances bytes but no columns, a C0 control byte, and
+/// the whitespace runs that drive the solver's break logic.
+const FRAGMENTS: &[&str] = &[
+    "a",
+    "word",
+    "supercalifragilisticexpialidocious",
+    " ",
+    "  ",
+    "\t",
+    "\u{a0}",
+    "日本語",
+    "👩\u{200d}👩\u{200d}👦",
+    "e\u{301}",
+    "\u{200b}",
+    "\u{1}",
+    "https://example.dev/a/b",
+    "—",
+    "❤\u{fe0f}",
+    "x\u{fe0e}",
+];
+
+/// A string assembled from [`FRAGMENTS`], never containing a newline (the wrap
+/// solver's documented contract is one source line per call).
+fn fuzz_text() -> impl Strategy<Value = String> {
+    proptest::collection::vec(proptest::sample::select(FRAGMENTS), 0..24)
+        .prop_map(|parts| parts.concat())
+}
+
+/// Widths that matter: the degenerate ones, the ordinary ones, and the
+/// max-content sentinel `AvailableSpace::MaxContent` measures with.
+fn fuzz_width() -> impl Strategy<Value = u16> {
+    prop_oneof![
+        3 => 0u16..=8,
+        3 => 1u16..=200,
+        1 => Just(u16::MAX),
+        1 => (u16::MAX - 4)..=u16::MAX,
+    ]
+}
+
+/// Every non-whitespace grapheme of `text`, concatenated — what wrapping must
+/// preserve exactly, whatever it does with the spaces between them.
+fn words_only(text: &str) -> String {
+    text.graphemes(true)
+        .filter(|g| !g.chars().all(char::is_whitespace))
+        .collect()
+}
+
+proptest! {
+    /// The plain-text solver, over adversarial graphemes at every width: it
+    /// terminates, keeps every word's bytes, maps each word back to the source
+    /// exactly, and never lets a row exceed the width it was given.
+    #[test]
+    fn wrap_str_preserves_content_and_respects_width(
+        text in fuzz_text(),
+        width in fuzz_width(),
+    ) {
+        let rows = wrap_str(&text, width);
+        prop_assert!(!rows.is_empty(), "a wrap always yields at least one row");
+
+        let mut recovered = String::new();
+        for row in &rows {
+            // Every word points at the source bytes it was copied from, on a
+            // grapheme boundary — the property link ranges and search hits are
+            // carried onto a wrapped row with.
+            for (row_start, src) in &row.words {
+                prop_assert!(text.is_char_boundary(src.start) && text.is_char_boundary(src.end));
+                prop_assert_eq!(&row.text[*row_start..row_start + src.len()], &text[src.clone()]);
+                recovered.push_str(&text[src.clone()]);
+            }
+            // A row may exceed the width only when it is a single grapheme
+            // wider than the row itself (nothing left to break), or when the
+            // column counter is deliberately saturating at max-content width.
+            let row_cols = cols(&row.text);
+            if row_cols > width as usize && width != u16::MAX {
+                prop_assert_eq!(row.words.len(), 1, "over-wide row: {:?}", row.text);
+                prop_assert_eq!(row.text.graphemes(true).count(), 1, "over-wide row: {:?}", row.text);
+            }
+        }
+        prop_assert_eq!(recovered, words_only(&text), "wrapping lost or reordered content");
+    }
+
+    /// Re-wrapping an already-wrapped row at the same width is a fixed point.
+    ///
+    /// Any row the solver emits that would wrap again means the first pass
+    /// produced a row it does not itself consider to fit — the signature of an
+    /// off-by-one in the joining-space accounting.
+    #[test]
+    fn wrapping_is_a_fixed_point(text in fuzz_text(), width in 1u16..80) {
+        for row in wrap_str(&text, width) {
+            let again = wrap_str(&row.text, width);
+            prop_assert_eq!(again.len(), 1, "row {:?} re-wrapped to {}", row.text, again.len());
+            prop_assert_eq!(&again[0].text, &row.text);
+        }
+    }
+
+    /// The styled solver agrees with the plain one, glyph for glyph.
+    ///
+    /// `wrap_lines` and `wrap_str` share the solver and differ only in how they
+    /// join words (a styled space vs a plain one), so a divergence here means
+    /// the styled path lost a cluster in `coalesce`.
+    #[test]
+    fn styled_and_plain_wrapping_agree(text in fuzz_text(), width in fuzz_width()) {
+        let plain: Vec<String> = wrap_str(&text, width).into_iter().map(|r| r.text).collect();
+        let styled: Vec<String> = wrap_lines(&[Line::from(text.clone())], width)
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        if width == 0 {
+            // A zero width is documented as a pass-through for `wrap_lines`.
+            prop_assert_eq!(styled, vec![text]);
+        } else {
+            prop_assert_eq!(styled, plain);
+        }
+    }
+
+    /// Multi-span input keeps every cluster and every style across the reflow,
+    /// at any width — including the degenerate ones.
+    #[test]
+    fn wrap_lines_preserves_styled_clusters(
+        parts in proptest::collection::vec(
+            (proptest::sample::select(FRAGMENTS), 0u8..4),
+            0..12,
+        ),
+        width in fuzz_width(),
+    ) {
+        let styles = [
+            Style::default(),
+            Style::default().fg(ratatui_core::style::Color::Red),
+            Style::default().bg(ratatui_core::style::Color::Blue),
+            Style::default().add_modifier(ratatui_core::style::Modifier::BOLD),
+        ];
+        let line = Line::from(
+            parts
+                .iter()
+                .map(|(frag, style)| Span::styled((*frag).to_string(), styles[*style as usize]))
+                .collect::<Vec<_>>(),
+        );
+        let source: String = parts.iter().map(|(frag, _)| *frag).collect();
+        let out = wrap_lines(&[line], width);
+        prop_assert!(!out.is_empty());
+        if width == 0 {
+            return Ok(());
+        }
+        let recovered: String = out
+            .iter()
+            .flat_map(|line| line.spans.iter().map(|s| s.content.as_ref()))
+            .collect();
+        prop_assert_eq!(words_only(&recovered), words_only(&source));
+        for line in &out {
+            let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            if cols(&text) > width as usize && width != u16::MAX {
+                prop_assert_eq!(text.graphemes(true).count(), 1, "over-wide row: {:?}", text);
+            }
+        }
+    }
+
+    /// `Paragraph` measures what it renders.
+    ///
+    /// Its height must equal the number of rows the shared solver produces for
+    /// the same width — the disagreement that a second, differently-modelled
+    /// wrapper reintroduces every time one is added.
+    #[test]
+    fn paragraph_measurement_matches_its_wrap(text in fuzz_text(), width in 1u16..60) {
+        let theme = Theme::default();
+        let paragraph = Paragraph::new(text.clone(), Style::default());
+        let measured = paragraph.measure(Size::new(width, u16::MAX), &RenderCtx::new(&theme));
+        prop_assert_eq!(measured.height as usize, wrap_str(&text, width).len());
+        // A 2-column grapheme cannot be narrowed to fit a 1-column row, so the
+        // measured width is the offered one *or* the width of one wide cell —
+        // never anything the content did not actually need.
+        prop_assert!(measured.width <= width.max(2), "measured wider than offered");
+    }
+
+    /// Prose components paint inside their rect for any text and any size.
+    ///
+    /// The view is rendered into an inset area of a larger buffer, so a write
+    /// past its own bounds shows up as a scribble on the margin rather than
+    /// being silently absorbed by a neighbouring component.
+    #[test]
+    fn prose_components_stay_inside_their_rect(
+        text in fuzz_text(),
+        width in 0u16..24,
+        height in 0u16..8,
+    ) {
+        let lines: Vec<Line<'static>> = text.split(' ').map(|w| Line::from(w.to_string())).collect();
+        assert_inside(&Paragraph::new(text.clone(), Style::default()), width, height)?;
+        assert_inside(&Wrap::new(lines.clone()), width, height)?;
+        assert_inside(&crate::components::Text::new(lines), width, height)?;
+    }
+}
+
+proptest! {
+    // The corpus is deliberately enormous — over 65_535 columns on one row — so
+    // a handful of cases is both enough and all the time this is worth.
+    #![proptest_config(ProptestConfig { cases: 8, ..ProptestConfig::default() })]
+
+    /// Measuring at `MaxContent` (`u16::MAX` columns) must degrade, never panic.
+    ///
+    /// Prose long enough to overflow the solver's column counter is ordinary
+    /// pasted input — a log line, a generated paragraph — and it reaches this
+    /// path through every intrinsic-sizing container. This is the regression
+    /// net around the counter overflow that saturating arithmetic fixed.
+    #[test]
+    fn prose_survives_max_content_measurement(text in fuzz_text()) {
+        let theme = Theme::default();
+        let unit = if text.trim().is_empty() { "word".to_string() } else { text };
+        let per_repeat = str_cols(&unit).max(1) as usize + 1;
+        let repeats = (u16::MAX as usize / per_repeat) + 8;
+        let long = std::iter::repeat_n(unit.as_str(), repeats)
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let rows = wrap_str(&long, u16::MAX);
+        prop_assert_eq!(rows.len(), 1, "everything fits at max-content width");
+        prop_assert_eq!(wrap_lines(&[Line::from(long.clone())], u16::MAX).len(), 1);
+        let measured = Paragraph::new(long, Style::default())
+            .measure(Size::new(u16::MAX, u16::MAX), &RenderCtx::new(&theme));
+        prop_assert_eq!(measured.height, 1);
+    }
+}
+
+/// Render `view` into an inset rect of a margined buffer and assert that every
+/// cell outside that rect is untouched.
+fn assert_inside(view: &dyn View, width: u16, height: u16) -> Result<(), TestCaseError> {
+    const MARGIN: u16 = 2;
+    let theme = Theme::default();
+    let outer = Rect::new(0, 0, width + MARGIN * 2, height + MARGIN * 2);
+    let inner = Rect::new(MARGIN, MARGIN, width, height);
+    let mut buffer = ratatui_core::buffer::Buffer::empty(outer);
+    crate::paint(&mut buffer, inner, &theme, view, &[]);
+    let untouched = ratatui_core::buffer::Cell::default();
+    for y in outer.top()..outer.bottom() {
+        for x in outer.left()..outer.right() {
+            if inner.contains(ratatui_core::layout::Position::new(x, y)) {
+                continue;
+            }
+            prop_assert_eq!(
+                &buffer[(x, y)],
+                &untouched,
+                "cell ({}, {}) outside {:?} was painted",
+                x,
+                y,
+                inner
+            );
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Event-sequence fuzzing
+// ---------------------------------------------------------------------------
+
+/// An arbitrary input event, weighted towards the kinds that move a selection
+/// or a scroll offset — the state a host indexes its own model with on the next
+/// frame, and therefore the state a bad clamp turns into a panic upstream.
+fn fuzz_event() -> impl Strategy<Value = crate::Event> {
+    use crate::{Event, Key, KeyCode, Mouse, MouseButton, MouseKind};
+    let codes = prop_oneof![
+        Just(KeyCode::Up),
+        Just(KeyCode::Down),
+        Just(KeyCode::Left),
+        Just(KeyCode::Right),
+        Just(KeyCode::Home),
+        Just(KeyCode::End),
+        Just(KeyCode::PageUp),
+        Just(KeyCode::PageDown),
+        Just(KeyCode::Enter),
+        Just(KeyCode::Esc),
+        Just(KeyCode::Tab),
+        Just(KeyCode::BackTab),
+        Just(KeyCode::Backspace),
+        Just(KeyCode::Delete),
+        proptest::sample::select(&['a', ' ', '\n', '界', '👩', '\u{301}', '\u{1}'][..])
+            .prop_map(KeyCode::Char),
+    ];
+    let keys = (codes, any::<bool>(), any::<bool>(), any::<bool>()).prop_map(
+        |(code, ctrl, alt, shift)| {
+            Event::Key(Key {
+                code,
+                ctrl,
+                alt,
+                shift,
+            })
+        },
+    );
+    let kinds = prop_oneof![
+        Just(MouseKind::Down(MouseButton::Left)),
+        Just(MouseKind::Up(MouseButton::Left)),
+        Just(MouseKind::Drag(MouseButton::Left)),
+        Just(MouseKind::Moved),
+        Just(MouseKind::ScrollUp),
+        Just(MouseKind::ScrollDown),
+        Just(MouseKind::ScrollLeft),
+        Just(MouseKind::ScrollRight),
+    ];
+    prop_oneof![
+        6 => keys,
+        3 => (kinds, 0u16..40, 0u16..20).prop_map(|(kind, x, y)| Event::Mouse(Mouse::at(kind, x, y))),
+        1 => fuzz_text().prop_map(crate::Event::Paste),
+    ]
+}
+
+fn fuzz_events() -> impl Strategy<Value = Vec<crate::Event>> {
+    proptest::collection::vec(fuzz_event(), 0..40)
+}
+
+proptest! {
+    /// A selection is an index its host will use to look a row up. For a list
+    /// whose length does not change under it, no event stream may push the
+    /// selection outside that list.
+    #[test]
+    fn select_state_never_points_outside_a_stable_list(
+        events in fuzz_events(),
+        len in 0usize..8,
+    ) {
+        use crate::components::SelectState;
+        let mut state = SelectState::new();
+        for event in &events {
+            let before = state.selected();
+            let _ = state.handle(event, len);
+            // A fresh state starts on row 0 and a host reconciles it with
+            // `clamp`; what the *handler* must never do is move a valid
+            // selection out of range.
+            if before.is_none_or(|index| index < len)
+                && let Some(index) = state.selected()
+            {
+                prop_assert!(index < len, "selected {} of {}", index, len);
+            }
+        }
+    }
+
+    /// When the list *does* change under the state — a filter, a refresh, a
+    /// stream that dropped rows — the documented reconcile is what restores the
+    /// invariant, and it must do so from any state an event stream can reach.
+    ///
+    /// This is the contract hosts rely on, so it is worth a test of its own:
+    /// tuika's stateful components deliberately keep a stale index rather than
+    /// silently moving a user's selection, and hand the caller `clamp` for the
+    /// frame where the collection actually changed.
+    #[test]
+    fn shrinking_a_list_is_reconciled_by_clamping(
+        events in fuzz_events(),
+        lens in proptest::collection::vec(0usize..8, 1..6),
+    ) {
+        use crate::components::{FormState, SelectState, TabSelectState, TabsState};
+        let mut select = SelectState::new();
+        let mut form = FormState::new();
+        let mut tabs = TabsState::new();
+        let mut tab_select = TabSelectState::new();
+        for (i, event) in events.iter().enumerate() {
+            let len = lens[i % lens.len()];
+            let _ = select.handle(event, len);
+            let _ = form.handle(event, len);
+            let _ = tabs.handle(event, len);
+            let _ = tab_select.handle(event, len);
+
+            select.clamp(len);
+            form.clamp(len);
+            tabs.select(tabs.selected(), len);
+            tab_select.select(tab_select.selected(), len);
+
+            if len == 0 {
+                prop_assert_eq!(select.selected(), None);
+                prop_assert_eq!(form.focused(), 0);
+            } else {
+                prop_assert!(select.selected().is_none_or(|index| index < len));
+                prop_assert!(form.focused() < len);
+                prop_assert!(tabs.selected() < len);
+                prop_assert!(tab_select.selected() < len);
+            }
+        }
+    }
+
+    /// A scroll offset stays within the scrollable range of the geometry it is
+    /// handled at — and after a resize or a content change, the documented
+    /// per-frame `clamp` brings it back in range.
+    #[test]
+    fn scroll_state_offset_stays_scrollable(
+        events in fuzz_events(),
+        shapes in proptest::collection::vec((0usize..40, 0usize..12), 1..6),
+    ) {
+        use crate::components::ScrollState;
+        let mut state = ScrollState::new();
+        let mut stable = ScrollState::new();
+        let (fixed_content, fixed_viewport) = shapes[0];
+        for (i, event) in events.iter().enumerate() {
+            let (content, viewport) = shapes[i % shapes.len()];
+            let _ = state.handle(event, content, viewport);
+            state.clamp(content, viewport);
+            prop_assert!(
+                state.offset() <= ScrollState::max_offset(content, viewport),
+                "offset {} past the end of {} rows in a {}-row viewport",
+                state.offset(),
+                content,
+                viewport
+            );
+
+            // Unchanging geometry needs no reconcile: handling alone must never
+            // put the offset out of range.
+            let _ = stable.handle(event, fixed_content, fixed_viewport);
+            prop_assert!(
+                stable.offset() <= ScrollState::max_offset(fixed_content, fixed_viewport),
+                "offset {} left the range of a viewport that never changed",
+                stable.offset()
+            );
+        }
+    }
+
+    /// The editor's cursor must stay addressable: a row that exists, and a
+    /// column no further than the end of that row. A cursor past either is what
+    /// turns the next keystroke into a slice panic.
+    #[test]
+    fn text_input_cursor_stays_addressable(events in fuzz_events(), seed in fuzz_text()) {
+        use crate::components::TextInputState;
+        let mut state = TextInputState::from_text(&seed);
+        for event in &events {
+            let _ = state.handle(event);
+            let (row, col) = state.cursor();
+            prop_assert!(row < state.line_count(), "cursor row {} of {}", row, state.line_count());
+            let text = state.text();
+            let line = text.split('\n').nth(row).expect("the cursor row exists in the text");
+            prop_assert!(col <= line.chars().count(), "cursor col {} past {:?}", col, line);
+        }
+        // Whatever the stream did, the text round-trips through the state.
+        let text = state.text();
+        prop_assert_eq!(TextInputState::from_text(&text).text(), text);
+    }
+
+    /// A slider's value never leaves its declared range, whatever is pressed or
+    /// dragged — a host reads it back as a ratio and multiplies by a length.
+    #[test]
+    fn slider_value_stays_in_range(
+        events in fuzz_events(),
+        min in -50.0f32..50.0,
+        span in 0.0f32..100.0,
+    ) {
+        use crate::components::SliderState;
+        let max = min + span;
+        let mut state = SliderState::new(min, max, min);
+        for event in &events {
+            let _ = state.handle(event);
+            prop_assert!(
+                state.value() >= min && state.value() <= max,
+                "{} outside {}..={}",
+                state.value(),
+                min,
+                max
+            );
+            let ratio = state.ratio();
+            prop_assert!((0.0..=1.0).contains(&ratio), "ratio {} outside 0..=1", ratio);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming markdown
+// ---------------------------------------------------------------------------
+
+/// Markdown-shaped fragments: block starts, inline markers, fence delimiters,
+/// table pipes, and the blank lines the streaming cache settles on.
+const MARKDOWN_FRAGMENTS: &[&str] = &[
+    "# heading\n",
+    "## deeper\n",
+    "text ",
+    "**bold** ",
+    "*em* ",
+    "`code` ",
+    "[label](https://example.dev) ",
+    "- item\n",
+    "1. item\n",
+    "> quote\n",
+    "\n",
+    "```rust\n",
+    "fn main() {}\n",
+    "```\n",
+    "| a | b |\n",
+    "| - | - |\n",
+    "| 1 | 2 |\n",
+    "---\n",
+    "日本語 👩\u{200d}👩\u{200d}👦 ",
+    "<b>html</b> ",
+];
+
+fn fuzz_markdown() -> impl Strategy<Value = String> {
+    proptest::collection::vec(proptest::sample::select(MARKDOWN_FRAGMENTS), 0..20)
+        .prop_map(|parts| parts.concat())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 96, ..ProptestConfig::default() })]
+
+    /// A streamed document renders exactly like the same document rendered in
+    /// one shot.
+    ///
+    /// `MarkdownState` settles a prefix and re-parses only the tail, so what a
+    /// user sees depends on *where the chunk boundaries fell* — the one thing a
+    /// host does not control. Any divergence is a rendering artifact that
+    /// appears only under streaming, which is the hardest kind to reproduce
+    /// from a bug report.
+    #[test]
+    fn streaming_markdown_matches_a_one_shot_render(
+        source in fuzz_markdown(),
+        chunk in 1usize..9,
+        width in 8u16..60,
+    ) {
+        use crate::components::MarkdownState;
+        use crate::highlight::CodeHighlighter;
+        use crate::style::StyleSheet;
+
+        let theme = Theme::default();
+        let sheet = StyleSheet::from_theme(&theme);
+        let mut state = MarkdownState::new();
+        let chars: Vec<char> = source.chars().collect();
+        for piece in chars.chunks(chunk) {
+            state.push_str(&piece.iter().collect::<String>());
+            // Rendering mid-stream is what a host does every frame, and it is
+            // what populates the cache the final render must agree with.
+            let _ = state.lines(width, &theme, &sheet, CodeHighlighter::Plain);
+        }
+        let streamed: Vec<String> = state
+            .lines(width, &theme, &sheet, CodeHighlighter::Plain)
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        let one_shot: Vec<String> = crate::components::markdown::to_lines(
+            &source,
+            width,
+            &theme,
+            &sheet,
+            CodeHighlighter::Plain,
+        )
+        .iter()
+        .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+        .collect();
+        prop_assert_eq!(streamed, one_shot, "streamed render diverged from one-shot");
+    }
+
+    /// Re-rendering a settled stream at a new width must equal a fresh state at
+    /// that width: the width-keyed cache invalidation has to drop everything a
+    /// re-wrap changes.
+    #[test]
+    fn markdown_rewraps_identically_after_a_resize(
+        source in fuzz_markdown(),
+        first in 8u16..60,
+        second in 8u16..60,
+    ) {
+        use crate::components::MarkdownState;
+        use crate::highlight::CodeHighlighter;
+        use crate::style::StyleSheet;
+
+        let theme = Theme::default();
+        let sheet = StyleSheet::from_theme(&theme);
+        let mut resized = MarkdownState::new();
+        resized.set(source.clone());
+        let _ = resized.lines(first, &theme, &sheet, CodeHighlighter::Plain);
+        let after: Vec<Line<'static>> = resized
+            .lines(second, &theme, &sheet, CodeHighlighter::Plain)
+            .to_vec();
+
+        let mut fresh = MarkdownState::new();
+        fresh.set(source);
+        let expected = fresh.lines(second, &theme, &sheet, CodeHighlighter::Plain);
+        prop_assert_eq!(&after, expected, "a resize left stale lines behind");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Composed trees and overlays
+// ---------------------------------------------------------------------------
+
+/// A description of an arbitrary view tree.
+///
+/// The tree is fuzzed as *data* and built in the test body, because an
+/// `Element` is neither `Clone` nor `Debug` — and a shrunk counterexample has to
+/// be printable to be worth anything.
+#[derive(Clone, Debug)]
+enum Node {
+    Text(String),
+    Paragraph(String),
+    Spacer,
+    Rule,
+    Progress(u16),
+    Boxed {
+        child: Box<Node>,
+        padding: u16,
+        titled: bool,
+    },
+    Clamp {
+        child: Box<Node>,
+        width: u16,
+        height: u16,
+    },
+    Flex {
+        row: bool,
+        gap: u16,
+        padding: u16,
+        wrap: bool,
+        children: Vec<(Node, u8, u16)>,
+    },
+}
+
+impl Node {
+    fn build(&self) -> crate::Element {
+        use crate::components::{Boxed, Constrained, Flex, ProgressBar, Rule, Spacer, Text};
+        use crate::element;
+        use crate::geometry::Padding;
+        use crate::layout::{AlignContent, Dimension, FlexWrap};
+
+        match self {
+            Self::Text(text) => element(Text::raw(text.clone())),
+            Self::Paragraph(text) => element(Paragraph::new(text.clone(), Style::default())),
+            Self::Spacer => element(Spacer),
+            Self::Rule => element(Rule::new()),
+            Self::Progress(pct) => element(ProgressBar::determinate(*pct as f32 / 100.0)),
+            Self::Boxed {
+                child,
+                padding,
+                titled,
+            } => {
+                let boxed = Boxed::new(child.build()).padding(Padding::all(*padding));
+                element(if *titled {
+                    boxed.title(Line::from("title"))
+                } else {
+                    boxed
+                })
+            }
+            Self::Clamp {
+                child,
+                width,
+                height,
+            } => element(Constrained::new(child.build()).min_size(*width, *height)),
+            Self::Flex {
+                row,
+                gap,
+                padding,
+                wrap,
+                children,
+            } => {
+                let mut flex = if *row { Flex::row() } else { Flex::column() }
+                    .gap(*gap)
+                    .padding(Padding::all(*padding))
+                    .align_content(AlignContent::Start);
+                if *wrap {
+                    flex = flex.wrap(FlexWrap::Wrap);
+                }
+                for (child, kind, cells) in children {
+                    let child = child.build();
+                    flex = match kind {
+                        0 => flex.auto(child),
+                        1 => flex.grow(1 + cells % 3, child),
+                        2 => flex.fixed(*cells, child),
+                        _ => flex.child(Dimension::Percent(cells.saturating_mul(8)), child),
+                    };
+                }
+                element(flex)
+            }
+        }
+    }
+}
+
+/// An arbitrary view tree: leaves wrapped in nested flex containers, boxes, and
+/// intrinsic clamps, with fuzzed gaps, padding, wrapping, and alignment.
+///
+/// Individual components are covered by the black-box sweep in
+/// `tests/robustness.rs`; what this adds is *depth*. A container that miscounts
+/// its chrome only overflows when something else has already eaten the space —
+/// a padded box inside a wrapped row inside a column, on a screen two cells
+/// tall.
+fn fuzz_tree() -> impl Strategy<Value = Node> {
+    let leaf = prop_oneof![
+        fuzz_text().prop_map(Node::Text),
+        fuzz_text().prop_map(Node::Paragraph),
+        Just(Node::Spacer),
+        Just(Node::Rule),
+        (0u16..=100).prop_map(Node::Progress),
+    ];
+
+    leaf.prop_recursive(4, 24, 3, |inner| {
+        prop_oneof![
+            (inner.clone(), 0u16..4, any::<bool>()).prop_map(|(child, padding, titled)| {
+                Node::Boxed {
+                    child: Box::new(child),
+                    padding,
+                    titled,
+                }
+            }),
+            (inner.clone(), 0u16..20, 0u16..20).prop_map(|(child, width, height)| Node::Clamp {
+                child: Box::new(child),
+                width,
+                height,
+            }),
+            (
+                proptest::collection::vec((inner, 0u8..4, 0u16..12), 1..4),
+                any::<bool>(),
+                0u16..4,
+                0u16..4,
+                any::<bool>(),
+            )
+                .prop_map(|(children, row, gap, padding, wrap)| Node::Flex {
+                    row,
+                    gap,
+                    padding,
+                    wrap,
+                    children,
+                }),
+        ]
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 128, ..ProptestConfig::default() })]
+
+    /// A composed tree paints only inside the rect it was given, at any size.
+    #[test]
+    fn composed_trees_stay_inside_their_rect(
+        tree in fuzz_tree(),
+        width in 0u16..40,
+        height in 0u16..16,
+    ) {
+        assert_inside(tree.build().as_ref(), width, height)?;
+    }
+
+    /// Overlays resolve inside the screen and paint inside themselves, for any
+    /// base tree, overlay tree, spec, and screen — including screens smaller
+    /// than the overlay's own minimum.
+    #[test]
+    fn scenes_with_overlays_stay_on_screen(
+        base in fuzz_tree(),
+        floating in fuzz_tree(),
+        width in 0u16..50,
+        height in 0u16..20,
+        pct in 0u16..=100,
+        margin in 0u16..8,
+        min in 0u16..20,
+        anchor in 0usize..9,
+    ) {
+        use crate::overlay::{Anchor, Extent, OverlaySpec};
+        use crate::scene::{Scene, SceneOverlay};
+
+        let anchors = [
+            Anchor::Center,
+            Anchor::Top,
+            Anchor::Bottom,
+            Anchor::Left,
+            Anchor::Right,
+            Anchor::TopLeft,
+            Anchor::TopRight,
+            Anchor::BottomLeft,
+            Anchor::BottomRight,
+        ];
+        let spec = OverlaySpec {
+            anchor: anchors[anchor],
+            width: Extent::Percent(pct),
+            height: Extent::Percent(pct),
+            min_width: min,
+            min_height: min,
+            margin,
+            ..OverlaySpec::centered(0, 0)
+        };
+        let scene = Scene::new(base.build()).overlay(SceneOverlay::new(floating.build(), spec));
+        assert_inside(&scene, width, height)?;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parsers on untrusted bytes
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// The terminal's replies are untrusted input.
+    ///
+    /// A palette/device-attributes probe reads whatever the emulator (or an
+    /// `ssh` session, or a mangled `tmux` passthrough) sends back — truncated
+    /// sequences, wrong digit counts, embedded NULs, a reply for a query that
+    /// was never sent. Parsing must always terminate with *some* answer, never
+    /// panic on a slice or an integer conversion.
+    #[test]
+    fn terminal_replies_parse_or_decline(bytes in proptest::collection::vec(any::<u8>(), 0..64)) {
+        use crate::term::capabilities::DeviceAttributes;
+        use crate::term::palette::TerminalPalette;
+
+        let palette = TerminalPalette::parse(&bytes);
+        // Whatever it decided, deriving a theme from it must agree with itself.
+        let theme = Theme::from_terminal(&palette);
+        prop_assert!(theme.is_none() || !palette.is_empty());
+        let _ = DeviceAttributes::parse(&bytes);
+    }
+
+    /// The same, on the byte shapes a real reply *nearly* has: a well-formed
+    /// OSC frame with fuzzed digits, lengths, and terminators.
+    #[test]
+    fn near_miss_terminal_replies_parse_or_decline(
+        index in 0u16..300,
+        digits in proptest::collection::vec(proptest::sample::select(&b"0123456789abcdefABCDEF/;:"[..]), 0..24),
+        terminated in any::<bool>(),
+    ) {
+        use crate::term::palette::TerminalPalette;
+
+        let body = String::from_utf8(digits).expect("ascii");
+        let mut reply = format!("\x1b]4;{index};rgb:{body}");
+        if terminated {
+            reply.push_str("\x1b\\");
+        }
+        let palette = TerminalPalette::parse(reply.as_bytes());
+        let _ = Theme::from_terminal(&palette);
+    }
+
+    /// Bare-URL detection runs over every line a host paints, so it sees
+    /// arbitrary text. Each range it returns must be a valid slice of the input
+    /// on char boundaries — a host slices with them.
+    #[test]
+    fn link_detection_returns_valid_ranges(text in fuzz_text(), scheme in fuzz_text()) {
+        use crate::term::hyperlink::LinkPolicy;
+
+        let subject = format!("{scheme}https://a.dev/{text} mailto:x@y.dev {text}");
+        for policy in [LinkPolicy::WEB, LinkPolicy::NONE, LinkPolicy::default()] {
+            for (start, end) in crate::term::hyperlink::find_links(&subject, policy) {
+                prop_assert!(start < end && end <= subject.len());
+                prop_assert!(subject.is_char_boundary(start) && subject.is_char_boundary(end));
+                prop_assert!(!subject[start..end].chars().any(char::is_whitespace));
+            }
+        }
+    }
+
+    /// The QR encoder takes a host-supplied payload and returns `None` rather
+    /// than panicking when it does not fit, and every matrix it does return is
+    /// square and non-empty.
+    #[test]
+    fn qr_encoding_either_fits_or_declines(payload in proptest::collection::vec(any::<u8>(), 0..200)) {
+        use crate::components::{QrCode, QrEcc};
+
+        let text = String::from_utf8_lossy(&payload).into_owned();
+        for ecc in [QrEcc::Low, QrEcc::Medium, QrEcc::Quartile, QrEcc::High] {
+            let Some(code) = QrCode::encode(&text, ecc) else {
+                continue;
+            };
+            let theme = Theme::default();
+            // A code that encoded must also paint at any size.
+            for (w, h) in [(0u16, 0u16), (1, 1), (21, 11), (80, 40)] {
+                let _ = crate::testing::render(&code, w, h, &theme);
+            }
+        }
+    }
+
+    /// Image payloads come from a host's decoder, so the dimensions and the
+    /// buffer can disagree. Construction must reject a mismatch instead of
+    /// trusting it into an out-of-bounds read later.
+    #[test]
+    fn image_data_rejects_mismatched_buffers(
+        width in 0u32..8,
+        height in 0u32..8,
+        len in 0usize..80,
+    ) {
+        use crate::term::image::ImageData;
+
+        let data = ImageData::from_rgba(width, height, vec![0u8; len]);
+        let expected = (width as usize) * (height as usize) * 4;
+        prop_assert_eq!(data.is_some(), expected != 0 && len == expected);
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -9,6 +9,7 @@
 //! Nothing here ships in the library. Public test helpers for *consumers* are a
 //! different thing and live in [`crate::testing`].
 
+mod fuzz;
 mod integration;
 mod proptests;
 mod snapshots;

--- a/tests/robustness.rs
+++ b/tests/robustness.rs
@@ -1,0 +1,595 @@
+//! Black-box robustness sweep over the public component surface.
+//!
+//! Every other suite renders a component the way its author expects it to be
+//! used. This one does the opposite: it feeds each component adversarial text
+//! (wide CJK, ZWJ emoji, combining marks, control bytes, a 4 KiB word, embedded
+//! newlines) and renders it at every degenerate geometry a terminal can
+//! actually produce — a zero column, a one-cell screen, a screen narrower than
+//! the component's own chrome — through nothing but the published API.
+//!
+//! Three properties are asserted for every (component × corpus × size)
+//! combination, because all three are ways the same class of bug reaches a
+//! user:
+//!
+//! 1. **No panic.** Untrusted text and a shrinking viewport must degrade, never
+//!    crash the host. The wrap solver's column counter overflowing at
+//!    max-content width was exactly this.
+//! 2. **No painting outside the rect.** Each view is rendered into an inset
+//!    area of a larger buffer; a write past its own bounds shows up on the
+//!    margin instead of silently landing in a neighbour.
+//! 3. **No control bytes in cells.** A component that copies a C0 byte from its
+//!    input into the cell grid corrupts the terminal for the whole session.
+//!
+//! The sweep is exhaustive and deterministic — no RNG — so a failure names the
+//! exact component, corpus, and size that broke.
+
+use tuika::components::{
+    ActivityItem, ActivityList, ActivityStatus, AsciiFont, Boxed, CodeBlock, CompletionItem,
+    CompletionPalette, CompletionState, Console, ConsoleLog, Diff, Flow, FormField, FormState,
+    Grid, ItemScroll, KeyHints, Loader, Markdown, MarkdownState, Paragraph, ProgressBar, QrCode,
+    QrEcc, Rule, Scroll, ScrollState, Scrollbar, SelectList, SelectState, SelectionScreen, Slider,
+    SliderState, Spinner, StatusBar, TabSelect, TabSelectState, Table, Tabs, TabsState, Text,
+    TextInput, TextInputState, ToastLevel, ToastList, Toasts, TreeList, TreeRow, TreeState,
+    Viewport, VirtualWindow, Wrap,
+};
+use tuika::prelude::*;
+use tuika::style::StyleSheet;
+use tuika::themes;
+
+/// Adversarial inputs, each aimed at one way text breaks a terminal renderer.
+const CORPORA: &[(&str, &str)] = &[
+    ("empty", ""),
+    ("ascii", "the quick brown fox jumps over the lazy dog"),
+    ("wide", "日本語のテキストと絵文字 👩‍👩‍👦 が混ざった行"),
+    (
+        "combining",
+        "e\u{301}e\u{301}e\u{301} a\u{300}\u{327} ❤\u{fe0f} x\u{fe0e}",
+    ),
+    ("zero_width", "a\u{200b}b\u{200b}c\u{200d}d\u{feff}e"),
+    ("control", "before\u{1}\u{7}\u{1b}after\u{7f}end"),
+    ("newlines", "one\ntwo\n\n\nthree\r\nfour"),
+    ("whitespace", "   \t\t   \u{a0}\u{2003}   "),
+    (
+        "long_word",
+        "supercalifragilisticexpialidocious-and-then-some-more-without-a-single-break",
+    ),
+    (
+        "markdownish",
+        "# h1\n\n- *a* **b** `c`\n\n| a | b |\n| - | - |\n| 1 | 2 |\n\n```rs\nfn f(){}\n```",
+    ),
+    (
+        "url",
+        "see https://example.dev/a/b?c=d&e=f#g and http://x.io",
+    ),
+];
+
+/// Geometries a real terminal can hand a component, degenerate ones first.
+const SIZES: &[(u16, u16)] = &[
+    (0, 0),
+    (0, 4),
+    (4, 0),
+    (1, 1),
+    (2, 1),
+    (1, 3),
+    (3, 3),
+    (5, 2),
+    (8, 4),
+    (13, 7),
+    (24, 3),
+    (40, 12),
+    (80, 24),
+    (120, 2),
+    (2, 60),
+    (200, 1),
+];
+
+/// Call `visit` once per component, with a name and a borrowed view built from
+/// `text`.
+///
+/// Views that borrow host state (every selection, scroll, and editor component)
+/// are constructed here with their state on the stack, so the sweep covers the
+/// borrowed forms without leaking a state per combination.
+fn for_each_component(text: &'static str, visit: &mut dyn FnMut(&str, &dyn View)) {
+    let theme = Theme::default();
+    let lines: Vec<Line<'static>> = text.lines().map(|l| Line::from(l.to_string())).collect();
+    let lines = if lines.is_empty() {
+        vec![Line::from(String::new())]
+    } else {
+        lines
+    };
+    let words: Vec<Line<'static>> = text
+        .split_whitespace()
+        .map(|w| Line::from(w.to_string()))
+        .collect();
+    let words = if words.is_empty() {
+        vec![Line::from(String::new())]
+    } else {
+        words
+    };
+
+    // Prose.
+    visit("text", &Text::new(lines.clone()));
+    visit("paragraph", &Paragraph::new(text, theme.text_style()));
+    visit("wrap", &Wrap::new(lines.clone()));
+    visit("markdown", &Markdown::new(text));
+    visit(
+        "code_block",
+        &CodeBlock::new("rust", text).line_numbers(true),
+    );
+    visit(
+        "diff",
+        &Diff::new(text, &format!("{text}\nchanged")).line_numbers(true),
+    );
+    visit("ascii_font", &AsciiFont::new(text));
+
+    // Streamed markdown, fed one chunk at a time like a host does.
+    let mut md = MarkdownState::new();
+    for chunk in text.as_bytes().chunks(7) {
+        md.push_str(&String::from_utf8_lossy(chunk));
+    }
+    let sheet = StyleSheet::from_theme(&theme);
+    let streamed = md
+        .lines(40, &theme, &sheet, tuika::highlight::CodeHighlighter::Plain)
+        .to_vec();
+    visit("markdown_streamed", &Text::new(streamed));
+
+    // Chrome and containers.
+    visit(
+        "boxed",
+        &Boxed::new(element(Text::new(lines.clone())))
+            .title(Line::from(text.to_string()))
+            .padding(Padding::all(1)),
+    );
+    visit("rule", &Rule::new().title(Line::from(text.to_string())));
+    visit(
+        "flow",
+        &words.iter().fold(Flow::new().gap(1), |flow, word| {
+            flow.item(element(Text::new(vec![word.clone()])))
+        }),
+    );
+    visit(
+        "grid",
+        &words.iter().fold(Grid::new(3).gap(1), |grid, word| {
+            grid.cell(element(Text::new(vec![word.clone()])))
+        }),
+    );
+    visit(
+        "status_bar",
+        &StatusBar::new()
+            .left(vec![Span::styled(text.to_string(), theme.text_style())])
+            .right(vec![Span::styled(text.to_string(), theme.muted_style())]),
+    );
+    visit(
+        "key_hints",
+        &KeyHints::new([("ctrl+c", text), (text, "quit")]),
+    );
+
+    // Progress and motion.
+    visit(
+        "progress_bar",
+        &ProgressBar::determinate(0.42).label(text).percent(true),
+    );
+    visit("spinner", &Spinner::new(7));
+    visit("loader", &Loader::new(3, text).hint(text));
+    visit(
+        "activity_list",
+        &ActivityList::new(vec![
+            ActivityItem::new(text, ActivityStatus::Running)
+                .detail(text)
+                .progress(0.5),
+            ActivityItem::new(text, ActivityStatus::Queued),
+        ])
+        .frame(2),
+    );
+
+    // Selection and scrolling, over borrowed state.
+    let mut select = SelectState::new();
+    select.select(Some(words.len().saturating_sub(1)));
+    visit("select_list", &SelectList::new(words.clone(), &select));
+    visit(
+        "table",
+        &Table::new(
+            vec![
+                Column::new(Line::from(text.to_string()), Dimension::Flex(1)),
+                Column::new(Line::from("n"), Dimension::Fixed(4)),
+            ],
+            words
+                .iter()
+                .map(|w| vec![w.clone(), Line::from("1")])
+                .collect(),
+            &select,
+        ),
+    );
+    visit(
+        "selection_screen",
+        &SelectionScreen::new(text, words.clone(), &select).leading_rule(),
+    );
+
+    let scroll = ScrollState::new();
+    visit("scroll", &Scroll::new(lines.clone(), &scroll));
+    visit(
+        "item_scroll",
+        &ItemScroll::new(
+            words
+                .iter()
+                .map(|w| element(Text::new(vec![w.clone()])))
+                .collect(),
+            &scroll,
+        )
+        .gap(1),
+    );
+    visit(
+        "viewport",
+        &Viewport::new(element(Text::new(lines.clone())), Size::new(30, 4), &scroll),
+    );
+    visit(
+        "scrollbar",
+        &Scrollbar::vertical(VirtualWindow::new(100, 10, 40)),
+    );
+
+    let tabs = TabsState::default();
+    visit("tabs", &Tabs::new(words.clone(), &tabs));
+    let tab_select = TabSelectState::default();
+    visit("tab_select", &TabSelect::new(words.clone(), &tab_select));
+
+    let rows: Vec<TreeRow<'_, usize>> = words
+        .iter()
+        .enumerate()
+        .map(|(i, w)| {
+            let label = w
+                .spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>();
+            if i == 0 {
+                TreeRow::root(i, label, true)
+            } else {
+                TreeRow::new(i, Some(0), 1, label, false)
+            }
+        })
+        .collect();
+    let mut tree = TreeState::with_selected(0usize);
+    tree.expand(0);
+    visit("tree_list", &TreeList::new(&rows, &tree));
+
+    let items: Vec<CompletionItem> = words
+        .iter()
+        .map(|w| {
+            let label = w
+                .spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<String>();
+            CompletionItem::new(label).detail(text)
+        })
+        .collect();
+    let mut completion = CompletionState::new();
+    completion.sync(text, &items);
+    visit(
+        "completion_palette",
+        &CompletionPalette::new(&items, &completion)
+            .title(text)
+            .show_query(true),
+    );
+
+    // Editing, forms, and floating chrome.
+    let input = TextInputState::from_text(text);
+    visit(
+        "text_input",
+        &TextInput::new(&input).placeholder(text, theme.muted_style()),
+    );
+    let form_state = FormState::default();
+    visit(
+        "form",
+        &Form::new(
+            vec![
+                FormField::new(text, element(Text::raw(text))).help(text),
+                FormField::new("second", element(Text::raw(text))).error(text),
+            ],
+            &form_state,
+        ),
+    );
+    let slider = SliderState::new(0.0, 1.0, 0.5);
+    visit("slider", &Slider::new(&slider).label(&slider));
+
+    let mut toasts = Toasts::new(4);
+    toasts.push(ToastLevel::Error, text);
+    toasts.push(ToastLevel::Info, text);
+    visit("toast_list", &ToastList::new(&toasts));
+
+    let log = ConsoleLog::new(16);
+    for line in text.lines() {
+        log.line(line);
+    }
+    visit("console", &Console::new(&log).title(" log "));
+
+    if let Some(qr) = QrCode::encode(text, QrEcc::Low) {
+        visit("qr", &qr);
+    }
+}
+
+/// Strip OSC 8 hyperlink wrappers from a cell symbol, leaving what the terminal
+/// actually displays.
+///
+/// tuika embeds `ESC ] 8 ; ; url ST` runs in the cells of a linked label, so an
+/// escape *there* is the feature. Anywhere else it is terminal corruption, and
+/// stripping the wrapper is what tells the two apart — the same thing a host
+/// reconstructing a row has to do.
+fn strip_osc8(symbol: &str) -> String {
+    let mut out = String::with_capacity(symbol.len());
+    let mut rest = symbol;
+    while let Some(open) = rest.find("\u{1b}]8;;") {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + "\u{1b}]8;;".len()..];
+        match after.find("\u{1b}\\") {
+            Some(end) => rest = &after[end + 2..],
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Render into an inset rect of a margined buffer and assert the component
+/// painted only inside it, wrote no control byte, and did not panic.
+fn assert_well_behaved(name: &str, corpus: &str, view: &dyn View, theme: &Theme) {
+    const MARGIN: u16 = 2;
+    for &(width, height) in SIZES {
+        let outer = Rect::new(0, 0, width + MARGIN * 2, height + MARGIN * 2);
+        let inner = Rect::new(MARGIN, MARGIN, width, height);
+        let mut buffer = ratatui::buffer::Buffer::empty(outer);
+        paint(&mut buffer, inner, theme, view, &[]);
+
+        let blank = ratatui::buffer::Cell::default();
+        for y in outer.top()..outer.bottom() {
+            for x in outer.left()..outer.right() {
+                let cell = &buffer[(x, y)];
+                if !inner.contains(ratatui::layout::Position::new(x, y)) {
+                    assert_eq!(
+                        cell, &blank,
+                        "{name}/{corpus} at {width}x{height} painted ({x}, {y}) outside {inner:?}"
+                    );
+                    continue;
+                }
+                let visible = strip_osc8(cell.symbol());
+                assert!(
+                    !visible.chars().any(char::is_control),
+                    "{name}/{corpus} at {width}x{height} put a control byte in a cell at ({x}, {y}): {:?}",
+                    cell.symbol()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn every_component_survives_every_corpus_at_every_size() {
+    let theme = Theme::default();
+    for (corpus, text) in CORPORA {
+        for_each_component(text, &mut |name, view| {
+            assert_well_behaved(name, corpus, view, &theme);
+        });
+    }
+}
+
+#[test]
+fn resolved_measurement_never_exceeds_the_space_offered() {
+    // `View::measure` reports an *intrinsic* size and may exceed the space it
+    // was offered; `measure_request` is what a layout container asks, and its
+    // answer is the one that must fit — a container hands out the rect it gets
+    // back. A component overriding `measure_request` (the width-sensitive ones
+    // do) can break that clamp, and a parent then allocates a rect the child
+    // paints past.
+    let theme = Theme::default();
+    let ctx = RenderCtx::new(&theme);
+    for (corpus, text) in CORPORA {
+        for_each_component(text, &mut |name, view| {
+            for &(width, height) in SIZES {
+                let request = MeasureRequest::new(Size::new(width, height));
+                let measured = view.measure_request(request, &ctx);
+                assert!(
+                    measured.width <= width && measured.height <= height,
+                    "{name}/{corpus} resolved to {measured:?} inside {width}x{height}"
+                );
+                // The unconstrained ask must not panic or report nonsense
+                // either: this is the max-content path that overflowed the wrap
+                // solver's column counter.
+                let unconstrained = request
+                    .with_available_width(AvailableSpace::MaxContent)
+                    .with_available_height(AvailableSpace::MaxContent);
+                let _ = view.measure_request(unconstrained, &ctx);
+                let min = request
+                    .with_available_width(AvailableSpace::MinContent)
+                    .with_available_height(AvailableSpace::MinContent);
+                let _ = view.measure_request(min, &ctx);
+            }
+        });
+    }
+}
+
+#[test]
+fn rendering_is_deterministic_across_themes_and_sheets() {
+    // Painting the same view twice must produce identical cells: a component
+    // that carries hidden per-render state (a cursor blink, an interior mutable
+    // cache keyed on the wrong thing) shows up here rather than as a flicker.
+    for named in themes::PRESETS {
+        for (corpus, text) in CORPORA.iter().take(4) {
+            for_each_component(text, &mut |name, view| {
+                for &(width, height) in &[(0u16, 0u16), (7, 3), (40, 12)] {
+                    let first = tuika::testing::render(view, width, height, &named.theme);
+                    let second = tuika::testing::render(view, width, height, &named.theme);
+                    assert_eq!(
+                        first, second,
+                        "{name}/{corpus} rendered differently on the second paint \
+                         under theme {} at {width}x{height}",
+                        named.name
+                    );
+                }
+            });
+        }
+    }
+}
+
+/// A tiny deterministic PRNG, so a "fuzzed" sequence is reproducible from its
+/// seed and a CI failure can be replayed exactly.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        // xorshift64*
+        self.0 ^= self.0 >> 12;
+        self.0 ^= self.0 << 25;
+        self.0 ^= self.0 >> 27;
+        self.0.wrapping_mul(0x2545_f491_4f6c_dd1d)
+    }
+
+    fn below(&mut self, n: u64) -> u64 {
+        self.next() % n.max(1)
+    }
+}
+
+/// The event stream a storm sends: the navigation keys and wheel actions that
+/// move persistent state, plus resizes.
+fn storm_event(rng: &mut Rng) -> Signal {
+    let codes = [
+        KeyCode::Up,
+        KeyCode::Down,
+        KeyCode::Left,
+        KeyCode::Right,
+        KeyCode::PageUp,
+        KeyCode::PageDown,
+        KeyCode::Home,
+        KeyCode::End,
+        KeyCode::Enter,
+        KeyCode::Esc,
+        KeyCode::Tab,
+        KeyCode::Backspace,
+        KeyCode::Char('x'),
+        KeyCode::Char('界'),
+    ];
+    match rng.below(4) {
+        0 => Signal::Event(Event::Mouse(Mouse::at(
+            if rng.below(2) == 0 {
+                MouseKind::ScrollDown
+            } else {
+                MouseKind::ScrollUp
+            },
+            rng.below(40) as u16,
+            rng.below(20) as u16,
+        ))),
+        1 => Signal::Event(Event::Resize {
+            width: rng.below(60) as u16,
+            height: rng.below(20) as u16,
+        }),
+        2 => Signal::Tick,
+        _ => Signal::Event(Event::Key(Key::new(
+            codes[rng.below(codes.len() as u64) as usize],
+        ))),
+    }
+}
+
+#[test]
+fn a_shrinking_list_under_a_scrolling_user_still_renders() {
+    // The combination that produces most host crash reports: persistent
+    // selection and scroll state built against one collection, then rendered
+    // against a shorter one — a filter applied, a stream that dropped rows, a
+    // refresh mid-scroll. tuika keeps the stale index deliberately (the host
+    // reconciles with `clamp`), so the *views* must survive being handed one.
+    let theme = Theme::default();
+    let mut rng = Rng(0x5eed_1234_9abc_def0);
+    let mut select = SelectState::new();
+    let mut scroll = ScrollState::new();
+
+    for step in 0..600u32 {
+        let len = (rng.below(9)) as usize;
+        let viewport = rng.below(8) as usize;
+        let event = storm_event(&mut rng);
+        if let Signal::Event(event) = &event {
+            let _ = select.handle(event, len);
+            let _ = scroll.handle(event, len, viewport);
+        }
+
+        // Rendered against a collection that may have shrunk since the event.
+        let shorter = (rng.below(len as u64 + 1)) as usize;
+        let rows: Vec<Line<'static>> = (0..shorter)
+            .map(|i| Line::from(format!("row {i} 日本語 👩‍👩‍👦")))
+            .collect();
+        let (width, height) = (rng.below(30) as u16, rng.below(10) as u16);
+        let _ = tuika::testing::render(
+            &SelectList::new(rows.clone(), &select),
+            width,
+            height,
+            &theme,
+        );
+        let _ = tuika::testing::render(&Scroll::new(rows, &scroll), width, height, &theme);
+        assert!(step < 600);
+    }
+}
+
+#[test]
+fn an_application_survives_a_resize_and_input_storm() {
+    // The public runtime path, end to end: a real `Application` fed a long
+    // pseudo-random stream of resizes, keys, wheel events, and ticks. Every
+    // frame it produces must match the viewport it was asked for — a component
+    // that panics or paints a differently-sized buffer under a zero-column
+    // screen fails here rather than in a user's terminal.
+    struct App {
+        select: SelectState,
+        scroll: ScrollState,
+        input: TextInputState,
+        rows: usize,
+    }
+
+    impl Application for App {
+        fn update(&mut self, signal: Signal) -> UpdateResult {
+            let Signal::Event(event) = signal else {
+                return UpdateResult::Dirty;
+            };
+            let _ = self.select.handle(&event, self.rows);
+            let _ = self.scroll.handle(&event, self.rows, 8);
+            let _ = self.input.handle(&event);
+            UpdateResult::Dirty
+        }
+
+        fn view(&self, frame: u64) -> Element {
+            let rows: Vec<Line<'static>> = (0..self.rows)
+                .map(|i| Line::from(format!("row {i}")))
+                .collect();
+            element(
+                Flex::column()
+                    .gap(1)
+                    .fixed(1, element(Text::raw(format!("frame {frame}"))))
+                    .grow(1, element(SelectList::new(rows, &self.select)))
+                    .fixed(3, element(TextInput::new(&self.input))),
+            )
+        }
+    }
+
+    let mut rng = Rng(0x1234_5678_9abc_def0);
+    let mut harness = tuika::testing::TestHarness::new(
+        App {
+            select: SelectState::new(),
+            scroll: ScrollState::new(),
+            input: TextInputState::from_text("seed 日本語"),
+            rows: 5,
+        },
+        40,
+        12,
+    );
+
+    let mut size = (40u16, 12u16);
+    for _ in 0..800 {
+        let signal = storm_event(&mut rng);
+        if let Signal::Event(Event::Resize { width, height }) = signal {
+            size = (width, height);
+        }
+        harness.state_mut().rows = rng.below(12) as usize;
+        if let (_, Some(frame)) = harness.step_app(signal) {
+            assert_eq!(
+                frame.area,
+                Rect::new(0, 0, size.0, size.1),
+                "a frame was painted at the wrong size"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Two new test suites aimed at the class of defect that reaches a user as a crash
or a rendering artifact rather than a wrong pixel, plus fixes for the three bugs
they found.

**`src/tests/fuzz.rs`** — five families of randomized test:

- **Text** — adversarial graphemes (wide CJK, ZWJ emoji, combining marks,
  zero-width and C0 characters, whitespace runs) through the wrap solver and the
  prose components at every width including `0` and `u16::MAX`, asserting
  content preservation, char-boundary source ranges, row widths, and that
  wrapping is a fixed point.
- **Event streams** — arbitrary key/mouse/paste sequences into the stateful
  components, asserting persistent state stays inside the bounds the caller
  declared, and that the documented `clamp` reconcile restores it when a
  collection shrinks under the state.
- **Streaming markdown** — a differential against the one-shot render over
  generated documents, chunk sizes, and widths.
- **Composed trees and overlays** — fuzzed nested flex/box/clamp trees and
  scenes, rendered into an inset rect of a larger buffer so a write past the
  rect lands on a margin the test owns.
- **Parsers on untrusted bytes** — terminal palette and device-attribute
  replies, bare-URL detection, QR payloads, image buffers.

**`tests/robustness.rs`** — a black-box sweep through the published API only:
every component × 11 adversarial corpora × 16 degenerate sizes, asserting no
panic, no paint outside the component's own rect, and no control byte in a cell
(OSC 8 wrappers stripped first, since an escape *there* is the feature). Plus
resolved-measurement bounds, render determinism across every preset theme, a
shrinking-list-under-a-scrolling-user storm, and an 800-event resize/input storm
through a real `Application`.

**Fixes, each with a focused regression test beside the code:**

1. **OSC 8 markers no longer land outside a component's rect.** `Paragraph` and
   `Markdown` embed link runs into cells after painting, and the placement was
   clipped to the *buffer* rather than the area the component was laid out in —
   so a markdown block whose links ran past its rows or columns stamped an
   escape onto a neighbour's cell.
2. **A fence line with an info string no longer closes an open fence** in the
   streaming boundary scan. `` ```rust `` inside an already-open block is code
   content, so treating it as a closer settled a cached boundary *inside* a code
   block, and everything after it rendered as markdown while a re-render of the
   same source rendered it as code.
3. **A blank line between list items no longer settles the streaming prefix.** A
   list continues across a blank line, so settling there parsed the rest in
   isolation and restarted the numbering. The blank becomes a boundary only once
   a following top-level block proves the list ended — and never on the strength
   of an in-flight partial line, since `1` is not yet the marker `1.` the next
   delta makes it.

`.github/workflows/nightly-fuzz.yml` re-runs the fuzz, property, and black-box
suites at 20k cases nightly and uploads any new regression seed, because the
default PR case count replays known counterexamples but does not find new ones.

## Why

The wrap solver had a reachable panic at `AvailableSpace::MaxContent` — untrusted
prose long enough to overflow a `u16` column counter. That is a class, not an
incident: components take text a host pasted and geometry a user dragged to one
column, and the only way to find the rest of the class is to generate the inputs.

Both markdown bugs are the reason the differential matters more than any number
of "does not panic" assertions: each depended on *where the stream's chunk
boundaries fell*, so a streamed transcript and a re-render of the same source
disagreed, and no example-based test could see it.

## Before / After

Both counterexamples are committed as proptest regression seeds, so they
reproduce on the parent commit immediately. Running the new suites against
`origin/main`:

```
$ cargo test --lib fuzz::streaming_markdown          # on origin/main
  left: `["1. item", "", "1. item"]`,
 right: `["1. item", "2. item"]`: streamed render diverged from one-shot
minimal failing input: source = "1. item\n\n1. item\n", chunk = 1, width = 8
test result: FAILED. 0 passed; 1 failed

$ cargo test --test robustness every_component       # on origin/main
assertion `left == right` failed:
  markdown/url at 24x3 painted (2, 5) outside Rect { x: 2, y: 2, width: 24, height: 3 }
test result: FAILED. 0 passed; 1 failed
```

After, on this branch — full workspace, all features:

```
$ cargo test --workspace --all-features
26 test binaries, all "test result: ok" (0 failed)

$ PROPTEST_CASES=8000 cargo test --lib -- tests::fuzz tests::proptests
test result: ok. 33 passed; 0 failed; finished in 682.88s
```

Links still embed where they belong — the clipping fix drops only placements
outside the rect (`cargo run --example demo -- markdown_table --dump`, escapes
visible because a dump prints cell symbols verbatim):

```
│ Markdown  │ ✅  stable │  ]8;;https://docs.rs/tuika\docs.rs]8;;\ │
```

Streaming list numbering, which is what fix 3 restores:

```
$ cargo test --lib streaming_a_list_across_a_blank_line_keeps_its_numbering
test ... ok      # streamed "1. 2. 3." now equals the one-shot render
```

## Risk

- **Low / Medium.** The test suites cannot affect consumers. The two markdown
  boundary rules change *when* the streaming cache settles, which is the one
  behavior a host sees indirectly: it settles slightly later inside an open
  fence or an open list, so a long streamed list re-parses its own tail until
  the list ends. That is the same cost an unterminated fence already had, and it
  buys agreement with the one-shot render.
- The hyperlink fix drops link placements outside the component's area. A caller
  that (accidentally) relied on a marker landing outside its rect loses it; the
  `apply_buffer_links` entry point is unchanged and still clips to the buffer.

**Instruction counts.** The iai baseline is re-blessed in its own commit, and the
shift was isolated the way `knowledge/processes/testing.md` prescribes — by
measuring `origin/main` on the same toolchain:

| bench | on `origin/main` | this branch | reading |
| --- | --- | --- | --- |
| `render.large` / `render.small` | +0.000% (exact) | +1.05% | codegen partitioning; measured path untouched |
| `frame_full` / `frame_windowed` | +0.000% (exact) | +0.01% / +1.02% | same |
| `streaming.mixed` | −0.41% | +2.2% vs that parent run | real work: a longer in-flight tail re-parses per delta |
| `reflow`, `paging`, `one_shot`, `highlight.*` | flat | flat | unaffected |

The streaming cost is the price of the streamed render matching the one-shot
render, and it is bounded by the open list's own length. The
`tuika-codeformatters` baseline is deliberately left untouched (its counts moved
0.005%, inside tolerance).

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

**API change:** additive only — `term::hyperlink::apply_buffer_links_in`, the
area-clipped counterpart to `apply_buffer_links`. Nothing removed, nothing
renamed, no signature changed. Declared in the changelog under **Added**.

## Knowledge

- `knowledge/processes/testing.md` — the fuzz and black-box sweep layers, why
  differential properties carry them, and how the nightly deep run relates to the
  per-PR default case count.
- `knowledge/specs/markdown.md` — the two constructs that decide whether a blank
  line is a stable block boundary, recorded as rules rather than intent.
- `knowledge/log.md` — the entry on what the panic hunt actually turned up.
- `AGENTS.md` and `CHANGELOG.md` kept in step.
- `python3 scripts/validate_okf.py knowledge --check-links` → 16 concepts, 0 errors.
- `cargo run --example demo -- check` → 42 scenes, recordings, and references in sync.

## Security

Reviewed against the repository threat model:

- **TM-ESC** — the change *narrows* escape emission: OSC 8 runs are now confined
  to the component's own area. Targets still go through `sanitize_url` and
  tuika's own encoder; no caller string reaches the terminal unencoded. The
  black-box sweep adds a standing assertion that no component puts a control
  byte in a cell outside a well-formed OSC 8 wrapper.
- **TM-PARSE** — directly strengthened. New properties drive the markdown
  parser, wrap solver, bare-URL detection, QR encoder, image constructor, and the
  terminal palette / device-attribute parsers with arbitrary bytes, asserting
  they degrade rather than panic, index out of bounds, or slice off a char
  boundary.
- **TM-CLIP** — the fixed bug was a clipping bug; the sweep now asserts
  every component paints only inside its rect at every degenerate size, and the
  clip check in `apply_buffer_links_in` bounds both axes in both directions so an
  area starting outside the buffer cannot index a cell that does not exist.
- **TM-STATE** — untouched; no enter/restore pair changed.
- **TM-DEP** — no new dependency. `proptest` was already a dev-dependency.

## Follow-ups

- The `Grid`, `KeyedTable`, `TreeList` mouse hit-testing paths and the keymap
  dispatcher are not yet fuzzed; the sweep covers their rendering only. Deferred
  because hit-testing needs a rendered-geometry oracle to assert against, which
  is a design question rather than more of the same test.
- `MarkdownState` settles later inside a long streamed list, so such a list
  re-parses its tail per delta — the `streaming.mixed` cost above. Correct, and
  bounded by the list's own length, but a future boundary that can settle
  *within* a list would remove it. Not attempted here: it needs the parser to
  expose list continuation, and the differential in this PR is what would keep it
  honest.