### PR TITLE
refactor(deps)!: own the cell grid and drop ratatui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,92 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **tuika no longer depends on ratatui.** It now owns its own `Rect`/`Position`,
+  `Color`/`Modifier`/`Style`, `Line`/`Span`, `Buffer`/`Cell`, `Backend`, and
+  `Terminal`. Every one of those types moved from `ratatui-core` to tuika, so
+  any signature naming one changes.
+
+  For most hosts the migration is an import change — the canonical path is
+  unchanged:
+
+  ```rust
+  // before
+  use ratatui_core::layout::Rect;
+  use ratatui_core::style::{Color, Modifier, Style};
+  use ratatui_core::text::{Line, Span};
+
+  // after (or just `use tuika::prelude::*;`)
+  use tuika::ui::{Color, Line, Modifier, Rect, Span, Style};
+  ```
+
+  A host driving its own terminal takes `tuika::term::terminal::{Terminal,
+  TerminalOptions, Viewport}` and `tuika::term::backend::CrosstermBackend`
+  instead of ratatui's, and `tuika::term::testbackend::TestBackend` in tests.
+
+  The types are deliberately shaped like the ones they replace, with two
+  behavioral notes:
+  - `Span::width` and `Line::width` count grapheme-aware display columns
+    (`width::str_cols`) rather than per-`char` widths, so they now agree with
+    what `Surface` actually paints. A line containing a ZWJ emoji measures
+    narrower than before — and correctly.
+  - `Cell` stores short grapheme clusters inline instead of in a
+    `CompactString`. `Cell::new` is no longer `const`; use `Cell::default()`
+    for a blank cell.
+
+- **Ratatui interoperability is now behind the `ratatui` feature**, off by
+  default. `Surface::render_ratatui`, `tuika::interop`, and `RatatuiView` need
+  it; a host wrapping ratatui widgets adds:
+
+  ```toml
+  tuika = { version = "0.12", features = ["ratatui"] }
+  ```
+
+  Every ratatui widget still works. The boundary is no longer a shared `Buffer`
+  — the two crates no longer share a cell type — but a cell-by-cell conversion
+  over the rendered area, which `render_ratatui` was already doing a copy for.
+
+- **`Surface::render_ratatui` was split.** The general escape hatch — a private
+  scratch buffer, composited back through the clip — is now
+  `Surface::render_scratch` and takes tuika's `Buffer`. `render_ratatui` is the
+  ratatui-specific wrapper around it. A caller using it for scratch access
+  rather than for ratatui widgets should switch to `render_scratch`, which needs
+  no feature.
+
+- **`Line::raw` and `Line::styled` split their content on line breaks**, one
+  span per line, matching what they replaced. `Line::raw("")` therefore yields a
+  line with no spans.
+
+### Added
+
+- `Surface::render_scratch` — clipped scratch-buffer access without ratatui.
+- `Buffer::set_style`, `Buffer::content()`, `Cell::raw_symbol()` (tells a wide
+  grapheme's placeholder apart from a blank cell).
+- `framebuffer::QUADRANTS` — the sixteen quadrant block glyphs, previously
+  reached through `ratatui_core::symbols::pixel`.
+- `Style::{bold, dim, italic, underlined, reversed, crossed_out}` shorthands.
+- `tuika::term::backend::CrosstermBackend` and
+  `tuika::term::testbackend::TestBackend` are public, for a host driving
+  `Terminal` itself.
+
+### Changed
+
+- **Dependencies: 55 crates to 32.** Dropping `ratatui-core` removed 23,
+  including `kasuari` (a Cassowary solver), `lru`, and a second `hashbrown` —
+  all of which existed for `ratatui_core::layout::Layout`, which tuika replaced
+  with its own flex solver and never called — plus `strum`, `compact_str`,
+  `itertools`, `unicode-truncate`, and a second `syn` major version. The cold
+  dependency build drops from roughly 32s to 6s.
+- **Rendering is ~7% cheaper.** `render`, `frame_windowed`, and the scroll paths
+  fall 7.3–7.4% in instruction count, because a `Cell` now stores short
+  grapheme clusters inline. The markdown paths rise ~2%, the cost of measuring
+  widths grapheme-aware; the benchmark baseline is updated accordingly.
+- `scrolling-regions` is now a feature of tuika's own `Backend` trait, and no
+  longer pulls in `ratatui-crossterm` to forward a flag.
+
 ## [0.11.1] - 2026-08-25
 
 `tuika` only. The companion crates carry a caret requirement on tuika 0.11, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,7 +2296,6 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "ratatui-core",
- "ratatui-crossterm",
  "tokio",
  "tokio-stream",
  "tuika-charts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
-description = "The application framework for Rust terminal UIs — flexbox layout, overlays, focus, keymap, components, and safe ratatui interoperability."
+description = "The application framework for Rust terminal UIs — flexbox layout, overlays, focus, keymap, components, and a dependency-light cell renderer."
 homepage.workspace = true
 documentation = "https://docs.rs/tuika"
 repository.workspace = true
@@ -101,12 +101,11 @@ bench = false
 # `StreamExt` for polling the event stream, and crossterm's async `EventStream`.
 async = ["dep:tokio", "dep:futures-core", "crossterm/event-stream"]
 
-# Mirror of ratatui's `scrolling-regions`, which changes how content is inserted
-# above an inline viewport: DECSTBM region scrolling instead of the portable
-# scroll-and-repaint. Cargo unifies features one way only, so a host that turns
-# the ratatui feature on would otherwise fail to build tuika — `HyperlinkBackend`
-# implements `Backend`, and the feature adds two required methods. Declaring it
-# here is what lets that impl be gated (see `src/term/hyperlink.rs`).
+# Adds DECSTBM region scrolling to `Backend` as an alternative to the portable
+# scroll-and-repaint when inserting content above an inline viewport. Now a
+# feature of tuika's *own* `Backend` trait (see `term/traits.rs`), so it adds two
+# required methods to any host implementation — which is the whole reason it is a
+# feature rather than always-on.
 #
 # It is NOT an optimization to reach for under `ScreenMode::SplitFooter`: rows
 # scrolled out of a DECSTBM region are discarded by the terminal instead of
@@ -114,36 +113,20 @@ async = ["dep:tokio", "dep:futures-core", "crossterm/event-stream"]
 # published output *becomes* scrollback. The portable path costs a viewport
 # repaint per published block and keeps it; the `codex` PTY tests pin the
 # difference. See `knowledge/specs/screen-modes.md`.
-# Turning this on flips a `ratatui-core` feature that adds two required methods
-# to `Backend`. Cargo unifies features one way only, so any *other*
-# `ratatui-crossterm` in the graph — a host's own `ratatui`, most likely — would
-# then fail to compile its `CrosstermBackend` unless its matching feature is on
-# too. tuika no longer depends on that crate (see `term/backend.rs`), so the
-# optional dep below exists purely to forward the flag and keep the graph
-# consistent; it is absent from every build that leaves this feature off.
-scrolling-regions = [
-    "ratatui-core/scrolling-regions",
-    "dep:ratatui-crossterm",
-    "ratatui-crossterm/scrolling-regions",
-]
+
+ratatui = ["dep:ratatui-core"]
+
+scrolling-regions = []
 
 [dependencies]
-# tuika uses only ratatui's cell buffer, style/text/layout primitives, the
-# `Widget`/`StatefulWidget` traits, and the `Terminal`/backend loop — all of
-# which live in `ratatui-core`. It renders none of ratatui's own widgets, so it
-# depends on the sub-crates directly instead of the `ratatui` umbrella. This
-# drops `ratatui-widgets` (Block/Paragraph/Table/Calendar/…) and `ratatui-macros`
-# — and with them the `time`/`lru`/`line-clipping` transitive weight — from
-# tuika's build. Downstream users keep every ratatui widget: they bring their own
-# `ratatui` and render it through `Surface::render_ratatui`/`RatatuiView`, whose
-# boundary is a raw `&mut Buffer` from this same `ratatui-core` (Cargo unifies the
-# version). `underline-color` matches the umbrella default so cell rendering is
-# byte-identical; `std` is required for the terminal I/O loop.
-ratatui-core = { version = "0.1", features = ["std", "underline-color"] }
+# Only for the optional `ratatui` interop feature — tuika owns its own cell
+# grid, layout primitives, backend, and terminal loop, so nothing here is on the
+# default path. See the `ratatui` feature below.
+ratatui-core = { version = "0.1", features = [
+    "std",
+    "underline-color",
+], optional = true }
 crossterm = "0.29"
-# Not used in any code path: pulled in only by `scrolling-regions`, to forward
-# that feature. See the feature's comment above.
-ratatui-crossterm = { version = "0.1", optional = true }
 # Async runner only (feature = "async"). `time` for the tick interval, `macros`
 # for `tokio::select!`; the host application brings its own runtime, so no `rt`.
 tokio = { version = "1", features = ["time", "macros"], optional = true }
@@ -226,3 +209,8 @@ harness = false
 [[example]]
 name = "async_dashboard"
 required-features = ["async"]
+
+# Demonstrates wrapping real ratatui widgets, so it needs the interop feature.
+[[example]]
+name = "ratatui_dashboard"
+required-features = ["ratatui"]

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@
 
 </details>
 
-`ratatui` gives you a cell buffer and widgets to draw into it; everything above
-that — layout, overlays, focus, input, the terminal lifecycle — has been left to
-each application to build for itself. tuika is that missing layer, and wants to
-be the standing answer to "what do I build a Rust TUI *application* on?": start
-with `cargo add tuika`, describe your screen, and get a real app instead of a
-render loop.
+Rust has excellent terminal *rendering*. What it has mostly left to each
+application is everything above that — layout, overlays, focus, input, the
+terminal lifecycle. tuika is that missing layer, and wants to be the standing
+answer to "what do I build a Rust TUI *application* on?": start with
+`cargo add tuika`, describe your screen, and get a real app instead of a render
+loop.
 
 You write views; tuika owns the rest:
 
@@ -81,29 +81,29 @@ You write views; tuika owns the rest:
   [charts](https://github.com/everruns/tuika/blob/v0.11.1/docs/charts.md), mermaid diagrams,
   [mouse selection and clipboard](#mouse-selection-and-clipboard), and
   [native OSC 9;4 progress](#native-terminal-progress).
-- **No lock-in** — it is additive to ratatui, not a replacement: wrap any
-  ratatui widget in [`RatatuiView`](#ratatui-interoperability) and it composes
-  like a built-in, and your own types implement the same `View` trait the
+- **No lock-in** — already have ratatui widgets? Turn on the `ratatui` feature,
+  wrap any of them in [`RatatuiView`](#ratatui-interoperability), and they
+  compose like built-ins. Your own types implement the same `View` trait the
   built-ins do (see [Extending](#extending)).
 - **Boring where it counts** — no reconciler, no retained tree, no runtime, no
-  macro DSL you are forced into. Views are rebuilt each frame and `ratatui`
-  diffs the buffer. Rendering is deterministic, so
+  macro DSL you are forced into. Views are rebuilt each frame and tuika diffs the
+  cell buffer. Rendering is deterministic, so
   [UI is unit-tested](#testing-your-ui) against an in-memory buffer with no
   terminal at all.
 - **Small enough to adopt without a second thought** — a self-contained crate
-  depending only on `ratatui-core`, `crossterm`, `unicode-segmentation`,
-  `unicode-width`, and `pulldown-cmark`. Anything heavy — grammars, diagram
-  layout, image decoding — lives behind a trait in a companion crate or your
-  host.
+  depending only on `crossterm`, `unicode-segmentation`, `unicode-width`, and
+  `pulldown-cmark`: 32 crates in the default graph, of which `crossterm` is 27.
+  Anything heavy — grammars, diagram layout, image decoding — lives behind a
+  trait in a companion crate or your host.
 
 It is host-agnostic: it knows nothing about the application embedding it, and no
-type, feature, or default exists to serve one host. tuika renders none of
-ratatui's own widgets, so it builds against `ratatui-core` directly rather than
-the `ratatui` umbrella — keeping `ratatui-widgets`, `ratatui-macros`, and their
-transitive weight out of its dependency tree. Your application still uses any
-ratatui widget it likes (see [Compatibility](#compatibility)). (The optional
-`async` feature adds Tokio for [`AsyncRunner`](#screen-modes-lifecycle-and-runner);
-it is off by default.)
+type, feature, or default exists to serve one host. tuika owns its stack down to
+the escape sequences — cell grid, backend, and terminal loop included — and has
+no runtime dependency on ratatui. That is a statement about dependencies, not a
+rivalry: ratatui is why a Rust TUI ecosystem exists, and every widget written for
+it still composes here through the optional `ratatui` feature (see
+[Compatibility](#compatibility)). (The optional `async` feature adds Tokio for
+[`AsyncRunner`](#screen-modes-lifecycle-and-runner); it is off by default.)
 
 See what that buys in practice: the [showcases](https://github.com/everruns/tuika/blob/v0.11.1/docs/showcases.md) are
 recordings of real applications running on tuika (also listed under
@@ -116,17 +116,25 @@ coding-agent UI built with nothing else.
 cargo add tuika
 ```
 
-`ratatui` and `crossterm` are part of `tuika`'s public interoperability
-surface, so add `ratatui` to your own crate and pin a compatible minor version.
-tuika depends on `ratatui-core`, which the `ratatui` umbrella re-exports, so
-Cargo unifies the shared `Buffer`/`Rect`/`Style` types and your widgets compose
-with tuika's surfaces (see [Compatibility](#compatibility)).
+That is the whole install for most applications — `Rect`, `Color`, `Style`,
+`Line`, `Span`, and the rest come from `tuika::ui` (or the prelude).
+
+To render existing **ratatui widgets** inside tuika, turn the feature on and add
+`ratatui` to your own crate:
+
+```toml
+tuika = { version = "0.12", features = ["ratatui"] }
+ratatui = "0.30"
+```
+
+See [Compatibility](#compatibility). `crossterm` remains part of tuika's public
+surface for terminal events either way.
 
 ## Model
 
 - **Views** (`view::View`) are rebuilt from application state every frame. This
-  is cheap because `ratatui` diffs the resulting cell buffer, so there is no
-  reconciler.
+  is cheap because tuika diffs the resulting cell buffer against the last one, so
+  there is no reconciler.
 - **State** that must survive across frames — scroll offset, selection index,
   focus, dock visibility — lives in host-persisted `*State` structs (the
   `StatefulWidget` idiom), not in the view tree.
@@ -307,7 +315,7 @@ let scene = Scene::new(root).overlay(
 );
 ```
 
-Custom views can import `Rect`, `Color`, `Style`, `Modifier`, `Line`, and `Span` from `tuika::ui` or the prelude without adding `ratatui-core` directly.
+Custom views import `Rect`, `Color`, `Style`, `Modifier`, `Line`, and `Span` from `tuika::ui` or the prelude — these are tuika's own types, so a view takes no rendering dependency beyond tuika itself.
 
 `Element` is an owned, boxed view. `ScopedElement<'_>` is its frame-borrowed
 counterpart: `element(view)` chooses the lifetime from `view`, and containers
@@ -609,9 +617,14 @@ all-owned tree to `Element`. Use `RatatuiView` for Ratatui widgets. The
 
 ## Ratatui interoperability
 
-Tuika deliberately does not duplicate Ratatui's widget catalog. Wrap existing
-widgets in `RatatuiView`; they render into an isolated buffer and only the
-assigned clip is composited into the frame:
+Tuika deliberately does not duplicate Ratatui's widget catalog. Enable the
+`ratatui` feature and wrap existing widgets in `RatatuiView`; they render into an
+isolated buffer and only the assigned clip is composited into the frame:
+
+```toml
+tuika = { version = "0.12", features = ["ratatui"] }
+ratatui = "0.30"
+```
 
 ```rust
 use ratatui::widgets::{Sparkline, Widget};
@@ -628,6 +641,12 @@ can capture host-owned synchronized state and call `StatefulWidget::render`
 inside the same closure. `Surface::render_ratatui` is the lower-level escape
 hatch for custom views that need several widgets. Neither API exposes the
 frame's mutable buffer.
+
+Because Tuika owns its own cell type, the boundary is a conversion over the
+rendered area rather than a shared buffer — so Tuika and Ratatui version
+independently, and a widget costs one cell copy in and out of the area it
+actually draws. A view that only needs a private scratch buffer, with no Ratatui
+involved, should use `Surface::render_scratch`, which needs no feature.
 
 ## Responsive and live views
 
@@ -897,7 +916,7 @@ Hosts with their own loop use the `mouse` module to build the same affordances:
 - **Text selection.** `SelectionState` turns a left-button `Down → Drag → Up`
   gesture into a `SelectionRange` (a plain click selects nothing; a new press
   clears the old selection). `selected_text(buffer, area, range)` reads the text
-  back out of the rendered `ratatui::Buffer` — linear/stream selection like a
+  back out of the rendered `Buffer` — linear/stream selection like a
   terminal's own, wide glyphs intact — and `mouse::paint_selection(buffer, area, range,
   style)` paints it in. A same-cell double click selects a word;
   `handle_with_clock` accepts a virtual monotonic `Clock`, while `handle` uses
@@ -933,7 +952,7 @@ path — there is no separate touch event to handle.
 
 Rendering is deterministic, so UI built on tuika can be tested without a real
 terminal or `TestBackend` setup. The [`testing`](https://docs.rs/tuika/latest/tuika/testing/index.html)
-module draws a `View` into an in-memory ratatui `Buffer` and reads it back:
+module draws a `View` into an in-memory `Buffer` and reads it back:
 
 - `render(view, width, height, &theme) -> Buffer` — draw once at a fixed size.
 - `render_with_sheet(view, width, height, &theme, sheet) -> Buffer` — the same
@@ -975,15 +994,16 @@ something on tuika? Open a PR adding it here.
   checked in CI.
 - Tuika 0.x follows Cargo semver: minor releases may make deliberate breaking
   API changes; patch releases do not.
-- Ratatui and Crossterm are part of Tuika's public interoperability surface.
-  Tuika builds against `ratatui-core` directly, not the `ratatui` umbrella; the umbrella re-exports that same `ratatui-core`, so a
-  matching `ratatui` minor line in your application resolves to one shared
-  `ratatui-core` and Cargo deduplicates the core types. Widgets such as
-  `Block`/`Paragraph`/`Table` live in `ratatui-widgets` (pulled in by your
-  `ratatui` dependency, not by tuika) and compose through
-  [`Surface::render_ratatui`](https://docs.rs/tuika/latest/tuika/surface/struct.Surface.html#method.render_ratatui)
-  and [`RatatuiView`](https://docs.rs/tuika/latest/tuika/interop/struct.RatatuiView.html),
-  whose boundary is a raw `ratatui-core` `Buffer`.
+- Crossterm is part of Tuika's public surface, for terminal events.
+- Ratatui is **not** a dependency of Tuika. Its widgets remain usable through the
+  optional `ratatui` feature: enable it, add `ratatui` to your own crate, and
+  wrap widgets in
+  [`RatatuiView`](https://docs.rs/tuika/latest/tuika/interop/struct.RatatuiView.html)
+  or
+  [`Surface::render_ratatui`](https://docs.rs/tuika/latest/tuika/surface/struct.Surface.html#method.render_ratatui).
+  The boundary is a cell-by-cell conversion over the rendered area rather than a
+  shared buffer, so the two crates' versions are independent — a `ratatui` major
+  bump is no longer a Tuika breaking change.
 
 ## Extending
 
@@ -994,8 +1014,9 @@ the built-ins get that yours don't:
   on your own type and splice it anywhere with `node(your_view)`, or hand it to
   any container — they accept any `impl View`. The built-in components are on
   equal footing with yours; nothing special-cases them.
-- **Existing Ratatui widgets.** Wrap one in `RatatuiView` rather than
-  reimplementing it — see [Ratatui interoperability](#ratatui-interoperability).
+- **Existing Ratatui widgets.** Enable the `ratatui` feature and wrap one in
+  `RatatuiView` rather than reimplementing it — see
+  [Ratatui interoperability](#ratatui-interoperability).
 
 The [`view!`](#declarative-dsl-view) DSL reaches your components through the same
 `node(...)` escape hatch, so they compose exactly like the built-ins.

--- a/benches/iai-baseline.json
+++ b/benches/iai-baseline.json
@@ -2,14 +2,14 @@
   "_comment": "iai-callgrind instruction-count baseline. Deterministic and machine-independent for a fixed toolchain + libc. Regenerate with `python3 benches/check_iai.py --update` and commit alongside the code change that shifted the counts.",
   "tolerance_pct": 2.0,
   "benchmarks": {
-    "frame_full.large": 81465395,
-    "frame_windowed.large": 880853,
-    "one_shot.large": 6455060,
-    "one_shot.small": 267089,
+    "frame_full.large": 80908588,
+    "frame_windowed.large": 823903,
+    "one_shot.large": 6594912,
+    "one_shot.small": 272920,
     "paging.large": 252164,
-    "reflow.mixed": 12383908,
-    "render.large": 861336,
-    "render.small": 861270,
-    "streaming.mixed": 12885320
+    "reflow.mixed": 12645267,
+    "render.large": 804531,
+    "render.small": 804465,
+    "streaming.mixed": 13118258
   }
 }

--- a/benches/layout.rs
+++ b/benches/layout.rs
@@ -5,7 +5,7 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use ratatui_core::layout::Rect;
+use tuika::ui::Rect;
 use tuika::{
     AlignContent, Dimension, FlexItemStyle, FlexWrap, Item, LayoutStyle, Size, solve_layout,
 };

--- a/benches/scroll.rs
+++ b/benches/scroll.rs
@@ -30,11 +30,11 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
-use ratatui::text::{Line, Span};
 use tuika::components::{Scroll, ScrollState};
+use tuika::ui::Buffer;
+use tuika::ui::Rect;
+use tuika::ui::{Color, Style};
+use tuika::ui::{Line, Span};
 use tuika::{Event, Key, KeyCode, RenderCtx, Surface, Theme, View};
 
 /// Fixed viewport the render benches paint into — a typical terminal transcript

--- a/benches/scroll_iai.rs
+++ b/benches/scroll_iai.rs
@@ -21,11 +21,11 @@
 use std::hint::black_box;
 
 use iai_callgrind::{library_benchmark, library_benchmark_group, main};
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::{Color, Style};
-use ratatui::text::{Line, Span};
 use tuika::components::{Scroll, ScrollState};
+use tuika::ui::Buffer;
+use tuika::ui::Rect;
+use tuika::ui::{Color, Style};
+use tuika::ui::{Line, Span};
 use tuika::{Event, Key, KeyCode, RenderCtx, Surface, Theme, View};
 
 const WIDTH: u16 = 80;

--- a/crates/tuika-charts/benches/render.rs
+++ b/crates/tuika-charts/benches/render.rs
@@ -5,9 +5,9 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
 use tuika::term::image::{ImageLayer, ImageSupport};
+use tuika::ui::Buffer;
+use tuika::ui::Rect;
 use tuika::{RenderCtx, Surface, Theme, View};
 use tuika_charts::{Chart, Point, Series};
 

--- a/crates/tuika-charts/src/axis.rs
+++ b/crates/tuika-charts/src/axis.rs
@@ -8,7 +8,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use ratatui_core::layout::Rect;
+use tuika::ui::Rect;
 use tuika::{RenderCtx, Surface};
 
 use crate::Chart;

--- a/crates/tuika-charts/src/cells.rs
+++ b/crates/tuika-charts/src/cells.rs
@@ -1,6 +1,6 @@
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::symbols::pixel::QUADRANTS;
+use tuika::framebuffer::QUADRANTS;
+use tuika::ui::Rect;
+use tuika::ui::Style;
 use tuika::{RenderCtx, Surface};
 
 use crate::axis::AxisLayout;

--- a/crates/tuika-charts/src/graphics.rs
+++ b/crates/tuika-charts/src/graphics.rs
@@ -1,6 +1,6 @@
-use ratatui_core::style::Color;
 use tuika::RenderCtx;
 use tuika::term::image::ImageData;
+use tuika::ui::Color;
 
 use crate::axis::AxisLayout;
 use crate::plan::{ChartPlan, Geometry};

--- a/crates/tuika-charts/src/lib.rs
+++ b/crates/tuika-charts/src/lib.rs
@@ -9,9 +9,9 @@
 //! [`tuika::term::image::ImageSupport`] and an
 //! [`tuika::term::image::ImageLayer`] through [`tuika::RenderCtx`].
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Style};
 use tuika::term::image::{ImageLayer, ImageSupport};
+use tuika::ui::Rect;
+use tuika::ui::{Color, Style};
 use tuika::{RenderCtx, Size, Surface, View};
 
 mod axis;
@@ -418,15 +418,15 @@ fn draw_line(mut from: (i32, i32), to: (i32, i32), mut draw: impl FnMut(i32, i32
 mod tests {
     use super::*;
     use crate::cells::{BrailleGrid, QuadrantGrid, draw_quadrant_band};
-    use ratatui_core::buffer::Buffer;
     use tuika::Theme;
+    use tuika::ui::Buffer;
 
     fn is_braille(ch: char) -> bool {
         ('\u{2801}'..='\u{28ff}').contains(&ch)
     }
 
     fn is_quadrant(ch: char) -> bool {
-        ratatui_core::symbols::pixel::QUADRANTS[1..].contains(&ch)
+        tuika::framebuffer::QUADRANTS[1..].contains(&ch)
     }
 
     pub(super) fn grid_of(buffer: &Buffer, area: Rect) -> String {
@@ -1019,7 +1019,7 @@ mod axis_tests {
         let (cells, area) = render_to(&chart, 36, 12);
 
         let layer = ImageLayer::new();
-        let mut graphics = ratatui_core::buffer::Buffer::empty(area);
+        let mut graphics = tuika::ui::Buffer::empty(area);
         chart.support(ImageSupport::Kitty).in_layer(&layer).render(
             area,
             &mut Surface::new(&mut graphics, area),
@@ -1163,7 +1163,7 @@ mod baseline_tests {
     #[test]
     fn bars_render_proportional_heights_from_the_baseline() {
         let area = Rect::new(0, 0, 30, 12);
-        let mut buffer = ratatui_core::buffer::Buffer::empty(area);
+        let mut buffer = tuika::ui::Buffer::empty(area);
         Chart::new()
             .legend(false)
             .series(Series::bar("bars", points([1.0, 2.0, 4.0])))

--- a/crates/tuika-charts/src/model.rs
+++ b/crates/tuika-charts/src/model.rs
@@ -1,4 +1,4 @@
-use ratatui_core::style::Color;
+use tuika::ui::Color;
 
 use crate::Chart;
 use crate::plan::Mark;

--- a/crates/tuika-charts/src/plan.rs
+++ b/crates/tuika-charts/src/plan.rs
@@ -7,8 +7,8 @@
 
 use std::collections::HashMap;
 
-use ratatui_core::style::Color;
 use tuika::RenderCtx;
+use tuika::ui::Color;
 
 use crate::model::{Domain, PlotModel, Point};
 use crate::{Chart, SeriesKind, chart_color};

--- a/crates/tuika-codeformatters/examples/languages.rs
+++ b/crates/tuika-codeformatters/examples/languages.rs
@@ -10,9 +10,9 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event;
-use ratatui::backend::CrosstermBackend;
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::backend::CrosstermBackend;
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::{Line, Span};
 
 use tuika::prelude::*;
 use tuika_codeformatters::TreeSitterHighlighter;

--- a/crates/tuika-codeformatters/src/lib.rs
+++ b/crates/tuika-codeformatters/src/lib.rs
@@ -42,11 +42,10 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Span;
 use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
 use tuika::Theme;
 use tuika::style::CodeTheme;
+use tuika::ui::{Modifier, Span, Style};
 
 /// Highlight capture names we recognize, longest-specific first so
 /// tree-sitter-highlight resolves the most precise style. Kept in sync with
@@ -387,7 +386,7 @@ mod tests {
     fn follows_the_host_theme() {
         // A different palette restyles the same token.
         let mut theme = Theme::default();
-        theme.code.keyword = ratatui::style::Color::Indexed(200);
+        theme.code.keyword = tuika::ui::Color::Indexed(200);
         let hl = TreeSitterHighlighter::new();
         let out = hl
             .highlight("rust", &["fn f() {}"], &theme)
@@ -396,7 +395,7 @@ mod tests {
             .iter()
             .find(|s| s.content.as_ref() == "fn")
             .expect("fn span");
-        assert_eq!(fn_span.style.fg, Some(ratatui::style::Color::Indexed(200)));
+        assert_eq!(fn_span.style.fg, Some(tuika::ui::Color::Indexed(200)));
     }
 
     // Aliases are per-grammar, so each assertion is gated on the feature that

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -34,9 +34,9 @@ impl View for Padded {
         available
     }
 
-    fn render(&self, area: ratatui_core::layout::Rect, surface: &mut Surface, ctx: &RenderCtx) {
+    fn render(&self, area: tuika::ui::Rect, surface: &mut Surface, ctx: &RenderCtx) {
         let html = HtmlRenderer::new();
-        let inner = ratatui_core::layout::Rect {
+        let inner = tuika::ui::Rect {
             x: area.x.saturating_add(2),
             y: area.y.saturating_add(1),
             width: area.width.saturating_sub(4),

--- a/crates/tuika-html/src/block.rs
+++ b/crates/tuika-html/src/block.rs
@@ -6,10 +6,10 @@
 //! renderer uses, minus the width-independent middle form — HTML is not
 //! streamed token by token, so there is no settled prefix to cache.
 
-use ratatui_core::style::{Modifier, Style};
-use ratatui_core::text::{Line, Span};
 use tuika::components::text::wrap_lines;
 use tuika::style::{StyleSheet, Theme};
+use tuika::ui::{Line, Span};
+use tuika::ui::{Modifier, Style};
 use tuika::width::str_cols;
 
 use markup5ever_rcdom::{Handle, NodeData};

--- a/crates/tuika-html/src/inline.rs
+++ b/crates/tuika-html/src/inline.rs
@@ -6,9 +6,9 @@
 //! are deliberately separate: tuika matches tag *strings* it never parses, while
 //! this one walks a real tree and can see attributes and nesting.
 
-use ratatui_core::style::{Modifier, Style};
-use ratatui_core::text::Span;
 use tuika::style::{StyleSheet, Theme};
+use tuika::ui::Span;
+use tuika::ui::{Modifier, Style};
 
 use crate::dom::{self, attr, tag};
 use markup5ever_rcdom::{Handle, NodeData};

--- a/crates/tuika-html/src/lib.rs
+++ b/crates/tuika-html/src/lib.rs
@@ -57,10 +57,10 @@
 //! [`MarkdownBlockRenderer`]: tuika::components::MarkdownBlockRenderer
 //! [`StyleSheet`]: tuika::style::StyleSheet
 
-use ratatui_core::text::Line;
 use tuika::Theme;
 use tuika::components::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
 use tuika::style::StyleSheet;
+use tuika::ui::Line;
 
 mod block;
 mod dom;
@@ -212,7 +212,7 @@ pub fn to_lines_with_limits(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui_core::style::Modifier;
+    use tuika::ui::Modifier;
 
     /// The plain text of a render, one string per line.
     fn plain(html: &str, width: u16) -> Vec<String> {
@@ -230,7 +230,7 @@ mod tests {
             .collect()
     }
 
-    fn styled(html: &str, needle: &str) -> ratatui_core::style::Style {
+    fn styled(html: &str, needle: &str) -> tuika::ui::Style {
         let theme = Theme::default();
         to_lines(html, 60, &theme, &StyleSheet::from_theme(&theme))
             .iter()
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn styling_follows_the_stylesheet() {
-        use ratatui_core::style::Color;
+        use tuika::ui::Color;
         let theme = Theme::default();
         let sheet = StyleSheet {
             strong: tuika::style::StyleBundle::new().fg(Color::Green),

--- a/crates/tuika-html/src/table.rs
+++ b/crates/tuika-html/src/table.rs
@@ -5,9 +5,9 @@
 //! cannot — because the two sit side by side in one document and a table should
 //! not change character depending on which syntax wrote it.
 
-use ratatui_core::style::Style;
-use ratatui_core::text::{Line, Span};
 use tuika::components::text::wrap_lines;
+use tuika::ui::Style;
+use tuika::ui::{Line, Span};
 use tuika::width::str_cols;
 
 use markup5ever_rcdom::Handle;

--- a/crates/tuika-html/src/view.rs
+++ b/crates/tuika-html/src/view.rs
@@ -1,10 +1,10 @@
 //! The [`Html`] view: a fragment placed in a layout.
 
-use ratatui_core::layout::Rect;
 use tuika::components::text::line_width;
 use tuika::geometry::Size;
 use tuika::style::{StyleSheet, Theme};
 use tuika::surface::Surface;
+use tuika::ui::Rect;
 use tuika::view::{RenderCtx, View};
 
 use crate::{Limits, to_lines_with_limits};
@@ -53,7 +53,7 @@ impl Html {
         width: u16,
         theme: &Theme,
         sheet: &StyleSheet,
-    ) -> Vec<ratatui_core::text::Line<'static>> {
+    ) -> Vec<tuika::ui::Line<'static>> {
         to_lines_with_limits(&self.source, width, theme, sheet, self.limits).unwrap_or_default()
     }
 }
@@ -89,9 +89,9 @@ impl View for Html {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui_core::style::Color;
     use tuika::style::StyleBundle;
     use tuika::testing::{grid, render, render_with_sheet};
+    use tuika::ui::Color;
 
     #[test]
     fn the_view_paints_its_fragment() {

--- a/crates/tuika-mermaid/src/lib.rs
+++ b/crates/tuika-mermaid/src/lib.rs
@@ -8,10 +8,10 @@
 //! fallback.
 
 use mmdflux::{OutputFormat, RenderConfig, TextColorMode, render_diagram};
-use ratatui_core::style::Style;
-use ratatui_core::text::{Line, Span};
 use tuika::Theme;
 use tuika::components::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
+use tuika::ui::Style;
+use tuika::ui::{Line, Span};
 
 /// Upper bound for one Mermaid fence handed to mmdflux.
 const MAX_SOURCE_BYTES: usize = 64 * 1024;

--- a/examples/codex/app.rs
+++ b/examples/codex/app.rs
@@ -7,8 +7,8 @@
 //! `ScrollState`, `SelectState`) and renders from them; the wiring below is the
 //! part a real host writes.
 
-use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
+use tuika::ui::Rect;
+use tuika::ui::{Color, Modifier, Style};
 
 use tuika::prelude::*;
 

--- a/examples/codex/history.rs
+++ b/examples/codex/history.rs
@@ -9,8 +9,8 @@
 //! their rows in a `Text`; panel-shaped ones return a real `Boxed`. A streamed
 //! answer still keeps a [`MarkdownState`] so only its in-flight tail re-parses.
 
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
+use tuika::ui::{Line, Span};
+use tuika::ui::{Modifier, Style};
 
 use tuika::components::text::wrap_lines;
 use tuika::prelude::*;

--- a/examples/codex/main.rs
+++ b/examples/codex/main.rs
@@ -43,8 +43,8 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event;
-use ratatui::backend::CrosstermBackend;
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::backend::CrosstermBackend;
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
 
 use tuika::components::Flex;
 use tuika::probe::RectProbe;

--- a/examples/codex/ui.rs
+++ b/examples/codex/ui.rs
@@ -8,9 +8,9 @@
 
 use std::io;
 
-use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
+use tuika::ui::Rect;
+use tuika::ui::{Line, Span};
+use tuika::ui::{Modifier, Style};
 
 use tuika::prelude::*;
 use tuika::probe::RectProbe;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -23,10 +23,10 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind};
-use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport as RatatuiViewport};
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport as TerminalViewport};
+use tuika::ui::Rect;
+use tuika::ui::{Color, Modifier, Style};
+use tuika::ui::{Line, Span};
 
 use tuika::framebuffer::{FrameBuffer, FrameBufferView};
 use tuika::prelude::*;
@@ -1067,9 +1067,9 @@ fn dump(d: &Demo, theme: &Theme) -> io::Result<()> {
 fn run(d: &Demo, theme: &Theme) -> io::Result<()> {
     let _session = tuika::TerminalSession::enter()?;
     let mut terminal = Terminal::with_options(
-        ratatui::backend::CrosstermBackend::new(io::stdout()),
+        tuika::term::backend::CrosstermBackend::new(io::stdout()),
         TerminalOptions {
-            viewport: RatatuiViewport::Fullscreen,
+            viewport: TerminalViewport::Fullscreen,
         },
     )?;
     let mut frame = 0u64;

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -15,9 +15,9 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEventKind};
-use ratatui::style::Modifier;
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::Modifier;
+use tuika::ui::{Line, Span};
 
 use tuika::prelude::*;
 
@@ -37,7 +37,7 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
 
     view! {
         col(padding = tuika::Padding::all(1), gap = 1,
-            background = ratatui::style::Style::default().bg(theme.background)) {
+            background = tuika::ui::Style::default().bg(theme.background)) {
             fixed(5) {
                 boxed(title = Line::from(Span::styled(" spinners ", theme.accent_style()))) {
                     col {
@@ -89,7 +89,7 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
                     }
                     grow(1) {
                         boxed(title = Line::from(Span::styled(" danger ", theme.accent_style())),
-                              border_color = ratatui::style::Color::Red) {
+                              border_color = tuika::ui::Color::Red) {
                             text("explicit color")
                         }
                     }

--- a/examples/image_demo.rs
+++ b/examples/image_demo.rs
@@ -21,8 +21,8 @@
 
 use std::io;
 
-use ratatui::style::Color;
 use tuika::Theme;
+use tuika::ui::Color;
 
 #[path = "support/image_app.rs"]
 mod image_app;

--- a/examples/inherit.rs
+++ b/examples/inherit.rs
@@ -27,8 +27,8 @@
 use std::io;
 use std::time::Duration;
 
-use ratatui::style::{Color, Style};
-use ratatui::text::{Line, Span};
+use tuika::ui::{Color, Style};
+use tuika::ui::{Line, Span};
 
 use tuika::components::{Flex, Rule, Text};
 use tuika::term::capabilities::Capabilities;

--- a/examples/keyed_table.rs
+++ b/examples/keyed_table.rs
@@ -8,9 +8,9 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event;
-use ratatui::backend::CrosstermBackend;
-use ratatui_core::terminal::Terminal;
 use tuika::prelude::*;
+use tuika::term::backend::CrosstermBackend;
+use tuika::term::terminal::Terminal;
 
 mod support;
 

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -34,9 +34,9 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self};
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Span;
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::Span;
+use tuika::ui::{Modifier, Style};
 
 use tuika::prelude::*;
 
@@ -275,7 +275,7 @@ fn main() -> io::Result<()> {
             paint(f.buffer_mut(), area, &theme, root.as_ref(), &[]);
             apply_buffer_links(
                 f.buffer_mut(),
-                ratatui::layout::Position {
+                tuika::ui::Position {
                     x: area.x.saturating_add(1),
                     y: area.y.saturating_add(1),
                 },

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -18,19 +18,19 @@ use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEventKind};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use ratatui::backend::CrosstermBackend;
-use ratatui::layout::Rect;
-use ratatui::style::Style;
-use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Paragraph};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::backend::CrosstermBackend;
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::Rect;
+use tuika::ui::Style;
 
+use tuika::Surface;
 use tuika::host::AltScreen;
 use tuika::mouse::{ClickTracker, HitMap, SelectionState, paint_selection, selected_text};
 use tuika::prelude::*;
+use tuika::style::BorderStyle;
+use tuika::term::clipboard;
 
 mod support;
-use tuika::term::clipboard;
 
 const SAMPLE: &[&str] = &[
     "Drag across this text to select it.",
@@ -84,29 +84,21 @@ fn main() -> io::Result<()> {
             clear_btn = Rect::new(2, btn_y, 9, 1);
             quit_btn = Rect::new(12, btn_y, 8, 1);
 
-            f.render_widget(
-                Paragraph::new(Line::from(Span::styled(
-                    " tuika mouse demo ",
-                    theme.accent_style(),
-                ))),
-                Rect::new(1, 0, area.width.saturating_sub(2), 1),
-            );
-            f.render_widget(
-                Block::bordered(),
-                Rect::new(1, 1, area.width.saturating_sub(2), SAMPLE.len() as u16 + 2),
-            );
-            f.render_widget(
-                Paragraph::new(SAMPLE.iter().map(|s| Line::from(*s)).collect::<Vec<_>>()),
-                text_area,
-            );
-            f.render_widget(
-                Paragraph::new(Span::styled("[ clear ]", theme.muted_style())),
-                clear_btn,
-            );
-            f.render_widget(
-                Paragraph::new(Span::styled("[ quit ]", theme.muted_style())),
-                quit_btn,
-            );
+            {
+                let full = f.area();
+                let mut surface = Surface::new(f.buffer_mut(), full);
+                surface.set_string(1, 0, " tuika mouse demo ", theme.accent_style());
+                surface.draw_border(
+                    Rect::new(1, 1, area.width.saturating_sub(2), SAMPLE.len() as u16 + 2),
+                    BorderStyle::Plain.glyphs(),
+                    Style::default().fg(theme.border),
+                );
+                for (i, line) in SAMPLE.iter().enumerate() {
+                    surface.set_string(text_area.x, text_area.y + i as u16, line, Style::default());
+                }
+                surface.set_string(clear_btn.x, clear_btn.y, "[ clear ]", theme.muted_style());
+                surface.set_string(quit_btn.x, quit_btn.y, "[ quit ]", theme.muted_style());
+            }
 
             if sel.resolve(f.buffer_mut(), text_area) {
                 pending_copy = true;
@@ -126,15 +118,16 @@ fn main() -> io::Result<()> {
                 pending_copy = false;
             }
 
-            f.render_widget(
-                Paragraph::new(Span::styled(status.clone(), theme.muted_style())),
-                Rect::new(
+            {
+                let full = f.area();
+                let mut surface = Surface::new(f.buffer_mut(), full);
+                surface.set_string(
                     1,
                     area.height.saturating_sub(1),
-                    area.width.saturating_sub(2),
-                    1,
-                ),
-            );
+                    &status,
+                    theme.muted_style(),
+                );
+            }
         })?;
 
         let mut hits: HitMap<Btn> = HitMap::new();

--- a/examples/overlay.rs
+++ b/examples/overlay.rs
@@ -10,9 +10,9 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self};
-use ratatui::backend::CrosstermBackend;
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::backend::CrosstermBackend;
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::{Line, Span};
 
 use tuika::prelude::*;
 

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -1,7 +1,7 @@
 //! Owned scenes, arbitrary-child viewports, forms, and custom drawing.
 
-use ratatui_core::layout::Rect;
 use tuika::prelude::*;
+use tuika::ui::Rect;
 use tuika::view::DrawView;
 
 mod support;

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -32,10 +32,10 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind};
-use ratatui::buffer::Buffer;
-use ratatui::style::{Color, Modifier};
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::Buffer;
+use tuika::ui::{Color, Modifier};
+use tuika::ui::{Line, Span};
 
 use tuika::prelude::*;
 
@@ -160,7 +160,7 @@ fn render_frame(frame: u64, theme: &Theme) -> Buffer {
 fn run_interactive(theme: &Theme) -> io::Result<()> {
     let _session = tuika::TerminalSession::enter()?;
     let mut terminal = Terminal::with_options(
-        ratatui::backend::CrosstermBackend::new(io::stdout()),
+        tuika::term::backend::CrosstermBackend::new(io::stdout()),
         TerminalOptions {
             viewport: Viewport::Fullscreen,
         },
@@ -187,7 +187,7 @@ fn run_interactive(theme: &Theme) -> io::Result<()> {
 }
 
 fn scene(frame: u64, theme: &Theme) -> Element {
-    let bg = ratatui::style::Style::default().bg(theme.background);
+    let bg = tuika::ui::Style::default().bg(theme.background);
 
     view! {
         col(padding = Padding::all(1), gap = 0, background = bg) {
@@ -306,7 +306,7 @@ fn status(theme: &Theme) -> Element {
                 Span::styled("tuika 0.2  ", theme.muted_style()),
                 Span::styled("⏎ run ", theme.text_style()),
             ])
-            .background(ratatui::style::Style::default().bg(theme.surface)),
+            .background(tuika::ui::Style::default().bg(theme.surface)),
     )
 }
 

--- a/examples/split_footer.rs
+++ b/examples/split_footer.rs
@@ -19,9 +19,9 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::thread;
 use std::time::Duration;
 
-use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
 use tuika::prelude::*;
+use tuika::ui::{Line, Span};
+use tuika::ui::{Modifier, Style};
 
 mod support;
 

--- a/examples/split_footer_demo.rs
+++ b/examples/split_footer_demo.rs
@@ -38,8 +38,8 @@ use std::thread;
 use std::time::Duration;
 
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use ratatui::style::Color;
 use tuika::prelude::Theme;
+use tuika::ui::Color;
 
 mod support;
 

--- a/examples/styling.rs
+++ b/examples/styling.rs
@@ -21,11 +21,11 @@ use std::io;
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind};
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier};
-use ratatui::text::{Line, Span};
-use ratatui::{Terminal, TerminalOptions, Viewport};
+use tuika::term::terminal::{Terminal, TerminalOptions, Viewport};
+use tuika::ui::Buffer;
+use tuika::ui::Rect;
+use tuika::ui::{Color, Modifier};
+use tuika::ui::{Line, Span};
 
 use tuika::prelude::*;
 
@@ -155,7 +155,7 @@ fn render_frame(frame: u64, theme: &Theme, sheet: StyleSheet, label: &str) -> Bu
 fn run_interactive(theme: &Theme, held: Option<&str>) -> io::Result<()> {
     let _session = tuika::TerminalSession::enter()?;
     let mut terminal = Terminal::with_options(
-        ratatui::backend::CrosstermBackend::new(io::stdout()),
+        tuika::term::backend::CrosstermBackend::new(io::stdout()),
         TerminalOptions {
             viewport: Viewport::Fullscreen,
         },
@@ -189,7 +189,7 @@ fn run_interactive(theme: &Theme, held: Option<&str>) -> io::Result<()> {
 /// The composite scene: a header naming the active sheet, a panel holding the
 /// markdown block, and a side panel with live motion (so the capture breathes).
 fn scene(frame: u64, theme: &Theme, label: &str) -> Element {
-    let bg = ratatui::style::Style::default().bg(theme.background);
+    let bg = tuika::ui::Style::default().bg(theme.background);
     view! {
         col(padding = Padding::all(1), gap = 0, background = bg) {
             fixed(1) { node(header(theme, label)) }

--- a/examples/support/image_app.rs
+++ b/examples/support/image_app.rs
@@ -1,9 +1,8 @@
 use std::io;
 
-use ratatui::style::Style;
-use ratatui::text::Span;
 use tuika::prelude::*;
 use tuika::term::image::{ImageData, ImageSupport};
+use tuika::ui::{Span, Style};
 
 pub const ALT: &str = "a red/green gradient";
 

--- a/examples/workbench_demo/main.rs
+++ b/examples/workbench_demo/main.rs
@@ -9,9 +9,9 @@
 
 use std::time::Duration;
 
-use ratatui::layout::Alignment;
 use tuika::prelude::*;
 use tuika::probe::RectProbe;
+use tuika::ui::Alignment;
 use tuika_charts::{Axis as ChartAxis, Chart, Domain, Point, Series};
 use tuika_codeformatters::TreeSitterHighlighter;
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -74,6 +74,45 @@
 
 ## 2026-08-21
 
+- **tuika owns the cell grid; ratatui is now optional interop**
+  - The `ratatui-core` dependency was removed. tuika owns `Rect`/`Position`,
+    `Color`/`Modifier`/`Style`, `Line`/`Span`, `Buffer`/`Cell`, the `Backend`
+    trait, `TestBackend`, and the `Terminal` render loop including the inline
+    viewport. The default graph went from 55 crates to 32, and the cold
+    dependency build from ~32s to ~6s. See
+    [architecture.md](specs/architecture.md#why-tuika-owns-the-cell-grid).
+  - The trigger was not size but **version coupling**: every `View` signature
+    named a `ratatui-core` type, so a major bump there was a breaking release
+    for tuika, all four companion crates, and every host simultaneously. The
+    maintenance process already recorded that as "an interoperability event, not
+    a routine upgrade" — owning the vocabulary removes the event.
+  - Roughly half the removed weight was for code tuika never called: `kasuari`
+    (a Cassowary solver), `lru`, and a second `hashbrown` exist for
+    `ratatui_core::layout::Layout`, which tuika replaced with its own flex
+    solver on day one.
+  - **Interop survived the removal**, behind an off-by-default `ratatui`
+    feature, because `Surface::render_ratatui` was *already* a scratch-buffer
+    round trip — cells were copied in and back out to enforce the clip. Only the
+    conversion in the middle is new. The general escape hatch split off as
+    `Surface::render_scratch`, which needs no feature.
+  - **The instruction-count gate earned its keep.** The first working version
+    regressed the render benchmarks by 72%, because `Cell` held a `String` and
+    so heap-allocated per cell; ratatui used `compact_str` for exactly this
+    reason. Storing short clusters inline fixed it and ended ~7% *faster* than
+    the old baseline. A second ~10% came from not re-validating UTF-8 on every
+    symbol read — the one place in this change where `unsafe` was worth it, with
+    the invariant documented and a `debug_assert!` behind it.
+  - The residual +2% on the markdown benchmarks is deliberate: `Span::width` now
+    counts grapheme-aware display columns, so it agrees with what `Surface`
+    actually paints. That is the same class of bug the `textwrap` removal fixed
+    for `Paragraph`.
+  - **The positioning claim changed and had to be rewritten, not quietly
+    dropped.** `goal.md` said "additive, never a replacement… with ratatui still
+    underneath". That is no longer true. The replacement wording is deliberately
+    non-adversarial: tuika is an alternative in dependency terms, ratatui is why
+    the ecosystem exists, and its widgets still compose. A maintainer changing
+    this again should change it in `goal.md`, the README lede, and the
+    Compatibility section together — they are one claim in three places.
 - **A session is a test subject the component sweep cannot reach**
   - `tests/stress_ui.rs` drives whole sessions — every `ScreenMode`, both
     runners, shell chrome and overlays — over an in-memory screen that changes

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -9,18 +9,18 @@ description: Defines tuika's view/state/layout/host model and the boundaries tha
 ## Why
 
 A terminal UI toolkit has two plausible shapes: a retained widget tree with a
-reconciler, or an immediate-mode redraw. ratatui already diffs a cell buffer
+reconciler, or an immediate-mode redraw. Diffing a cell buffer
 against the terminal every frame, so a second reconciliation layer above it
 would duplicate work and introduce a second source of truth for "what is on
-screen". tuika therefore builds *on top of* the diff ratatui already performs
-rather than beside it.
+screen". tuika therefore makes that buffer diff its *only* reconciliation
+rather than adding a second layer above it.
 
 ## The model
 
 - **Views are ephemeral.** A `View` is rebuilt from application state every
   frame. There is no identity, no keys, no lifecycle. This is affordable because
-  ratatui diffs the resulting buffer, so an unchanged frame writes nothing to
-  the terminal.
+  `Buffer::diff` compares the resulting buffer against the last frame, so an
+  unchanged frame writes nothing to the terminal.
 - **State that must survive lives in the host.** Scroll offset, selection index,
   focus registry, text-input cursor, and toast expiry are `*State` structs the
   host owns and passes back in each frame — the `StatefulWidget` idiom. A view
@@ -185,31 +185,54 @@ max-content availability. Its default adapts to the original `measure`, so old
 views remain source-compatible; the non-exhaustive request and availability
 types can gain future measurement inputs without another trait-wide break.
 
-## Why the `ratatui-core` boundary, not the umbrella
+## Why tuika owns the cell grid
 
-tuika renders none of ratatui's own widgets, so it depends on `ratatui-core`
-directly. This drops `ratatui-widgets`, `ratatui-macros`, and their transitive
-weight from every downstream build that does not use them.
+tuika has no runtime dependency on ratatui. It owns its own `Rect`/`Position`,
+`Color`/`Modifier`/`Style`, `Line`/`Span`, `Buffer`/`Cell`, `Backend`, and
+`Terminal` — everything from the layout area down to the bytes on the wire.
 
-It does not take `ratatui-crossterm` either. That crate supplies exactly one
-thing tuika needs — a `Backend` that writes through crossterm — and tuika
-already implemented the whole trait once, in `HyperlinkBackend`, to wrap it.
-Owning the cell-drawing loop as well collapses those two layers into one and
-drops the crate's eight-crate `instability`/`darling` proc-macro tree. The
-emitted byte stream is held byte-identical to `ratatui-crossterm`'s by a
-differential unit test that draws the same cells through both, so the choice
-stays an implementation detail rather than a compatibility claim. tuika keeps an
-*optional* dependency on it under the `scrolling-regions` feature only, to
-forward that flag: enabling `ratatui-core/scrolling-regions` adds two required
-`Backend` methods, and Cargo unifies features one way, so a host's own
-`ratatui-crossterm` would otherwise fail to compile.
+This was not always so, and the reasoning for the change is worth keeping:
 
-It costs nothing in interoperability: the interop boundary is a raw
-`&mut Buffer` from that same `ratatui-core`. A host bringing the `ratatui`
-umbrella resolves to one shared `ratatui-core`, so `Surface::render_ratatui` and
-`RatatuiView` accept any real ratatui widget without conversion. The
-`underline-color` feature is enabled to match the umbrella's default so cell
-rendering is byte-identical either way.
+- **The public API was version-locked to someone else's crate.** Every `View`
+  signature named a `ratatui-core` type, so a `ratatui-core` major bump was a
+  breaking release for tuika, all four companion crates, and every host at once.
+  Owning the vocabulary makes that a private implementation detail.
+- **Half the dependency weight was for code tuika never called.** `ratatui-core`
+  pulls `kasuari` (a Cassowary solver), `lru`, and a second `hashbrown` for
+  `layout::Layout` — which tuika replaced with its own flex solver on day one —
+  plus `strum`, `compact_str`, `itertools`, and `unicode-truncate`. Removing it
+  took the default graph from 55 crates to 32 and the cold dependency build from
+  roughly 32s to 6s.
+- **The cell model had already outgrown it.** OSC 8 hyperlinks do not fit in a
+  ratatui `Cell`, which is why `HyperlinkBackend` existed as a whole `Backend`
+  implementation whose job was to re-scan finished cells for URLs.
+
+What did *not* motivate it: performance. That the render benchmarks came out
+~7% faster is a side effect of `Cell` storing short grapheme clusters inline
+rather than in a `CompactString`, not the goal.
+
+### Interoperability is preserved, not abandoned
+
+`Surface::render_ratatui` and `RatatuiView` still accept any real ratatui
+widget, behind the optional `ratatui` feature. The boundary is no longer a
+shared `Buffer` — the two crates no longer share a cell type — but a cell-by-cell
+conversion over the *rendered area only*, in `interop.rs`.
+
+That conversion is cheap because `render_ratatui` was always a scratch-buffer
+round trip: cells were already copied in and back out to enforce the clip. The
+only change is that the scratch is converted on the way through. A host that
+renders no ratatui widgets compiles none of it and takes no dependency.
+
+The conversions are exhaustive `match`es rather than transmutes, and the
+modifier bit layout — the one place a silent divergence could hide — is pinned
+by a test rather than assumed.
+
+### The cost that was accepted
+
+Every `pub` item that named a ratatui type changed, which is a breaking release
+for every host. It was taken as one change rather than two: decoupling the API
+without removing the dependency would have broken hosts once, and removing the
+dependency later would have broken them again.
 
 ## The probe pattern
 
@@ -340,7 +363,8 @@ the child's logical extent is much larger.
 3. Views paint into a clipped `Surface`; overlays composite over the base.
 4. The host calls out-of-band emitters (images, native progress) after the
    frame, because those escapes paint outside the cell model.
-5. ratatui diffs the buffer and writes only what changed.
+5. `Terminal` diffs the buffer against the previous frame and writes only what
+   changed.
 
 ## Non-goals
 

--- a/knowledge/specs/goal.md
+++ b/knowledge/specs/goal.md
@@ -8,12 +8,11 @@ description: Defines what tuika is for, the default-framework ambition it is pos
 
 ## Purpose
 
-tuika supplies the pieces `ratatui` deliberately leaves to the application — a
-flexbox-style layout solver, anchored overlays, focus and input ownership, a
-declarative keymap, an alternate-screen host, and a component set — while
-leaving `ratatui` in charge of the cell buffer and its diff against the
-terminal. A host should be able to describe a screen declaratively and get
-correct layout, focus, and terminal lifecycle without writing a reconciler.
+tuika is a complete terminal-UI toolkit: a flexbox-style layout solver, anchored
+overlays, focus and input ownership, a declarative keymap, an alternate-screen
+host, a component set, and the cell grid and terminal loop underneath them. A
+host should be able to describe a screen declaratively and get correct layout,
+focus, and terminal lifecycle without writing a reconciler.
 
 ## Positioning
 
@@ -30,10 +29,12 @@ The claim is earned by scope and by adoption evidence, never by overstatement:
   focus, keymap, theming, terminal lifecycle, screen modes, and a component set
   covering the modern expectations (streaming markdown, images, mouse and
   clipboard, native progress) — is in the box.
-- **Additive, never a replacement.** Positioning above ratatui must not read as
-  competing with it. tuika depends on ratatui's buffer and composes its widgets;
-  "default framework" means the layer applications sit on, with ratatui still
-  underneath.
+- **Complete, but not hostile.** tuika owns its stack down to the bytes and has
+  no runtime dependency on ratatui, so it is an alternative rather than a layer.
+  That is a statement about dependencies, not a claim to be better: ratatui is
+  the reason a Rust TUI ecosystem exists, its widgets remain usable through the
+  optional `ratatui` feature, and public material says so plainly rather than
+  positioning against it.
 - **Evidence over adjectives.** Public claims point at runnable examples and the
   [showcases](../../docs/showcases.md) — real applications on tuika — rather
   than asserting popularity the project does not yet have.
@@ -44,14 +45,15 @@ The claim is earned by scope and by adoption evidence, never by overstatement:
    type, feature, or default exists to serve one host.
 2. **Composable over configurable.** Behavior is reached by composing views, not
    by accumulating knobs on a component.
-3. **Dependency-light.** The published crate depends only on `ratatui-core`,
-   `crossterm`, `unicode-segmentation`, `unicode-width`, and `pulldown-cmark`.
-   Anything heavier belongs behind a trait the host implements — and a
-   dependency tuika could *own* in a page of code, rather than delegate, is one
-   it should: see
+3. **Dependency-light.** The published crate depends only on `crossterm`,
+   `unicode-segmentation`, `unicode-width`, and `pulldown-cmark` — 32 crates in
+   the default graph, of which `crossterm` is 27. Anything heavier belongs behind
+   a trait the host implements — and a dependency tuika could *own* in a page of
+   code, rather than delegate, is one it should: see
    [Dependency Discipline](../processes/maintenance.md#dependency-discipline).
 4. **Interoperable, not exclusive.** Existing ratatui widgets compose through a
-   raw-`Buffer` boundary; adopting tuika never means giving up ratatui.
+   cell-conversion boundary behind the optional `ratatui` feature; adopting tuika
+   never means giving up the widgets already written for it.
 5. **Testable without a terminal.** Rendering is observable as cells in memory,
    so behavior is asserted hermetically.
 
@@ -84,13 +86,14 @@ dependency, not the topic.
 ## Non-goals
 
 - **No reconciler or retained widget tree.** Views are rebuilt each frame;
-  ratatui's buffer diff is the only reconciliation.
+  the cell-buffer diff is the only reconciliation.
 - **No async runtime requirement.** The optional `async` feature adds an
   `AsyncRunner` for hosts already on Tokio; the default build has no runtime.
 - **No data sources.** tuika neither spawns tasks nor performs I/O beyond the
   terminal.
-- **No re-implementation of ratatui widgets.** Where ratatui has a widget, wrap
-  it rather than clone it.
+- **No re-implementation of ratatui widgets.** tuika owns the cell grid, not a
+  widget catalogue. Where ratatui has a widget tuika lacks, wrap it through the
+  `ratatui` feature rather than cloning it.
 - **No configuration format.** Themes, stylesheets, and keymaps are code-defined
   values; parsing a user's config file is the host's job.
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,932 @@
+//! The cell grid: [`Cell`] and [`Buffer`].
+//!
+//! A [`Buffer`] is a rectangle of [`Cell`]s — one grapheme cluster plus its
+//! attributes each — and is the only thing a [`View`](crate::View) ever writes
+//! to, always through a clipped [`Surface`](crate::Surface).
+//!
+//! Rendering is immediate-mode: the whole frame is rebuilt every time. What
+//! makes that affordable is [`Buffer::diff`], which compares the new frame
+//! against the last one and yields only the cells that changed, so an unchanged
+//! frame writes nothing to the terminal.
+//!
+//! # Wide graphemes
+//!
+//! A cell holds a *grapheme cluster*, not a `char`, and that cluster may be two
+//! columns wide (CJK, most emoji). The convention — the same one every terminal
+//! uses — is that the wide cluster lives in its leading cell and the cell to its
+//! right is left empty as a placeholder. [`Buffer::set_string`] maintains that
+//! invariant, and [`diff`](Buffer::diff) knows to step over the placeholder
+//! rather than emitting a stray write into it.
+
+use std::num::NonZeroU16;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::geometry::{Position, Rect};
+use crate::style::{Color, Modifier, Style};
+use crate::width::grapheme_cols;
+
+/// How [`Buffer::diff`] should treat one cell.
+///
+/// The default compares against the previous frame and writes on a difference.
+/// The other variants exist because some things a terminal displays are not
+/// under the cell grid's control — an image painted by a graphics protocol, or
+/// an OSC 8 hyperlink whose escape bytes live in a cell's symbol but occupy no
+/// columns.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CellDiffOption {
+    /// Compare against the previous frame; write when it differs.
+    #[default]
+    None,
+    /// Never write this cell. Used where something outside the cell model owns
+    /// the pixels, so a redraw would erase it.
+    Skip,
+    /// Always write this cell, even when unchanged. Used where another renderer
+    /// may have painted over the same area, so the previous frame is not
+    /// evidence of what is on screen.
+    AlwaysUpdate,
+    /// Treat the cell as exactly this many columns wide, whatever its symbol
+    /// measures. This is what lets a symbol carry escape bytes — an OSC 8 link
+    /// wrapper — without those bytes being counted as columns.
+    ForcedWidth(NonZeroU16),
+}
+
+/// Bytes a [`Symbol`] stores without allocating.
+///
+/// Sized so the enum lands in the same 24 bytes a `String` would take, and so
+/// the clusters that actually occur — a `char`, a combining sequence, a
+/// flag or skin-tone emoji — all fit. Longer ones still work; they just spill
+/// to the heap.
+const SYMBOL_INLINE_CAP: usize = 22;
+
+/// A cell's grapheme cluster, stored inline when it fits.
+///
+/// A plain `String` would put every one of a screen's cells on the heap — and
+/// the grid is reallocated on every resize and cloned per scratch buffer, so
+/// that showed up as a ~70% instruction-count regression on the render
+/// benchmarks. Clusters are almost always a handful of bytes, so they live in
+/// the cell itself.
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Symbol {
+    /// `len` valid UTF-8 bytes at the front of `bytes`.
+    Inline {
+        len: u8,
+        bytes: [u8; SYMBOL_INLINE_CAP],
+    },
+    /// A cluster too long to inline. Rare enough not to matter.
+    Heap(Box<str>),
+}
+
+impl Symbol {
+    const EMPTY: Symbol = Symbol::Inline {
+        len: 0,
+        bytes: [0; SYMBOL_INLINE_CAP],
+    };
+
+    fn new(text: &str) -> Self {
+        let bytes = text.as_bytes();
+        if bytes.len() <= SYMBOL_INLINE_CAP {
+            let mut buf = [0u8; SYMBOL_INLINE_CAP];
+            buf[..bytes.len()].copy_from_slice(bytes);
+            Symbol::Inline {
+                len: bytes.len() as u8,
+                bytes: buf,
+            }
+        } else {
+            Symbol::Heap(text.into())
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        match self {
+            // Safe: only ever written from a `&str`, so the prefix is valid
+            // UTF-8 by construction.
+            Symbol::Inline { len, bytes } => {
+                let bytes = &bytes[..*len as usize];
+                debug_assert!(
+                    std::str::from_utf8(bytes).is_ok(),
+                    "inline symbol bytes must stay valid UTF-8"
+                );
+                // SAFETY: `Symbol` is private, and the only way to populate
+                // `Inline` is `Symbol::new`, which copies a whole `&str`'s bytes
+                // and records that exact length — so this slice is always a
+                // complete, valid UTF-8 string. Nothing else writes `bytes`, and
+                // `len` is never changed independently of it.
+                //
+                // Re-validating here instead costs about 10% of the render
+                // benchmarks' instructions, because this runs for every cell on
+                // every diff. The `debug_assert!` turns any future break of the
+                // invariant into a test failure rather than undefined behavior.
+                unsafe { std::str::from_utf8_unchecked(bytes) }
+            }
+            Symbol::Heap(text) => text,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Symbol::Inline { len, .. } => *len == 0,
+            Symbol::Heap(text) => text.is_empty(),
+        }
+    }
+}
+
+impl Default for Symbol {
+    fn default() -> Self {
+        Symbol::EMPTY
+    }
+}
+
+/// One cell of the grid: a grapheme cluster and its attributes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Cell {
+    /// The grapheme cluster to draw. Empty means this is the placeholder to the
+    /// right of a wide cluster.
+    symbol: Symbol,
+    /// Foreground color.
+    pub fg: Color,
+    /// Background color.
+    pub bg: Color,
+    /// Underline color, honored only by terminals implementing the extended
+    /// underline SGR.
+    pub underline_color: Color,
+    /// Attributes.
+    pub modifier: Modifier,
+    /// How the diff should treat this cell.
+    pub diff_option: CellDiffOption,
+}
+
+impl Cell {
+    /// A cell showing `symbol`, unstyled.
+    ///
+    /// Not `const`: a cell can hold any grapheme
+    /// cluster, and a cluster is not known at compile time. Use
+    /// [`Cell::default`] for the blank cell, which is the only one a `const`
+    /// would have bought.
+    pub fn new(symbol: &str) -> Self {
+        let mut cell = Self::default();
+        cell.set_symbol(symbol);
+        cell
+    }
+
+    /// The grapheme cluster, or `" "` when this cell is blank.
+    pub fn symbol(&self) -> &str {
+        if self.symbol.is_empty() {
+            " "
+        } else {
+            self.symbol.as_str()
+        }
+    }
+
+    /// The symbol exactly as stored — empty when this cell is the placeholder
+    /// to the right of a wide grapheme.
+    ///
+    /// [`symbol`](Self::symbol) reports `" "` for both a blank cell and a
+    /// placeholder; this is how a caller tells them apart.
+    pub fn raw_symbol(&self) -> &str {
+        self.symbol.as_str()
+    }
+
+    /// Set the grapheme cluster.
+    pub fn set_symbol(&mut self, symbol: &str) -> &mut Self {
+        self.symbol = Symbol::new(symbol);
+        self
+    }
+
+    /// Set the cell to a single character.
+    pub fn set_char(&mut self, ch: char) -> &mut Self {
+        let mut buf = [0u8; 4];
+        self.set_symbol(ch.encode_utf8(&mut buf));
+        self
+    }
+
+    /// Set the foreground color.
+    pub const fn set_fg(&mut self, color: Color) -> &mut Self {
+        self.fg = color;
+        self
+    }
+
+    /// Set the background color.
+    pub const fn set_bg(&mut self, color: Color) -> &mut Self {
+        self.bg = color;
+        self
+    }
+
+    /// Apply `style`, leaving fields the style does not set untouched.
+    pub fn set_style<S: Into<Style>>(&mut self, style: S) -> &mut Self {
+        let style = style.into();
+        if let Some(fg) = style.fg {
+            self.fg = fg;
+        }
+        if let Some(bg) = style.bg {
+            self.bg = bg;
+        }
+        if let Some(underline) = style.underline_color {
+            self.underline_color = underline;
+        }
+        self.modifier = self
+            .modifier
+            .union(style.add_modifier)
+            .difference(style.sub_modifier);
+        self
+    }
+
+    /// This cell's attributes as a [`Style`].
+    pub const fn style(&self) -> Style {
+        Style {
+            fg: Some(self.fg),
+            bg: Some(self.bg),
+            underline_color: Some(self.underline_color),
+            add_modifier: self.modifier,
+            sub_modifier: Modifier::empty(),
+        }
+    }
+
+    /// Set how the diff treats this cell.
+    pub const fn set_diff_option(&mut self, diff_option: CellDiffOption) -> &mut Self {
+        self.diff_option = diff_option;
+        self
+    }
+
+    /// Reset to blank and unstyled.
+    pub fn reset(&mut self) {
+        self.symbol = Symbol::new(" ");
+        self.fg = Color::Reset;
+        self.bg = Color::Reset;
+        self.underline_color = Color::Reset;
+        self.modifier = Modifier::empty();
+        self.diff_option = CellDiffOption::None;
+    }
+
+    /// Display width in columns, honoring [`CellDiffOption::ForcedWidth`].
+    pub fn cell_width(&self) -> u16 {
+        match self.diff_option {
+            CellDiffOption::ForcedWidth(width) => width.get(),
+            _ => grapheme_cols(self.symbol()),
+        }
+    }
+
+    /// Whether the diff must leave this cell alone.
+    const fn is_skipped(&self) -> bool {
+        matches!(self.diff_option, CellDiffOption::Skip)
+    }
+}
+
+impl Default for Cell {
+    fn default() -> Self {
+        Self {
+            symbol: Symbol::new(" "),
+            fg: Color::Reset,
+            bg: Color::Reset,
+            underline_color: Color::Reset,
+            modifier: Modifier::empty(),
+            diff_option: CellDiffOption::None,
+        }
+    }
+}
+
+/// A rectangle of cells.
+///
+/// The area's `x`/`y` are the buffer's position on screen, so a buffer covering
+/// an inline viewport reports its real screen rows. Indexing is by absolute
+/// coordinate, not by offset into the rect.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Buffer {
+    /// The region this buffer covers, in screen coordinates.
+    pub area: Rect,
+    /// Cells in row-major order, `area.area()` of them.
+    pub content: Vec<Cell>,
+}
+
+impl Buffer {
+    /// A buffer of blank cells covering `area`.
+    pub fn empty(area: Rect) -> Self {
+        Self::filled(area, Cell::default())
+    }
+
+    /// A buffer covering `area` with every cell a clone of `cell`.
+    pub fn filled(area: Rect, cell: Cell) -> Self {
+        let size = area.area() as usize;
+        Self {
+            area,
+            content: vec![cell; size],
+        }
+    }
+
+    /// A buffer built from one string per row, unstyled.
+    ///
+    /// Chiefly a test convenience — it is how the golden-snapshot suite states
+    /// an expected screen.
+    pub fn with_lines<'a, I>(lines: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<crate::text::Line<'a>>,
+    {
+        let lines: Vec<crate::text::Line<'a>> = lines.into_iter().map(Into::into).collect();
+        let height = lines.len() as u16;
+        let width = lines
+            .iter()
+            .map(crate::text::Line::width)
+            .max()
+            .unwrap_or(0);
+        let mut buffer = Self::empty(Rect::new(0, 0, width, height));
+        for (y, line) in lines.iter().enumerate() {
+            buffer.set_line(0, y as u16, line, width);
+        }
+        buffer
+    }
+
+    /// Flat index of a screen position, or `None` when outside the area.
+    fn index_of(&self, x: u16, y: u16) -> Option<usize> {
+        if !self.area.contains(Position { x, y }) {
+            return None;
+        }
+        let dx = (x - self.area.x) as usize;
+        let dy = (y - self.area.y) as usize;
+        Some(dy * self.area.width as usize + dx)
+    }
+
+    /// The screen position of a flat index.
+    fn pos_of(&self, index: usize) -> (u16, u16) {
+        let width = self.area.width.max(1) as usize;
+        let x = index % width + self.area.x as usize;
+        let y = index / width + self.area.y as usize;
+        (x as u16, y as u16)
+    }
+
+    /// The cell at `position`, or `None` when outside the area.
+    pub fn cell<P: Into<Position>>(&self, position: P) -> Option<&Cell> {
+        let position = position.into();
+        self.index_of(position.x, position.y)
+            .map(|index| &self.content[index])
+    }
+
+    /// Mutable access to the cell at `position`, or `None` when outside.
+    pub fn cell_mut<P: Into<Position>>(&mut self, position: P) -> Option<&mut Cell> {
+        let position = position.into();
+        self.index_of(position.x, position.y)
+            .map(|index| &mut self.content[index])
+    }
+
+    /// The cells, row-major. Same data as the [`content`](Self::content)
+    /// field; the accessor exists so a caller can chain off it.
+    pub fn content(&self) -> &[Cell] {
+        &self.content
+    }
+
+    /// Reset every cell to blank and unstyled.
+    pub fn reset(&mut self) {
+        for cell in &mut self.content {
+            cell.reset();
+        }
+    }
+
+    /// Resize to `area`, keeping as many cells as still fit.
+    ///
+    /// Deliberately not a reflow — cells are kept by flat index, so a width
+    /// change shifts rows — because the frame is rebuilt from application state
+    /// anyway and the diff repaints whatever moved.
+    ///
+    /// It must not *clear*, though: resizing to the same area is a no-op that
+    /// several call sites rely on, and a
+    /// [`Terminal`](crate::term::terminal::Terminal) skips its repaint when the
+    /// dimensions are unchanged. Wiping here would blank the screen with nothing
+    /// to restore it — which is exactly what the split-footer stress sweep
+    /// caught.
+    pub fn resize(&mut self, area: Rect) {
+        let size = area.area() as usize;
+        if self.content.len() > size {
+            self.content.truncate(size);
+        } else {
+            self.content.resize(size, Cell::default());
+        }
+        self.area = area;
+    }
+
+    /// Overlay `other` onto this buffer, growing the area to cover both.
+    ///
+    /// Cells from `other` win where they overlap. Used by
+    /// [`Surface::render_ratatui`](crate::Surface::render_ratatui) when a
+    /// callback hands back a buffer larger than the one it was given.
+    pub fn merge(&mut self, other: &Self) {
+        let merged = self.area.union(other.area);
+        let mut content = vec![Cell::default(); merged.area() as usize];
+        let width = merged.width as usize;
+
+        let mut place = |buffer: &Self| {
+            for (index, cell) in buffer.content.iter().enumerate() {
+                let (x, y) = buffer.pos_of(index);
+                if !merged.contains(Position { x, y }) {
+                    continue;
+                }
+                let dx = (x - merged.x) as usize;
+                let dy = (y - merged.y) as usize;
+                content[dy * width + dx] = cell.clone();
+            }
+        };
+        place(self);
+        place(other);
+
+        self.area = merged;
+        self.content = content;
+    }
+
+    /// Apply `style` to every cell in `area`, leaving symbols untouched.
+    ///
+    /// Only the part of `area` inside this buffer is touched, so a caller may
+    /// pass a rect larger than the frame.
+    pub fn set_style<S: Into<Style>>(&mut self, area: Rect, style: S) {
+        let style = style.into();
+        let target = area.intersection(self.area);
+        for y in target.y..target.bottom() {
+            for x in target.x..target.right() {
+                if let Some(cell) = self.cell_mut((x, y)) {
+                    cell.set_style(style);
+                }
+            }
+        }
+    }
+
+    /// Write `string` starting at `x`, `y`, clipped to `max_width` columns and
+    /// to the buffer's own area. Returns the column just past what was written.
+    pub fn set_string<S: Into<Style>>(&mut self, x: u16, y: u16, string: &str, style: S) -> u16 {
+        self.set_stringn(x, y, string, usize::MAX, style).0
+    }
+
+    /// Like [`set_string`](Self::set_string) but stopping after `max_width`
+    /// columns. Returns the next free column and the columns consumed.
+    pub fn set_stringn<S: Into<Style>>(
+        &mut self,
+        x: u16,
+        y: u16,
+        string: &str,
+        max_width: usize,
+        style: S,
+    ) -> (u16, u16) {
+        let style = style.into();
+        let mut column = x;
+        let mut used = 0u16;
+        let limit = max_width.min(u16::MAX as usize) as u16;
+
+        for grapheme in string.graphemes(true) {
+            let width = grapheme_cols(grapheme);
+            // A zero-width cluster (a lone combining mark) has no cell of its
+            // own; dropping it is what keeps the column count honest.
+            if width == 0 {
+                continue;
+            }
+            if used.saturating_add(width) > limit || column >= self.area.right() {
+                break;
+            }
+            let Some(index) = self.index_of(column, y) else {
+                break;
+            };
+            self.content[index].set_symbol(grapheme);
+            self.content[index].set_style(style);
+            // Blank out the placeholder columns a wide cluster occupies, so a
+            // narrower glyph previously there cannot show through.
+            for offset in 1..width {
+                if let Some(trailing) = self.index_of(column + offset, y) {
+                    self.content[trailing].set_symbol("");
+                    self.content[trailing].set_style(style);
+                }
+            }
+            column = column.saturating_add(width);
+            used = used.saturating_add(width);
+        }
+        (column, used)
+    }
+
+    /// Write a [`Span`](crate::text::Span), returning the next free column and
+    /// the columns consumed.
+    pub fn set_span(
+        &mut self,
+        x: u16,
+        y: u16,
+        span: &crate::text::Span<'_>,
+        max_width: u16,
+    ) -> (u16, u16) {
+        self.set_stringn(x, y, span.content.as_ref(), max_width as usize, span.style)
+    }
+
+    /// Write a [`Line`](crate::text::Line), each span styled over the line's own
+    /// style. Returns the next free column and the columns consumed.
+    pub fn set_line(
+        &mut self,
+        x: u16,
+        y: u16,
+        line: &crate::text::Line<'_>,
+        max_width: u16,
+    ) -> (u16, u16) {
+        let mut column = x;
+        let mut used = 0u16;
+        for span in &line.spans {
+            let remaining = max_width.saturating_sub(used);
+            if remaining == 0 {
+                break;
+            }
+            let (next, consumed) = self.set_stringn(
+                column,
+                y,
+                span.content.as_ref(),
+                remaining as usize,
+                line.style.patch(span.style),
+            );
+            column = next;
+            used = used.saturating_add(consumed);
+        }
+        (column, used)
+    }
+
+    /// The cells that changed between `self` (the previous frame) and `next`.
+    ///
+    /// Yields `(x, y, &Cell)` in row-major order. Both buffers must share the
+    /// same origin and width; height may differ, in which case the shorter one
+    /// bounds the walk.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the origins or widths differ — that is a caller bug, not a
+    /// recoverable state, and silently diffing mismatched grids would corrupt
+    /// the screen.
+    pub fn diff<'next>(&self, next: &'next Self) -> Vec<(u16, u16, &'next Cell)> {
+        assert!(
+            self.area.x == next.area.x
+                && self.area.y == next.area.y
+                && self.area.width == next.area.width,
+            "diffed buffers must share an origin and width: prev={:?}, next={:?}",
+            self.area,
+            next.area,
+        );
+
+        let len = self.content.len().min(next.content.len());
+        let mut updates = Vec::new();
+        let mut index = 0usize;
+
+        while index < len {
+            let current = &next.content[index];
+            let previous = &self.content[index];
+            let position = index;
+            index += 1;
+
+            if current.is_skipped() {
+                continue;
+            }
+
+            match current.diff_option {
+                CellDiffOption::Skip => {}
+                CellDiffOption::ForcedWidth(width) => {
+                    // The symbol carries escape bytes that occupy `width`
+                    // columns on screen; step over the columns they cover.
+                    index = index.saturating_add(width.get().saturating_sub(1) as usize);
+                    if current != previous {
+                        let (x, y) = next.pos_of(position);
+                        updates.push((x, y, current));
+                    }
+                }
+                CellDiffOption::None | CellDiffOption::AlwaysUpdate => {
+                    let width = current.cell_width() as usize;
+                    let unchanged =
+                        matches!(current.diff_option, CellDiffOption::None) && current == previous;
+                    if unchanged {
+                        index += width.saturating_sub(1);
+                        continue;
+                    }
+
+                    let previous_width = previous.cell_width() as usize;
+                    let (x, y) = next.pos_of(position);
+                    updates.push((x, y, current));
+
+                    if width > 1 {
+                        // The wide cluster covers its placeholder column; the
+                        // terminal paints both from the one write.
+                        index += width - 1;
+                    } else if previous_width > width
+                        && (previous.bg != Color::Reset
+                            || previous.modifier.intersection(VISIBLE_ON_BLANK)
+                                != Modifier::empty())
+                    {
+                        // A wide cluster with visible background or decoration
+                        // was replaced by a narrow one. Some terminals leave the
+                        // old styling on the freed column, so refresh every cell
+                        // it used to cover whether or not the buffer changed.
+                        let end = (position + previous_width).min(len);
+                        for trailing in (position + 1)..end {
+                            if !next.content[trailing].is_skipped() {
+                                let (tx, ty) = next.pos_of(trailing);
+                                updates.push((tx, ty, &next.content[trailing]));
+                            }
+                        }
+                        index = end;
+                    }
+                }
+            }
+        }
+
+        updates
+    }
+}
+
+/// Modifiers that remain visible on a blank cell, so a stale one must be
+/// actively cleared rather than left to be overwritten by a space.
+const VISIBLE_ON_BLANK: Modifier = Modifier::REVERSED
+    .union(Modifier::UNDERLINED)
+    .union(Modifier::SLOW_BLINK)
+    .union(Modifier::RAPID_BLINK)
+    .union(Modifier::CROSSED_OUT);
+
+impl<P: Into<Position>> std::ops::Index<P> for Buffer {
+    type Output = Cell;
+
+    #[track_caller]
+    fn index(&self, position: P) -> &Self::Output {
+        let position = position.into();
+        self.cell(position)
+            .expect("position out of the buffer's area")
+    }
+}
+
+impl<P: Into<Position>> std::ops::IndexMut<P> for Buffer {
+    #[track_caller]
+    fn index_mut(&mut self, position: P) -> &mut Self::Output {
+        let area = self.area;
+        self.cell_mut(position).unwrap_or_else(|| {
+            panic!("position out of the buffer's area {area:?}");
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(buffer: &Buffer, y: u16) -> String {
+        (buffer.area.x..buffer.area.right())
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn empty_cells_render_as_spaces() {
+        let buffer = Buffer::empty(Rect::new(0, 0, 3, 1));
+        assert_eq!(row(&buffer, 0), "   ");
+    }
+
+    #[test]
+    fn set_string_writes_and_returns_the_next_column() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 6, 1));
+        let next = buffer.set_string(1, 0, "abc", Style::default());
+        assert_eq!(next, 4);
+        assert_eq!(row(&buffer, 0), " abc  ");
+    }
+
+    /// The wide-grapheme invariant: the cluster sits in its leading cell and the
+    /// next cell is an empty placeholder, never a duplicate.
+    #[test]
+    fn a_wide_grapheme_blanks_its_trailing_cell() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+        buffer.set_string(0, 0, "日本", Style::default());
+        assert_eq!(buffer[(0, 0)].symbol(), "日");
+        assert_eq!(buffer[(1, 0)].raw_symbol(), "");
+        assert_eq!(buffer[(2, 0)].symbol(), "本");
+        assert_eq!(buffer[(3, 0)].raw_symbol(), "");
+    }
+
+    /// Half a wide grapheme must not be written: it would desynchronize every
+    /// column after it.
+    #[test]
+    fn a_wide_grapheme_that_does_not_fit_is_dropped() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 1));
+        let (next, used) = buffer.set_stringn(0, 0, "a日", 2, Style::default());
+        assert_eq!(used, 1, "only the narrow grapheme fits in two columns");
+        assert_eq!(next, 1);
+        assert_eq!(buffer[(1, 0)].symbol(), " ");
+    }
+
+    #[test]
+    fn set_string_clips_at_the_area_edge() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 1));
+        buffer.set_string(1, 0, "abcdef", Style::default());
+        assert_eq!(row(&buffer, 0), " ab");
+    }
+
+    #[test]
+    fn zero_width_clusters_consume_no_columns() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+        let (next, used) = buffer.set_stringn(0, 0, "a\u{0301}b", 4, Style::default());
+        assert_eq!(used, 2, "the combining acute joins its base grapheme");
+        assert_eq!(next, 2);
+    }
+
+    /// The inline/heap split must be invisible: a cluster longer than the
+    /// inline capacity still round-trips exactly.
+    #[test]
+    fn a_symbol_too_long_to_inline_spills_to_the_heap() {
+        let long = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+        assert!(
+            long.len() > SYMBOL_INLINE_CAP,
+            "corpus must exceed the inline cap"
+        );
+        let mut cell = Cell::default();
+        cell.set_symbol(long);
+        assert_eq!(cell.symbol(), long);
+        assert!(matches!(cell.symbol, Symbol::Heap(_)));
+    }
+
+    #[test]
+    fn a_short_symbol_stays_inline() {
+        let mut cell = Cell::default();
+        cell.set_symbol("\u{1F600}");
+        assert_eq!(cell.symbol(), "\u{1F600}");
+        assert!(matches!(cell.symbol, Symbol::Inline { .. }));
+    }
+
+    /// Overwriting a heap symbol with a short one must return to inline storage,
+    /// or a cell would keep an allocation it no longer needs.
+    #[test]
+    fn overwriting_a_heap_symbol_returns_to_inline() {
+        let long = "x".repeat(SYMBOL_INLINE_CAP + 8);
+        let mut cell = Cell::default();
+        cell.set_symbol(&long);
+        cell.set_symbol("a");
+        assert_eq!(cell.symbol(), "a");
+        assert!(matches!(cell.symbol, Symbol::Inline { .. }));
+    }
+
+    #[test]
+    fn indexing_uses_absolute_coordinates() {
+        let mut buffer = Buffer::empty(Rect::new(5, 5, 2, 2));
+        buffer[(5, 5)].set_char('x');
+        assert_eq!(buffer[(5, 5)].symbol(), "x");
+        assert!(buffer.cell((0, 0)).is_none(), "outside the area");
+    }
+
+    #[test]
+    fn an_unchanged_frame_diffs_to_nothing() {
+        let buffer = Buffer::empty(Rect::new(0, 0, 4, 2));
+        assert!(buffer.diff(&buffer.clone()).is_empty());
+    }
+
+    #[test]
+    fn diff_yields_only_changed_cells() {
+        let previous = Buffer::empty(Rect::new(0, 0, 4, 1));
+        let mut next = previous.clone();
+        next[(2, 0)].set_char('x');
+        let updates = previous.diff(&next);
+        assert_eq!(updates.len(), 1);
+        assert_eq!((updates[0].0, updates[0].1), (2, 0));
+    }
+
+    /// A skipped cell is owned by something outside the grid (an image), so the
+    /// diff must never write over it even when the buffer says it changed.
+    #[test]
+    fn a_skipped_cell_is_never_emitted() {
+        let previous = Buffer::empty(Rect::new(0, 0, 3, 1));
+        let mut next = previous.clone();
+        next[(1, 0)].set_char('x');
+        next[(1, 0)].set_diff_option(CellDiffOption::Skip);
+        assert!(previous.diff(&next).is_empty());
+    }
+
+    #[test]
+    fn always_update_emits_an_unchanged_cell() {
+        let previous = Buffer::empty(Rect::new(0, 0, 2, 1));
+        let mut next = previous.clone();
+        next[(0, 0)].set_diff_option(CellDiffOption::AlwaysUpdate);
+        let updates = previous.diff(&next);
+        assert_eq!(updates.len(), 1);
+    }
+
+    /// The OSC 8 case: a symbol full of escape bytes that must be billed one
+    /// column, not the width of the escape text.
+    #[test]
+    fn forced_width_bills_the_declared_columns() {
+        let previous = Buffer::empty(Rect::new(0, 0, 3, 1));
+        let mut next = previous.clone();
+        next[(0, 0)].set_symbol("\u{1b}]8;;http://x\u{1b}\\a");
+        next[(0, 0)].set_diff_option(CellDiffOption::ForcedWidth(NonZeroU16::new(1).unwrap()));
+        let updates = previous.diff(&next);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(next[(0, 0)].cell_width(), 1);
+    }
+
+    /// Replacing a styled wide grapheme with a narrow one has to refresh the
+    /// column it vacated, or the old background lingers there.
+    #[test]
+    fn a_narrowed_wide_cell_refreshes_its_vacated_column() {
+        let mut previous = Buffer::empty(Rect::new(0, 0, 3, 1));
+        previous[(0, 0)].set_symbol("日");
+        previous[(0, 0)].set_bg(Color::Blue);
+        let mut next = Buffer::empty(Rect::new(0, 0, 3, 1));
+        next[(0, 0)].set_char('a');
+
+        let updates = previous.diff(&next);
+        let columns: Vec<u16> = updates.iter().map(|(x, _, _)| *x).collect();
+        assert!(columns.contains(&0));
+        assert!(
+            columns.contains(&1),
+            "the freed column must be refreshed, got {columns:?}"
+        );
+    }
+
+    /// The same replacement with no visible styling needs no extra write —
+    /// otherwise every frame would bloat with redundant updates.
+    #[test]
+    fn a_narrowed_unstyled_wide_cell_needs_no_extra_write() {
+        let mut previous = Buffer::empty(Rect::new(0, 0, 3, 1));
+        previous[(0, 0)].set_symbol("日");
+        let mut next = Buffer::empty(Rect::new(0, 0, 3, 1));
+        next[(0, 0)].set_char('a');
+
+        let updates = previous.diff(&next);
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].0, 0);
+    }
+
+    #[test]
+    fn set_style_repaints_an_area_without_touching_symbols() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 2));
+        buffer.set_string(0, 0, "ab", Style::default());
+        buffer.set_style(Rect::new(0, 0, 2, 1), Style::new().bg(Color::Blue));
+        assert_eq!(buffer[(0, 0)].symbol(), "a");
+        assert_eq!(buffer[(0, 0)].bg, Color::Blue);
+        assert_eq!(buffer[(2, 0)].bg, Color::Reset, "outside the area");
+    }
+
+    #[test]
+    fn set_style_clips_an_oversized_area() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 1));
+        buffer.set_style(Rect::new(0, 0, 99, 99), Style::new().bg(Color::Blue));
+        assert_eq!(buffer[(1, 0)].bg, Color::Blue);
+    }
+
+    #[test]
+    fn resize_changes_the_area_and_cell_count() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 1));
+        buffer.resize(Rect::new(0, 0, 3, 2));
+        assert_eq!(buffer.area, Rect::new(0, 0, 3, 2));
+        assert_eq!(buffer.content.len(), 6);
+    }
+
+    /// Resizing to the same area must not touch a single cell. A
+    /// [`Terminal`](crate::term::terminal::Terminal) skips its repaint when the
+    /// dimensions have not changed, so clearing here would blank the screen
+    /// with nothing left to restore it.
+    #[test]
+    fn resizing_to_the_same_area_preserves_every_cell() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 2));
+        buffer.set_string(0, 0, "abc", Style::default());
+        buffer.resize(Rect::new(0, 0, 3, 2));
+        assert_eq!(buffer[(0, 0)].symbol(), "a");
+        assert_eq!(buffer[(2, 0)].symbol(), "c");
+    }
+
+    #[test]
+    fn growing_keeps_existing_cells_and_blanks_the_rest() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 1));
+        buffer.set_string(0, 0, "ab", Style::default());
+        buffer.resize(Rect::new(0, 0, 2, 2));
+        assert_eq!(buffer[(0, 0)].symbol(), "a");
+        assert_eq!(buffer[(1, 0)].symbol(), "b");
+        assert_eq!(buffer[(0, 1)].symbol(), " ");
+    }
+
+    #[test]
+    fn shrinking_truncates_rather_than_clearing() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 2, 2));
+        buffer.set_string(0, 0, "ab", Style::default());
+        buffer.resize(Rect::new(0, 0, 2, 1));
+        assert_eq!(buffer.content.len(), 2);
+        assert_eq!(buffer[(0, 0)].symbol(), "a");
+    }
+
+    #[test]
+    fn merge_grows_the_area_and_lets_the_other_win() {
+        let mut base = Buffer::empty(Rect::new(0, 0, 2, 1));
+        base[(0, 0)].set_char('a');
+        let mut overlay = Buffer::empty(Rect::new(1, 0, 2, 1));
+        overlay[(1, 0)].set_char('b');
+
+        base.merge(&overlay);
+        assert_eq!(base.area, Rect::new(0, 0, 3, 1));
+        assert_eq!(base[(0, 0)].symbol(), "a");
+        assert_eq!(base[(1, 0)].symbol(), "b");
+    }
+
+    #[test]
+    fn set_style_leaves_unset_fields_alone() {
+        let mut cell = Cell::new("x");
+        cell.set_bg(Color::Blue);
+        cell.set_style(Style::new().fg(Color::Red));
+        assert_eq!(cell.fg, Color::Red);
+        assert_eq!(cell.bg, Color::Blue);
+    }
+
+    #[test]
+    fn with_lines_builds_a_grid_sized_to_the_widest_row() {
+        let buffer = Buffer::with_lines(["ab", "cdef"]);
+        assert_eq!(buffer.area, Rect::new(0, 0, 4, 2));
+        assert_eq!(row(&buffer, 0), "ab  ");
+        assert_eq!(row(&buffer, 1), "cdef");
+    }
+}

--- a/src/components/activity.rs
+++ b/src/components/activity.rs
@@ -5,8 +5,8 @@
 //! question of *how much* of one measurable step is complete; an activity item
 //! may include that fraction and the list composes a bar beneath the status row.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 
 use crate::geometry::Size;
 use crate::style::SemanticRole;

--- a/src/components/app_shell.rs
+++ b/src/components/app_shell.rs
@@ -1,6 +1,6 @@
 //! Responsive application chrome for tool-style terminal UIs.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::layout::{Dimension, FlexItemStyle, Item, LayoutStyle, solve};

--- a/src/components/ascii_font.rs
+++ b/src/components/ascii_font.rs
@@ -6,8 +6,8 @@
 //! banner/headline analog of OpenTUI's `ASCIIFont`, kept dependency-free by
 //! bundling one compact font rather than parsing FIGlet files.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Style};
+use crate::geometry::Rect;
+use crate::style::{Color, Style};
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/src/components/boxed.rs
+++ b/src/components/boxed.rs
@@ -4,9 +4,10 @@
 //! explicit color for semantic frames (accent/danger modals, per-pane colors).
 //! This is `tuika`'s framing primitive (Pi's `DynamicBorder` / `Box`).
 
-use ratatui_core::layout::{Alignment, Rect};
-use ratatui_core::style::{Color, Style};
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::{Color, Style};
+use crate::text::Alignment;
+use crate::text::Line;
 
 use crate::geometry::{Padding, Size};
 use crate::style::{BorderStyle, Role};
@@ -273,11 +274,11 @@ mod tests {
     use super::*;
     use crate::Surface;
     use crate::components::Text;
+    use crate::style::{Color, Modifier};
     use crate::style::{StyleBundle, StyleSheet, Theme};
     use crate::tests::support::{buffer, rainbow_theme, row};
+    use crate::text::Span;
     use crate::view::{RenderCtx, View, element};
-    use ratatui_core::style::{Color, Modifier};
-    use ratatui_core::text::Span;
 
     #[test]
     fn boxed_border_closed_across_sizes() {

--- a/src/components/code_block.rs
+++ b/src/components/code_block.rs
@@ -11,9 +11,9 @@
 //! width, never word-wrapped) because indentation is meaningful in code — unlike
 //! prose, which [`Markdown`](crate::components::Markdown) word-wraps.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
-use ratatui_core::text::{Line, Span};
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
+use crate::text::{Line, Span};
 
 use crate::components::text::line_width;
 use crate::geometry::Size;

--- a/src/components/completion.rs
+++ b/src/components/completion.rs
@@ -6,8 +6,8 @@
 //! it here, then replace the token with [`CompletionItem::replacement`] when
 //! handling [`InputOutcome::Submitted`](crate::InputOutcome::Submitted).
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 
 use crate::event::{Event, InputOutcome};
 use crate::geometry::{Padding, Size};

--- a/src/components/console.rs
+++ b/src/components/console.rs
@@ -15,8 +15,8 @@ use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/src/components/constrained.rs
+++ b/src/components/constrained.rs
@@ -1,6 +1,6 @@
 //! Intrinsic min/max sizing for responsive flex children.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 

--- a/src/components/dialog_presets.rs
+++ b/src/components/dialog_presets.rs
@@ -1,8 +1,8 @@
 //! Stateful dialog presets assembled from [`Dialog`](super::Dialog) and the
 //! ordinary input components.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::text::Line;
 
 use crate::components::text::wrap_str;
 use crate::event::{Event, InputOutcome, KeyCode};

--- a/src/components/diff.rs
+++ b/src/components/diff.rs
@@ -9,8 +9,8 @@
 //! The diff itself ([`rows`]) is a pure function, so classification is
 //! testable without rendering.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Modifier, Style};
+use crate::geometry::Rect;
+use crate::style::{Color, Modifier, Style};
 
 use crate::geometry::Size;
 use crate::style::StyleRole;

--- a/src/components/flex.rs
+++ b/src/components/flex.rs
@@ -6,8 +6,8 @@
 //! child into its rect through a clipped child surface. Nesting `Flex`es is how
 //! every screen is built.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 
 use crate::geometry::Size;
 use crate::layout::{AlignContent, Dimension, FlexItemStyle, FlexWrap, Item, LayoutStyle, solve};
@@ -237,7 +237,7 @@ impl<V: View> Flex<V> {
     ///
     /// ```
     /// use tuika::prelude::*;
-    /// use ratatui_core::layout::Rect;
+    /// use tuika::ui::Rect;
     ///
     /// let flex = Flex::row()
     ///     .fixed(4, element(Text::raw("abcd")))

--- a/src/components/flow.rs
+++ b/src/components/flow.rs
@@ -1,6 +1,6 @@
 //! Wrapping content flow built on flex lines.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::{Padding, Size};
 use crate::layout::{Align, AlignContent, FlexItemStyle, FlexWrap};

--- a/src/components/focus_scope.rs
+++ b/src/components/focus_scope.rs
@@ -10,7 +10,7 @@
 //! focus-aware view inside it (notably [`Boxed`](crate::components::Boxed)) recolors
 //! accordingly.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -82,7 +82,7 @@ mod tests {
 
     /// The focus flag a `FocusScope` imposes on its subtree wins over the root
     /// context's flag — a `Boxed` inside picks the matching theme border color.
-    fn corner_color(scope_focused: bool, root_focused: bool) -> ratatui_core::style::Color {
+    fn corner_color(scope_focused: bool, root_focused: bool) -> crate::style::Color {
         let t = rainbow_theme();
         let mut buf = buffer(8, 3);
         let area = buf.area;

--- a/src/components/form.rs
+++ b/src/components/form.rs
@@ -1,6 +1,6 @@
 //! Responsive labeled-form composition.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::event::{Event, InputOutcome, KeyCode};
 use crate::geometry::Size;

--- a/src/components/grid.rs
+++ b/src/components/grid.rs
@@ -1,6 +1,6 @@
 //! A deliberately small row-major terminal grid.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::{Padding, Size};
 use crate::surface::Surface;

--- a/src/components/image.rs
+++ b/src/components/image.rs
@@ -7,8 +7,8 @@
 //! into an [`ImageLayer`] and emitted after the frame by
 //! [`term::image`](crate::term::image), which owns the graphics protocols.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/src/components/item_scroll.rs
+++ b/src/components/item_scroll.rs
@@ -22,8 +22,8 @@
 
 use std::cell::RefCell;
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::style::{StyleSheet, Theme};
@@ -349,7 +349,7 @@ fn render_scrolled<V: View>(
         return;
     }
     let destination = Rect::new(x, y, width, visible);
-    surface.render_ratatui(destination, |dst, buffer| {
+    surface.render_scratch(destination, |dst, buffer| {
         let window = Rect::new(0, hidden, width, dst.height);
         let mut scratch = Buffer::empty(window);
         // Seed the window with what is already on screen, so an item that paints
@@ -379,8 +379,8 @@ mod tests {
     use crate::components::{Boxed, Text};
     use crate::style::Theme;
     use crate::tests::support::{buffer, row};
+    use crate::text::Line;
     use crate::view::element;
-    use ratatui_core::text::Line;
 
     /// `n` items, each a `rows`-tall block of numbered lines.
     fn blocks(n: usize, rows: usize) -> Vec<Element> {
@@ -553,7 +553,7 @@ mod tests {
             }
             fn render(&self, area: Rect, surface: &mut Surface, _ctx: &RenderCtx) {
                 for y in area.y..area.bottom().min(area.y.saturating_add(4)) {
-                    surface.set_string(area.x, y, "greedy", ratatui_core::style::Style::default());
+                    surface.set_string(area.x, y, "greedy", crate::style::Style::default());
                 }
             }
         }

--- a/src/components/key_hints.rs
+++ b/src/components/key_hints.rs
@@ -1,10 +1,10 @@
 //! Compact, responsive key/action hints and complete keymap help.
 
+use crate::geometry::Rect;
 use crate::keymap::{Hint, Keymap};
 use crate::style::StyleRole;
 use crate::width::str_cols;
 use crate::{RenderCtx, Size, Surface, View};
-use ratatui_core::layout::Rect;
 
 /// A key/action hint with a responsive fitting priority.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -244,9 +244,9 @@ impl View for KeymapHelp {
 mod tests {
     use super::*;
     use crate::keymap::Layer;
+    use crate::style::Color;
     use crate::testing::{grid, render, render_sizes};
     use crate::{Size, Theme};
-    use ratatui_core::style::Color;
 
     #[test]
     fn key_hints_measure_unicode_by_terminal_width() {

--- a/src/components/keyed_table.rs
+++ b/src/components/keyed_table.rs
@@ -11,9 +11,9 @@
 use std::collections::BTreeSet;
 use std::marker::PhantomData;
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Line;
 
 use crate::event::{Event, InputOutcome, KeyCode, MouseButton, MouseKind};
 use crate::geometry::Size;
@@ -1262,8 +1262,8 @@ mod tests {
     use std::rc::Rc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use ratatui_core::style::{Color, Style};
-    use ratatui_core::text::Span;
+    use crate::style::{Color, Style};
+    use crate::text::Span;
 
     use super::*;
     use crate::event::{Key, Mouse};

--- a/src/components/loader.rs
+++ b/src/components/loader.rs
@@ -4,7 +4,7 @@
 //! [`Boxed`](super::Boxed) when they want a frame; on its own it fits inline in
 //! a status row or overlay.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/src/components/markdown/flatten.rs
+++ b/src/components/markdown/flatten.rs
@@ -5,8 +5,8 @@
 //! meaningful. Tables are wide enough a concern to live in
 //! [`table`](super::table).
 
-use ratatui_core::style::Style;
-use ratatui_core::text::{Line, Span};
+use crate::style::Style;
+use crate::text::{Line, Span};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::style::{StyleSheet, Theme};

--- a/src/components/markdown/html.rs
+++ b/src/components/markdown/html.rs
@@ -18,7 +18,7 @@
 //! [`Event::InlineHtml`]: pulldown_cmark::Event::InlineHtml
 //! [`Event::Html`]: pulldown_cmark::Event::Html
 
-use ratatui_core::style::Modifier;
+use crate::style::Modifier;
 
 use crate::style::Role;
 

--- a/src/components/markdown/image.rs
+++ b/src/components/markdown/image.rs
@@ -4,7 +4,7 @@
 //! [`ImageResolver`]), so this module owns the boundary between the two: what a
 //! resolved image costs in cells, and where it lands once the frame is painted.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::term::image::ImageData;
 
@@ -78,11 +78,11 @@ mod tests {
     use super::super::{Markdown, to_lines};
     use super::*;
 
+    use crate::geometry::Rect;
     use crate::highlight::CodeHighlighter;
+    use crate::style::Modifier;
     use crate::style::{StyleSheet, Theme};
     use crate::term::image::{ImageData, ImageLayer, ImageSupport};
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::Modifier;
 
     #[test]
     fn image_renders_alt_as_a_marked_placeholder() {

--- a/src/components/markdown/item.rs
+++ b/src/components/markdown/item.rs
@@ -4,9 +4,9 @@
 //! apart is what makes streaming affordable: a settled block is parsed once and
 //! only re-flattened when the render width changes.
 
+use crate::style::Style;
+use crate::text::Span;
 use pulldown_cmark::Alignment;
-use ratatui_core::style::Style;
-use ratatui_core::text::Span;
 
 use crate::components::code_block::CodeRow;
 use crate::term::image::ImageData;

--- a/src/components/markdown/mod.rs
+++ b/src/components/markdown/mod.rs
@@ -44,7 +44,7 @@
 //! The submodules are private: `components::markdown` is the one path in, and
 //! `to_lines`, `MarkdownState`, and `Markdown` are what it exposes.
 
-use ratatui_core::text::Line;
+use crate::text::Line;
 
 use crate::highlight::CodeHighlighter;
 use crate::style::{StyleSheet, Theme};
@@ -329,10 +329,10 @@ mod tests {
     use crate::style::StyleBundle;
     use crate::style::{StyleSheet, Theme};
     use crate::term::hyperlink::LinkPolicy;
-    use ratatui_core::text::Span;
+    use crate::text::Span;
 
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::Modifier;
+    use crate::geometry::Rect;
+    use crate::style::Modifier;
 
     #[test]
     fn heading_is_bold_and_themed() {
@@ -594,7 +594,7 @@ mod tests {
             (language == "diagram").then(|| {
                 vec![Line::from(Span::styled(
                     format!("rendered at {}: {source}", context.width),
-                    ratatui_core::style::Style::default().fg(context.theme.accent),
+                    crate::style::Style::default().fg(context.theme.accent),
                 ))]
             })
         }
@@ -642,7 +642,7 @@ mod tests {
 
     #[test]
     fn fenced_block_renderer_receives_the_active_stylesheet() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
 
         struct StyledFence;
         impl MarkdownBlockRenderer for StyledFence {
@@ -748,10 +748,10 @@ mod tests {
         // Reproduction of the Ghostty Ctrl+click failure: `[label](url)` was
         // only styled — the destination was dropped — so OSC 8 / ctrl_click had
         // nothing to open under the pointer.
+        use crate::buffer::Buffer;
+        use crate::geometry::Position;
         use crate::term::hyperlink::{apply_buffer_links, ctrl_click_url};
         use crate::{Mouse, MouseButton, MouseKind};
-        use ratatui_core::buffer::Buffer;
-        use ratatui_core::layout::Position;
 
         let theme = Theme::default();
         let (lines, links) = to_linked_lines(
@@ -807,7 +807,7 @@ mod tests {
 
     #[test]
     fn custom_sheet_restyles_both_links_and_bare_urls() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let theme = Theme::default();
         // One central rule remaps the link role: green + bold, no underline.
         let sheet = StyleSheet {
@@ -842,7 +842,7 @@ mod tests {
 
     #[test]
     fn custom_sheet_restyles_headings() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let theme = Theme::default();
         let sheet = StyleSheet {
             heading: StyleBundle::new().fg(Color::Magenta).italic(),
@@ -919,7 +919,7 @@ mod tests {
     fn inline_html_follows_a_restyled_role() {
         // The point of routing tags through the stylesheet: a host that restyles
         // `strong` restyles `<b>` with it, without knowing HTML exists.
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let theme = Theme::default();
         let sheet = StyleSheet {
             strong: StyleBundle::new().fg(Color::Green),
@@ -1006,7 +1006,7 @@ mod tests {
             (!text.is_empty()).then(|| {
                 vec![Line::from(Span::styled(
                     format!("[{}] {text}", context.width),
-                    ratatui_core::style::Style::default().fg(context.theme.accent),
+                    crate::style::Style::default().fg(context.theme.accent),
                 ))]
             })
         }

--- a/src/components/markdown/parse.rs
+++ b/src/components/markdown/parse.rs
@@ -5,8 +5,8 @@
 //! output carries styles but not line breaks; [`flatten`](super::flatten) adds
 //! those.
 
+use crate::style::{Modifier, Style};
 use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
-use ratatui_core::style::{Modifier, Style};
 
 use crate::components::code_block::code_block_rows;
 use crate::highlight::CodeHighlighter;

--- a/src/components/markdown/stream.rs
+++ b/src/components/markdown/stream.rs
@@ -5,7 +5,7 @@
 //! the in-flight tail. Without it a streamed render is O(n²) in transcript
 //! length — see the comments on the cache fields.
 
-use ratatui_core::text::Line;
+use crate::text::Line;
 
 use crate::highlight::CodeHighlighter;
 use crate::style::{StyleSheet, Theme};
@@ -417,7 +417,7 @@ mod tests {
     use crate::highlight::CodeHighlighter;
     use crate::style::{StyleSheet, Theme};
 
-    use ratatui_core::text::Line;
+    use crate::text::Line;
     use std::cell::Cell;
     use std::rc::Rc;
 
@@ -449,7 +449,7 @@ mod tests {
 
     #[test]
     fn sheet_change_invalidates_stream_cache() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let theme = Theme::default();
         let mut state = MarkdownState::new();
         state.set("A [link](https://ex.com) in prose.");
@@ -599,7 +599,7 @@ mod tests {
         let sheet = StyleSheet::from_theme(&theme);
         // Compare the *styles* too: a leaked scope changes how the tail is
         // painted without changing a single character of it.
-        let styled = |lines: &[Line<'static>]| -> Vec<(String, ratatui_core::style::Style)> {
+        let styled = |lines: &[Line<'static>]| -> Vec<(String, crate::style::Style)> {
             lines
                 .iter()
                 .flat_map(|l| &l.spans)
@@ -833,7 +833,7 @@ mod tests {
         assert!(state.stable_len > 0);
 
         let mut b = Theme::default();
-        b.code.heading = ratatui_core::style::Color::Indexed(200);
+        b.code.heading = crate::style::Color::Indexed(200);
         let _ = state.lines(40, &b, &StyleSheet::from_theme(&b), CodeHighlighter::Plain);
         // Cache was rebuilt under the new theme; still consistent, no stale panic.
         assert_eq!(state.cached_theme, Some(b));

--- a/src/components/markdown/table.rs
+++ b/src/components/markdown/table.rs
@@ -4,8 +4,8 @@
 //! fitting columns to a width, drawing box rules, and degrading to a plain
 //! layout when the table cannot fit is a third of that pass on its own.
 
+use crate::style::Style;
 use pulldown_cmark::Alignment;
-use ratatui_core::style::Style;
 
 use crate::style::Theme;
 use crate::term::hyperlink::BufferLink;
@@ -213,9 +213,9 @@ mod tests {
 
     use crate::highlight::CodeHighlighter;
     use crate::style::{StyleSheet, Theme};
-    use ratatui_core::text::Span;
+    use crate::text::Span;
 
-    use ratatui_core::style::Modifier;
+    use crate::style::Modifier;
 
     #[test]
     fn table_renders_boxed_with_headers() {

--- a/src/components/markdown/testutil.rs
+++ b/src/components/markdown/testutil.rs
@@ -4,7 +4,7 @@
 //! against the same rendered output, so the two render helpers and the stub
 //! image resolver live here rather than being copied four times.
 
-use ratatui_core::text::Line;
+use crate::text::Line;
 
 use crate::highlight::CodeHighlighter;
 use crate::style::{StyleSheet, Theme};

--- a/src/components/markdown/view.rs
+++ b/src/components/markdown/view.rs
@@ -3,8 +3,8 @@
 //! A thin `View` over the same two passes, for static markdown. Streaming hosts
 //! hold a [`MarkdownState`](super::MarkdownState) instead and draw its lines.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::text::Line;
 
 use crate::components::Image;
 use crate::components::text::line_width;
@@ -209,10 +209,10 @@ impl View for Markdown<'_> {
 mod tests {
     use super::*;
     use crate::components::{MarkdownBlock, MarkdownBlockContext, MarkdownBlockRenderer};
+    use crate::style::Color;
     use crate::style::StyleBundle;
     use crate::testing::{grid, render_with_sheet};
-    use ratatui_core::style::Color;
-    use ratatui_core::text::{Line, Span};
+    use crate::text::{Line, Span};
 
     struct ContextBlock;
 

--- a/src/components/progress_bar.rs
+++ b/src/components/progress_bar.rs
@@ -4,8 +4,8 @@
 //! bar shows 160 distinct levels. Indeterminate bars slide a bright segment
 //! across a dim track, driven by the host frame counter (see [`crate::anim`]).
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 
 use crate::anim;
 use crate::geometry::Size;
@@ -28,8 +28,8 @@ pub struct ProgressBar {
     show_percent: bool,
     label: Option<String>,
     label_style: Option<Style>,
-    filled: Option<ratatui_core::style::Color>,
-    track: Option<ratatui_core::style::Color>,
+    filled: Option<crate::style::Color>,
+    track: Option<crate::style::Color>,
 }
 
 impl ProgressBar {
@@ -84,11 +84,7 @@ impl ProgressBar {
     }
 
     /// Override the filled and track colors (default to theme accent and dim).
-    pub fn colors(
-        mut self,
-        filled: ratatui_core::style::Color,
-        track: ratatui_core::style::Color,
-    ) -> Self {
+    pub fn colors(mut self, filled: crate::style::Color, track: crate::style::Color) -> Self {
         self.filled = Some(filled);
         self.track = Some(track);
         self
@@ -219,10 +215,10 @@ impl View for ProgressBar {
 mod tests {
     use super::*;
     use crate::Surface;
+    use crate::style::Color;
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
     use crate::view::{RenderCtx, View};
-    use ratatui_core::style::Color;
 
     #[test]
     fn progress_bar_determinate_fills_by_fraction() {
@@ -271,7 +267,7 @@ mod tests {
         let theme = Theme::default();
         let style = Style::default()
             .fg(Color::Cyan)
-            .add_modifier(ratatui_core::style::Modifier::ITALIC);
+            .add_modifier(crate::style::Modifier::ITALIC);
         let bar = ProgressBar::determinate(0.5)
             .colors(Color::Green, Color::Black)
             .label("0:42")
@@ -284,7 +280,7 @@ mod tests {
             assert!(
                 buf[(x, 0)]
                     .modifier
-                    .contains(ratatui_core::style::Modifier::ITALIC),
+                    .contains(crate::style::Modifier::ITALIC),
                 "caption italic at {x}"
             );
         }

--- a/src/components/qr.rs
+++ b/src/components/qr.rs
@@ -13,8 +13,8 @@
 //! (dark modules black, light modules white by default, for scanner contrast),
 //! surrounded by the mandatory 4-module quiet zone.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Style};
+use crate::geometry::Rect;
+use crate::style::{Color, Style};
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/src/components/responsive.rs
+++ b/src/components/responsive.rs
@@ -1,6 +1,6 @@
 //! Width-driven view selection for responsive terminal layouts.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 

--- a/src/components/rule.rs
+++ b/src/components/rule.rs
@@ -6,9 +6,9 @@
 //! the reusable form of the blue/gold separators a chat UI draws above and
 //! below its composer.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::{Line, Span};
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::{Line, Span};
 
 use super::text::line_width;
 use crate::geometry::Size;
@@ -95,9 +95,9 @@ impl View for Rule {
 mod tests {
     use super::*;
     use crate::style::Theme;
+    use crate::style::{Color, Style};
     use crate::tests::support::row;
-    use ratatui_core::style::{Color, Style};
-    use ratatui_core::text::{Line, Span};
+    use crate::text::{Line, Span};
 
     #[test]
     fn rule_renders_title_then_fills_to_width() {

--- a/src/components/scroll.rs
+++ b/src/components/scroll.rs
@@ -23,8 +23,8 @@
 //! [`Scroll::wrap`] reflows owned styled lines at the assigned width before
 //! windowing, for prose that must both wrap and scroll.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::text::Line;
 
 use crate::event::{Event, InputOutcome, KeyCode, MouseKind};
 use crate::geometry::Size;
@@ -423,12 +423,12 @@ mod tests {
     use super::*;
     use crate::Surface;
     use crate::event::{Event, InputOutcome, Key, KeyCode, Mouse, MouseKind};
+    use crate::style::Color;
+    use crate::style::Style;
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
+    use crate::text::{Line, Span};
     use crate::view::{RenderCtx, View};
-    use ratatui_core::style::Color;
-    use ratatui_core::style::Style;
-    use ratatui_core::text::{Line, Span};
 
     #[test]
     fn scroll_sticks_to_bottom_until_scrolled_up() {

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -6,9 +6,9 @@
 //! Enter is surfaced as [`InputOutcome::Submitted`] so the caller decides what
 //! "confirm" means.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Line;
 
 use crate::event::{Event, InputOutcome, KeyCode, MouseButton, MouseKind};
 use crate::geometry::Size;
@@ -478,7 +478,7 @@ impl MultiSelectState {
 /// # Example
 ///
 /// ```
-/// use ratatui_core::text::Line;
+/// use tuika::ui::Line;
 /// use tuika::prelude::*;
 /// use tuika::testing::{grid, render};
 ///
@@ -771,9 +771,9 @@ mod tests {
     use crate::event::{Event, InputOutcome, Key, KeyCode};
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
+    use crate::text::Line;
     use crate::view::{RenderCtx, View};
     use crate::{Size, Surface};
-    use ratatui_core::text::Line;
 
     #[test]
     fn select_navigation_wraps_and_confirms() {
@@ -937,15 +937,11 @@ mod tests {
     #[test]
     fn select_list_accepts_an_instance_selection_style() {
         let state = SelectState::new();
-        let style = Style::default().fg(ratatui_core::style::Color::Blue);
+        let style = Style::default().fg(crate::style::Color::Blue);
         let list = SelectList::new(vec![Line::from("a")], &state).selection_style(style);
         let buf = crate::testing::render(&list, 5, 1, &Theme::default());
-        assert_eq!(buf[(0, 0)].fg, ratatui_core::style::Color::Blue);
-        assert!(
-            !buf[(0, 0)]
-                .modifier
-                .contains(ratatui_core::style::Modifier::BOLD)
-        );
+        assert_eq!(buf[(0, 0)].fg, crate::style::Color::Blue);
+        assert!(!buf[(0, 0)].modifier.contains(crate::style::Modifier::BOLD));
     }
 
     #[test]
@@ -963,7 +959,7 @@ mod tests {
         assert!(row(&buf, 1).contains("beta"));
         // Selected row carries the selection background.
         assert_eq!(buf[(0, 1)].bg, theme.selection_bg);
-        assert_eq!(buf[(0, 0)].bg, ratatui_core::style::Color::Reset);
+        assert_eq!(buf[(0, 0)].bg, crate::style::Color::Reset);
     }
 
     #[test]

--- a/src/components/selection_screen.rs
+++ b/src/components/selection_screen.rs
@@ -1,8 +1,8 @@
 //! Responsive full-screen selection flows composed from Tuika primitives.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Line;
 
 use super::select::SelectRows;
 use super::{AppShell, SelectState, VirtualWindow};

--- a/src/components/slider.rs
+++ b/src/components/slider.rs
@@ -6,8 +6,8 @@
 //! renders a filled track with a thumb. This is the `StatefulWidget` idiom — the
 //! value survives across frames in the host, the view is rebuilt each frame.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
 
 use crate::event::{Event, InputOutcome, KeyCode};
 use crate::geometry::Size;

--- a/src/components/spacer.rs
+++ b/src/components/spacer.rs
@@ -1,7 +1,7 @@
 //! Spacer — empty, flexible filler. Paints nothing; useful as a
 //! `Dimension::Flex` child to push siblings apart, or fixed to insert a gap.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;

--- a/src/components/spinner.rs
+++ b/src/components/spinner.rs
@@ -4,8 +4,8 @@
 //! for that frame. Pair with a steady tick (yolop advances `busy_frame` every
 //! loop iteration while a turn runs) for smooth motion.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -40,7 +40,7 @@ impl SpinnerStyle {
 pub struct Spinner {
     style: SpinnerStyle,
     frame: u64,
-    color: Option<ratatui_core::style::Color>,
+    color: Option<crate::style::Color>,
 }
 
 impl Spinner {
@@ -60,7 +60,7 @@ impl Spinner {
     }
 
     /// Override the glyph color (defaults to the theme accent).
-    pub fn color(mut self, color: ratatui_core::style::Color) -> Self {
+    pub fn color(mut self, color: crate::style::Color) -> Self {
         self.color = Some(color);
         self
     }

--- a/src/components/status_bar.rs
+++ b/src/components/status_bar.rs
@@ -2,9 +2,9 @@
 //! surface-colored background. Used for the full-screen renderer's model /
 //! mode / token line, mirroring yolop's inline status chrome.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::Span;
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Span;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -105,8 +105,8 @@ mod tests {
     use super::*;
     use crate::Surface;
     use crate::tests::support::{buffer, rainbow_theme};
+    use crate::text::Span;
     use crate::view::{RenderCtx, View};
-    use ratatui_core::text::Span;
 
     #[test]
     fn status_bar_background_is_theme_surface() {

--- a/src/components/tab_select.rs
+++ b/src/components/tab_select.rs
@@ -7,9 +7,9 @@
 //! [`InputOutcome`] contract so the host can react to a change versus an
 //! activation — the value-select analog of OpenTUI's `TabSelect`.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
+use crate::text::Line;
 
 use crate::components::text::line_width;
 use crate::event::{Event, InputOutcome, KeyCode};
@@ -163,7 +163,7 @@ mod tests {
     use crate::event::{Event, Key, KeyCode};
     use crate::style::Theme;
     use crate::tests::support::{rainbow_theme, row};
-    use ratatui_core::text::Line;
+    use crate::text::Line;
 
     fn key(code: KeyCode) -> Event {
         Event::Key(Key::new(code))

--- a/src/components/table.rs
+++ b/src/components/table.rs
@@ -22,9 +22,9 @@
 //! [`SelectList`]: crate::components::SelectList
 //! [`Boxed::border_color`]: crate::components::Boxed::border_color
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Line;
 
 use crate::geometry::Size;
 use crate::layout::{Dimension, Item, LayoutStyle, solve};
@@ -77,7 +77,7 @@ impl Column {
 /// # Example
 ///
 /// ```
-/// use ratatui_core::text::Line;
+/// use tuika::ui::Line;
 /// use tuika::prelude::*;
 /// use tuika::testing::{grid, render};
 ///
@@ -470,9 +470,9 @@ mod tests {
     use crate::event::{Event, Key, KeyCode};
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
+    use crate::text::{Line, Span};
     use crate::view::{RenderCtx, View};
     use crate::{Size, Surface};
-    use ratatui_core::text::{Line, Span};
 
     fn sample() -> (Vec<Column>, Vec<Vec<Line<'static>>>) {
         let cols = vec![Column::auto("name"), Column::auto("kind")];
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn table_header_style_overrides_the_theme_default() {
-        use ratatui_core::style::{Color, Style};
+        use crate::style::{Color, Style};
         let (cols, rows) = sample();
         let t = rainbow_theme();
         let state = SelectState::new();
@@ -716,7 +716,7 @@ mod tests {
 
     #[test]
     fn table_preserve_selection_fg_keeps_cell_colors() {
-        use ratatui_core::style::{Color, Style};
+        use crate::style::{Color, Style};
         let t = rainbow_theme();
         let cols = vec![Column::auto("c")];
         // A color-coded cell on the (only, selected) data row.
@@ -766,7 +766,7 @@ mod tests {
 
     #[test]
     fn table_accepts_an_instance_selection_style() {
-        use ratatui_core::style::{Color, Modifier};
+        use crate::style::{Color, Modifier};
         let (cols, rows) = sample();
         let state = SelectState::new();
         let table =
@@ -778,7 +778,7 @@ mod tests {
 
     #[test]
     fn table_cells_compose_line_style_under_span_style() {
-        use ratatui_core::style::{Color, Modifier};
+        use crate::style::{Color, Modifier};
         let cols = vec![Column::auto("c")];
         let rows = vec![vec![
             Line::from(vec![

--- a/src/components/tabs.rs
+++ b/src/components/tabs.rs
@@ -1,8 +1,8 @@
 //! Focus-independent tab navigation with host-owned selection state.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
+use crate::text::Line;
 
 use crate::{Event, InputOutcome, KeyCode, RenderCtx, Size, Surface, View};
 
@@ -133,7 +133,7 @@ mod tests {
     use crate::event::{Event, InputOutcome, Key, KeyCode};
     use crate::style::Theme;
     use crate::tests::support::row;
-    use ratatui_core::text::Line;
+    use crate::text::Line;
 
     #[test]
     fn tabs_state_wraps_and_tabs_render_selection() {
@@ -154,7 +154,7 @@ mod tests {
         assert!(
             rendered[(10, 0)]
                 .modifier
-                .contains(ratatui_core::style::Modifier::UNDERLINED)
+                .contains(crate::style::Modifier::UNDERLINED)
         );
     }
 }

--- a/src/components/text.rs
+++ b/src/components/text.rs
@@ -16,9 +16,10 @@
 
 use std::ops::Range;
 
-use ratatui_core::layout::{Alignment, Rect};
-use ratatui_core::style::Style;
-use ratatui_core::text::{Line, Span};
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Alignment;
+use crate::text::{Line, Span};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::geometry::Size;
@@ -80,7 +81,7 @@ pub fn line_width(line: &Line) -> u16 {
 ///
 /// ```
 /// use tuika::prelude::*;
-/// use ratatui_core::text::Line;
+/// use tuika::ui::Line;
 /// # use tuika::testing::render;
 /// let view = Text::new(vec![
 ///     Line::from("left"),
@@ -535,26 +536,21 @@ impl View for Wrap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::geometry::Rect;
     use crate::style::Theme;
+    use crate::style::{Color, Modifier, Style};
     use crate::term::hyperlink::ctrl_click_url;
     use crate::tests::support::{buffer, row};
+    use crate::text::{Line, Span};
     use crate::view::{RenderCtx, View};
     use crate::{Mouse, MouseButton, MouseKind, Size, Surface};
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::{Color, Modifier, Style};
-    use ratatui_core::text::{Line, Span};
 
     /// Concatenated text of a line's spans.
     fn line_text(line: &Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
     }
 
-    fn link_at(
-        buffer: &ratatui_core::buffer::Buffer,
-        area: Rect,
-        col: u16,
-        row: u16,
-    ) -> Option<String> {
+    fn link_at(buffer: &crate::buffer::Buffer, area: Rect, col: u16, row: u16) -> Option<String> {
         let mut event = Mouse::at(MouseKind::Up(MouseButton::Left), col, row);
         event.ctrl = true;
         ctrl_click_url(&event, buffer, area)

--- a/src/components/textinput.rs
+++ b/src/components/textinput.rs
@@ -15,8 +15,8 @@
 //! `set_cursor_position`. Hosts can configure whether Enter or Shift+Enter
 //! submits via [`TextInputMode`]; the other chord inserts a newline.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::event::{Event, KeyCode};
@@ -1163,7 +1163,7 @@ impl TextInput {
     /// match into one directly. Where spans overlap, the last one wins.
     ///
     /// ```
-    /// use ratatui_core::style::{Color, Style};
+    /// use tuika::ui::{Color, Style};
     /// use tuika::prelude::*;
     ///
     /// let state = TextInputState::from_text("ship @docs/readme.md");
@@ -1251,12 +1251,12 @@ impl View for TextInput {
 mod tests {
     use super::*;
     use crate::event::{Event, Key, KeyCode};
+    use crate::geometry::Rect;
+    use crate::style::Color;
     use crate::style::Theme;
     use crate::surface::Surface;
     use crate::tests::support::{buffer, render_el, render_view_rows};
     use crate::view::{RenderCtx, element};
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::Color;
 
     #[test]
     fn single_line_normalizes_setter_and_paste_newlines() {

--- a/src/components/toast.rs
+++ b/src/components/toast.rs
@@ -9,8 +9,8 @@
 //! corner. This is the notification analog of OpenTUI's toast system, without a
 //! scheduler.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Modifier};
+use crate::geometry::Rect;
+use crate::style::{Color, Modifier};
 
 use crate::geometry::Size;
 use crate::style::StyleRole;

--- a/src/components/tree_list.rs
+++ b/src/components/tree_list.rs
@@ -2,9 +2,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::Line;
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::Line;
 
 use crate::event::{Event, InputOutcome, KeyCode, MouseButton, MouseKind};
 use crate::geometry::Size;

--- a/src/components/viewport.rs
+++ b/src/components/viewport.rs
@@ -1,7 +1,7 @@
 //! A two-dimensional viewport over any Tuika view.
 
-use ratatui_core::buffer::{Buffer, Cell};
-use ratatui_core::layout::Rect;
+use crate::buffer::{Buffer, Cell};
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -13,7 +13,7 @@ use super::{ScrollState, Scrollbar, VirtualWindow};
 /// A clipped, vertically scrollable and horizontally pannable child view.
 ///
 /// Unlike [`Scroll`](super::Scroll), which is optimized for owned
-/// [`Line`](ratatui_core::text::Line) rows, `Viewport` accepts any child view.
+/// [`Line`](crate::text::Line) rows, `Viewport` accepts any child view.
 /// The host supplies the child's full cell extent and persists offsets in
 /// [`ScrollState`].
 ///
@@ -189,8 +189,8 @@ mod tests {
     use super::*;
     use crate::components::Text;
     use crate::testing::{grid, render};
+    use crate::text::Line;
     use crate::{Theme, element};
-    use ratatui_core::text::Line;
 
     #[test]
     fn viewport_clamps_offsets_and_crops_arbitrary_child() {

--- a/src/components/virtualization.rs
+++ b/src/components/virtualization.rs
@@ -2,8 +2,8 @@
 
 use std::ops::Range;
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::geometry::Rect;
+use crate::style::Style;
 
 use crate::geometry::Size;
 use crate::style::StyleRole;

--- a/src/dock.rs
+++ b/src/dock.rs
@@ -5,7 +5,7 @@
 //! passive panel. The panel's content, focus id, input routing, and chrome stay
 //! with the host.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 /// Screen edge that owns a dock or drawer.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -232,7 +232,7 @@ fn split(area: Rect, panel_width: u16, edge: DockEdge) -> (Rect, Rect) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui_core::layout::Rect;
+    use crate::geometry::Rect;
 
     #[test]
     fn passive_dock_focuses_then_closes() {

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -20,8 +20,8 @@
 //! tuika owns none of the *content* — the host draws into the buffer each frame,
 //! exactly as it owns image decoding and syntax highlighting.
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Color, Style};
+use crate::geometry::Rect;
+use crate::style::{Color, Style};
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -33,6 +33,16 @@ pub type Rgba = [u8; 4];
 
 /// A fully transparent pixel.
 pub const TRANSPARENT: Rgba = [0, 0, 0, 0];
+
+/// The sixteen quadrant block glyphs, indexed by a four-bit occupancy mask.
+///
+/// Bit 0 is the top-left quadrant, 1 top-right, 2 bottom-left, 3 bottom-right,
+/// so `QUADRANTS[0b0101]` is the left half `▌`. Packing four sub-cells into one
+/// glyph doubles the effective resolution of a cell grid in both axes, which is
+/// what lets a chart or canvas render without any graphics protocol.
+pub const QUADRANTS: [char; 16] = [
+    ' ', '▘', '▝', '▀', '▖', '▌', '▞', '▛', '▗', '▚', '▐', '▜', '▄', '▙', '▟', '█',
+];
 
 /// Source-over alpha composite of `src` onto `dst`.
 fn over(src: Rgba, dst: Rgba) -> Rgba {

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,12 +1,213 @@
 //! Geometry helpers shared across `tuika`.
 //!
-//! `tuika` reuses ratatui's [`Rect`] as its area type so the compositor can
-//! draw straight into a ratatui [`Buffer`](ratatui_core::buffer::Buffer), but the
-//! layout solver reasons about a direction-agnostic main/cross axis. The
-//! helpers here bridge the two: an [`Axis`] projects a `Rect` onto its main or
-//! cross extent so the flex solver can be written once for rows and columns.
+//! [`Rect`] is the area type every [`View`](crate::View) is handed, and
+//! [`Position`] a single cell coordinate. The layout solver, though, reasons
+//! about a direction-agnostic main/cross axis: an [`Axis`] projects a `Rect`
+//! onto its main or cross extent so the flex solver can be written once for
+//! rows and columns.
+//!
+//! Coordinates are `u16` and every operation saturates. A terminal can report a
+//! degenerate or absurd size, and a custom `View` can hand back any `Rect` it
+//! likes, so arithmetic that could overflow clamps instead of panicking — the
+//! size sweep in the test suite walks from `0×0` up asserting exactly that.
 
-use ratatui_core::layout::Rect;
+/// A single cell coordinate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Position {
+    /// Column, counted from the left edge.
+    pub x: u16,
+    /// Row, counted from the top edge.
+    pub y: u16,
+}
+
+impl Position {
+    /// The top-left corner.
+    pub const ORIGIN: Position = Position { x: 0, y: 0 };
+
+    /// A position at `x`, `y`.
+    pub const fn new(x: u16, y: u16) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<(u16, u16)> for Position {
+    fn from((x, y): (u16, u16)) -> Self {
+        Self { x, y }
+    }
+}
+
+impl From<Position> for (u16, u16) {
+    fn from(position: Position) -> Self {
+        (position.x, position.y)
+    }
+}
+
+/// A rectangular region of the cell grid.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Rect {
+    /// Column of the top-left corner.
+    pub x: u16,
+    /// Row of the top-left corner.
+    pub y: u16,
+    /// Width in cells.
+    pub width: u16,
+    /// Height in cells.
+    pub height: u16,
+}
+
+impl Rect {
+    /// A zero-size rect at the origin.
+    pub const ZERO: Rect = Rect {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    };
+
+    /// A rect at `x`, `y` with the given extents.
+    ///
+    /// The extents are clamped so the far edge cannot exceed [`u16::MAX`]:
+    /// `Rect::new(u16::MAX - 1, 0, 10, 1)` is one cell wide, not a wrapped
+    /// rect. Callers therefore never have to pre-check their own arithmetic.
+    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Self {
+        Self {
+            x,
+            y,
+            width: x.saturating_add(width) - x,
+            height: y.saturating_add(height) - y,
+        }
+    }
+
+    /// Cell count, as `u32` because `width * height` overflows `u16`.
+    pub const fn area(self) -> u32 {
+        (self.width as u32) * (self.height as u32)
+    }
+
+    /// Whether this rect covers no cells.
+    pub const fn is_empty(self) -> bool {
+        self.width == 0 || self.height == 0
+    }
+
+    /// Column of the left edge (inclusive).
+    pub const fn left(self) -> u16 {
+        self.x
+    }
+
+    /// Column just past the right edge (exclusive).
+    pub const fn right(self) -> u16 {
+        self.x.saturating_add(self.width)
+    }
+
+    /// Row of the top edge (inclusive).
+    pub const fn top(self) -> u16 {
+        self.y
+    }
+
+    /// Row just past the bottom edge (exclusive).
+    pub const fn bottom(self) -> u16 {
+        self.y.saturating_add(self.height)
+    }
+
+    /// The overlapping region, or a zero-size rect when they do not overlap.
+    ///
+    /// This is what [`Surface`](crate::Surface) clips every write with, so a
+    /// child can never paint outside the area layout gave it.
+    #[must_use = "returns a new Rect"]
+    pub fn intersection(self, other: Self) -> Self {
+        let x1 = self.x.max(other.x);
+        let y1 = self.y.max(other.y);
+        let x2 = self.right().min(other.right());
+        let y2 = self.bottom().min(other.bottom());
+        Self {
+            x: x1,
+            y: y1,
+            width: x2.saturating_sub(x1),
+            height: y2.saturating_sub(y1),
+        }
+    }
+
+    /// The smallest rect covering both.
+    #[must_use = "returns a new Rect"]
+    pub fn union(self, other: Self) -> Self {
+        let x1 = self.x.min(other.x);
+        let y1 = self.y.min(other.y);
+        let x2 = self.right().max(other.right());
+        let y2 = self.bottom().max(other.bottom());
+        Self {
+            x: x1,
+            y: y1,
+            width: x2.saturating_sub(x1),
+            height: y2.saturating_sub(y1),
+        }
+    }
+
+    /// Whether the two rects share at least one cell.
+    pub const fn intersects(self, other: Self) -> bool {
+        self.x < other.right()
+            && self.right() > other.x
+            && self.y < other.bottom()
+            && self.bottom() > other.y
+    }
+
+    /// Whether `position` falls inside this rect.
+    pub const fn contains(self, position: Position) -> bool {
+        position.x >= self.x
+            && position.x < self.right()
+            && position.y >= self.y
+            && position.y < self.bottom()
+    }
+
+    /// Move and shrink this rect so it fits inside `other`.
+    ///
+    /// Size is reduced first, then the origin is pulled back — so the result is
+    /// always inside `other`, even when this rect started larger.
+    #[must_use = "returns a new Rect"]
+    pub fn clamp(self, other: Self) -> Self {
+        let width = self.width.min(other.width);
+        let height = self.height.min(other.height);
+        let x = self.x.clamp(other.x, other.right().saturating_sub(width));
+        let y = self.y.clamp(other.y, other.bottom().saturating_sub(height));
+        Self::new(x, y, width, height)
+    }
+
+    /// The top-left corner.
+    pub const fn as_position(self) -> Position {
+        Position {
+            x: self.x,
+            y: self.y,
+        }
+    }
+
+    /// The extents, discarding the origin.
+    pub const fn as_size(self) -> Size {
+        Size {
+            width: self.width,
+            height: self.height,
+        }
+    }
+
+    /// Every row of this rect, top to bottom, each a full-width one-row rect.
+    pub fn rows(self) -> impl Iterator<Item = Rect> {
+        (self.top()..self.bottom()).map(move |y| Rect::new(self.x, y, self.width, 1))
+    }
+
+    /// Every column of this rect, left to right, each a full-height one-column rect.
+    pub fn columns(self) -> impl Iterator<Item = Rect> {
+        (self.left()..self.right()).map(move |x| Rect::new(x, self.y, 1, self.height))
+    }
+
+    /// Every cell position in this rect, in row-major order.
+    pub fn positions(self) -> impl Iterator<Item = Position> {
+        (self.top()..self.bottom())
+            .flat_map(move |y| (self.left()..self.right()).map(move |x| Position { x, y }))
+    }
+}
+
+impl From<(Position, Size)> for Rect {
+    fn from((position, size): (Position, Size)) -> Self {
+        Self::new(position.x, position.y, size.width, size.height)
+    }
+}
 
 /// An intrinsic size in terminal cells.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -166,5 +367,112 @@ impl Padding {
             width,
             height,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The saturation rule that keeps the size sweep panic-free: a rect placed
+    /// near `u16::MAX` is truncated, never wrapped.
+    #[test]
+    fn new_clamps_extents_that_would_overflow() {
+        let rect = Rect::new(u16::MAX - 1, u16::MAX - 2, 10, 10);
+        assert_eq!(rect.width, 1);
+        assert_eq!(rect.height, 2);
+        assert_eq!(rect.right(), u16::MAX);
+        assert_eq!(rect.bottom(), u16::MAX);
+    }
+
+    #[test]
+    fn area_does_not_overflow_u16() {
+        assert_eq!(Rect::new(0, 0, 300, 300).area(), 90_000);
+    }
+
+    #[test]
+    fn intersection_of_disjoint_rects_is_empty() {
+        let left = Rect::new(0, 0, 4, 4);
+        let right = Rect::new(10, 10, 4, 4);
+        assert!(left.intersection(right).is_empty());
+        assert!(!left.intersects(right));
+    }
+
+    #[test]
+    fn intersection_is_the_overlap() {
+        let a = Rect::new(0, 0, 6, 6);
+        let b = Rect::new(4, 4, 6, 6);
+        assert_eq!(a.intersection(b), Rect::new(4, 4, 2, 2));
+        assert!(a.intersects(b));
+    }
+
+    /// Rects that only touch edges do not overlap — an off-by-one here would
+    /// let a clipped child paint one column into its sibling.
+    #[test]
+    fn adjacent_rects_do_not_intersect() {
+        let a = Rect::new(0, 0, 4, 4);
+        let b = Rect::new(4, 0, 4, 4);
+        assert!(!a.intersects(b));
+        assert!(a.intersection(b).is_empty());
+    }
+
+    #[test]
+    fn union_covers_both() {
+        let a = Rect::new(0, 0, 2, 2);
+        let b = Rect::new(4, 4, 2, 2);
+        assert_eq!(a.union(b), Rect::new(0, 0, 6, 6));
+    }
+
+    #[test]
+    fn contains_is_half_open() {
+        let rect = Rect::new(1, 1, 2, 2);
+        assert!(rect.contains(Position::new(1, 1)));
+        assert!(rect.contains(Position::new(2, 2)));
+        assert!(!rect.contains(Position::new(3, 2)), "right edge excluded");
+        assert!(!rect.contains(Position::new(2, 3)), "bottom edge excluded");
+        assert!(!rect.contains(Position::new(0, 1)));
+    }
+
+    /// An overlay larger than the screen has to end up inside it, not merely
+    /// moved — this is what keeps a too-big dialog on screen.
+    #[test]
+    fn clamp_shrinks_then_moves_inside() {
+        let bounds = Rect::new(0, 0, 10, 10);
+        let oversized = Rect::new(8, 8, 20, 20).clamp(bounds);
+        assert_eq!(oversized, bounds);
+
+        let overhanging = Rect::new(8, 8, 4, 4).clamp(bounds);
+        assert_eq!(overhanging, Rect::new(6, 6, 4, 4));
+    }
+
+    #[test]
+    fn rows_and_columns_walk_the_rect() {
+        let rect = Rect::new(2, 3, 2, 2);
+        let rows: Vec<_> = rect.rows().collect();
+        assert_eq!(rows, vec![Rect::new(2, 3, 2, 1), Rect::new(2, 4, 2, 1)]);
+        let columns: Vec<_> = rect.columns().collect();
+        assert_eq!(columns, vec![Rect::new(2, 3, 1, 2), Rect::new(3, 3, 1, 2)]);
+    }
+
+    #[test]
+    fn positions_are_row_major() {
+        let positions: Vec<_> = Rect::new(0, 0, 2, 2).positions().collect();
+        assert_eq!(
+            positions,
+            vec![
+                Position::new(0, 0),
+                Position::new(1, 0),
+                Position::new(0, 1),
+                Position::new(1, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_empty_rect_yields_no_positions() {
+        let empty = Rect::new(5, 5, 0, 3);
+        assert_eq!(empty.rows().count(), 3);
+        assert_eq!(empty.positions().count(), 0);
+        assert_eq!(Rect::ZERO.rows().count(), 0);
     }
 }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -11,7 +11,7 @@
 //! token colors. The companion crate `tuika-codeformatters` ships a tree-sitter
 //! implementation; hosts can also write their own.
 
-use ratatui_core::text::Span;
+use crate::text::Span;
 
 use crate::style::Theme;
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -14,6 +14,9 @@
 use std::io::{self, Write};
 use std::process::{Command as ProcessCommand, Stdio};
 
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
+use crate::style::Style;
 use crossterm::cursor::{Hide, Show};
 use crossterm::event::{
     DisableMouseCapture, EnableMouseCapture, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind,
@@ -25,9 +28,6 @@ use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
     is_raw_mode_enabled,
 };
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
 
 use super::event::{Event, Key, KeyCode, Mouse, MouseButton, MouseKind};
 use super::overlay::Overlay;
@@ -546,14 +546,14 @@ fn button(b: CtMouseButton) -> MouseButton {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::buffer::Buffer;
     use crate::components::{Boxed, Flex, ProgressBar, Scroll, ScrollState, StatusBar, Text};
     use crate::event::{Event, MouseButton, MouseKind};
+    use crate::geometry::Rect;
     use crate::style::Theme;
     use crate::tests::support::{buffer, rainbow_theme, row};
+    use crate::text::{Line, Span};
     use crate::view::{Element, element};
-    use ratatui_core::buffer::Buffer;
-    use ratatui_core::layout::Rect;
-    use ratatui_core::text::{Line, Span};
 
     #[test]
     fn session_mouse_policy_can_override_screen_mode_defaults() {

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -1,15 +1,169 @@
-//! Safe interoperability with ratatui widgets.
+//! Interoperability with ratatui widgets.
 //!
-//! [`RatatuiView`] participates in Tuika layout while rendering through
-//! [`Surface::render_ratatui`](crate::Surface::render_ratatui), so arbitrary
-//! widget code never receives the frame's underlying buffer.
+//! tuika owns its cell grid, so its [`Buffer`] and
+//! ratatui's are different types. Everything in this module exists to bridge
+//! that one boundary, so a host keeps every ratatui widget ever written:
+//! [`RatatuiView`] participates in tuika layout while rendering through
+//! [`Surface::render_ratatui`](crate::Surface::render_ratatui), which converts
+//! a scratch buffer across and back.
+//!
+//! The conversion is a cell-by-cell copy of the *rendered area only* — never the
+//! whole frame — so it costs one clone per cell a ratatui widget actually
+//! touches, and nothing at all for a host that renders no ratatui widgets.
+//!
+//! The whole module requires the `ratatui` feature, which is what keeps
+//! `ratatui-core` out of the default dependency graph.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
+use ratatui_core::buffer::Buffer as ForeignBuffer;
+use ratatui_core::layout::Rect as ForeignRect;
+use ratatui_core::style::{Color as ForeignColor, Modifier as ForeignModifier};
 
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
+use crate::style::{Color, Modifier};
 use crate::{RenderCtx, Size, Surface, View};
 
-/// A Tuika view backed by a ratatui rendering closure.
+/// Convert a tuika rect to ratatui's.
+pub(crate) fn to_ratatui_rect(rect: Rect) -> ForeignRect {
+    ForeignRect::new(rect.x, rect.y, rect.width, rect.height)
+}
+
+/// Convert a ratatui rect to tuika's.
+pub(crate) fn from_ratatui_rect(rect: ForeignRect) -> Rect {
+    Rect::new(rect.x, rect.y, rect.width, rect.height)
+}
+
+fn to_ratatui_color(color: Color) -> ForeignColor {
+    match color {
+        Color::Reset => ForeignColor::Reset,
+        Color::Black => ForeignColor::Black,
+        Color::Red => ForeignColor::Red,
+        Color::Green => ForeignColor::Green,
+        Color::Yellow => ForeignColor::Yellow,
+        Color::Blue => ForeignColor::Blue,
+        Color::Magenta => ForeignColor::Magenta,
+        Color::Cyan => ForeignColor::Cyan,
+        Color::Gray => ForeignColor::Gray,
+        Color::DarkGray => ForeignColor::DarkGray,
+        Color::LightRed => ForeignColor::LightRed,
+        Color::LightGreen => ForeignColor::LightGreen,
+        Color::LightYellow => ForeignColor::LightYellow,
+        Color::LightBlue => ForeignColor::LightBlue,
+        Color::LightMagenta => ForeignColor::LightMagenta,
+        Color::LightCyan => ForeignColor::LightCyan,
+        Color::White => ForeignColor::White,
+        Color::Rgb(r, g, b) => ForeignColor::Rgb(r, g, b),
+        Color::Indexed(i) => ForeignColor::Indexed(i),
+    }
+}
+
+fn from_ratatui_color(color: ForeignColor) -> Color {
+    match color {
+        ForeignColor::Reset => Color::Reset,
+        ForeignColor::Black => Color::Black,
+        ForeignColor::Red => Color::Red,
+        ForeignColor::Green => Color::Green,
+        ForeignColor::Yellow => Color::Yellow,
+        ForeignColor::Blue => Color::Blue,
+        ForeignColor::Magenta => Color::Magenta,
+        ForeignColor::Cyan => Color::Cyan,
+        ForeignColor::Gray => Color::Gray,
+        ForeignColor::DarkGray => Color::DarkGray,
+        ForeignColor::LightRed => Color::LightRed,
+        ForeignColor::LightGreen => Color::LightGreen,
+        ForeignColor::LightYellow => Color::LightYellow,
+        ForeignColor::LightBlue => Color::LightBlue,
+        ForeignColor::LightMagenta => Color::LightMagenta,
+        ForeignColor::LightCyan => Color::LightCyan,
+        ForeignColor::White => Color::White,
+        ForeignColor::Rgb(r, g, b) => Color::Rgb(r, g, b),
+        ForeignColor::Indexed(i) => Color::Indexed(i),
+    }
+}
+
+/// Both sides use the same bit layout, so modifiers convert by value.
+///
+/// Asserted by `modifier_bits_line_up` below rather than assumed — a
+/// reordering upstream would otherwise silently swap bold for dim.
+fn to_ratatui_modifier(modifier: Modifier) -> ForeignModifier {
+    ForeignModifier::from_bits_truncate(modifier.bits())
+}
+
+fn from_ratatui_modifier(modifier: ForeignModifier) -> Modifier {
+    [
+        (ForeignModifier::BOLD, Modifier::BOLD),
+        (ForeignModifier::DIM, Modifier::DIM),
+        (ForeignModifier::ITALIC, Modifier::ITALIC),
+        (ForeignModifier::UNDERLINED, Modifier::UNDERLINED),
+        (ForeignModifier::SLOW_BLINK, Modifier::SLOW_BLINK),
+        (ForeignModifier::RAPID_BLINK, Modifier::RAPID_BLINK),
+        (ForeignModifier::REVERSED, Modifier::REVERSED),
+        (ForeignModifier::HIDDEN, Modifier::HIDDEN),
+        (ForeignModifier::CROSSED_OUT, Modifier::CROSSED_OUT),
+    ]
+    .into_iter()
+    .filter(|(foreign, _)| modifier.contains(*foreign))
+    .fold(Modifier::empty(), |acc, (_, own)| acc.union(own))
+}
+
+/// Convert one cell to ratatui's.
+///
+/// Only the differential backend test needs a single cell; the render path
+/// converts whole buffers.
+#[cfg(test)]
+pub(crate) fn to_ratatui_cell(cell: &crate::buffer::Cell) -> ratatui_core::buffer::Cell {
+    // `Cell::new` upstream takes `&'static str`; a grapheme from our grid is
+    // borrowed, so the symbol is set after construction.
+    let mut out = ratatui_core::buffer::Cell::default();
+    out.set_symbol(cell.symbol());
+    out.set_fg(to_ratatui_color(cell.fg));
+    out.set_bg(to_ratatui_color(cell.bg));
+    out.underline_color = to_ratatui_color(cell.underline_color);
+    out.modifier = to_ratatui_modifier(cell.modifier);
+    out
+}
+
+/// Copy a tuika buffer into a fresh ratatui one covering the same area.
+pub(crate) fn to_ratatui_buffer(source: &Buffer) -> ForeignBuffer {
+    let mut out = ForeignBuffer::empty(to_ratatui_rect(source.area));
+    for y in source.area.y..source.area.bottom() {
+        for x in source.area.x..source.area.right() {
+            let Some(cell) = source.cell((x, y)) else {
+                continue;
+            };
+            let target = &mut out[(x, y)];
+            target.set_symbol(cell.symbol());
+            target.set_fg(to_ratatui_color(cell.fg));
+            target.set_bg(to_ratatui_color(cell.bg));
+            target.modifier = to_ratatui_modifier(cell.modifier);
+        }
+    }
+    out
+}
+
+/// Copy a ratatui buffer back over a tuika one, cell for cell.
+///
+/// Only the overlap is copied: a widget that resized its buffer cannot enlarge
+/// the destination, which is what keeps the clip guarantee intact.
+pub(crate) fn from_ratatui_buffer(source: &ForeignBuffer, destination: &mut Buffer) {
+    let overlap = from_ratatui_rect(source.area).intersection(destination.area);
+    for y in overlap.y..overlap.bottom() {
+        for x in overlap.x..overlap.right() {
+            let Some(cell) = source.cell((x, y)) else {
+                continue;
+            };
+            let Some(target) = destination.cell_mut((x, y)) else {
+                continue;
+            };
+            target.set_symbol(cell.symbol());
+            target.fg = from_ratatui_color(cell.fg);
+            target.bg = from_ratatui_color(cell.bg);
+            target.modifier = from_ratatui_modifier(cell.modifier);
+        }
+    }
+}
+
+/// A tuika view backed by a ratatui rendering closure.
 ///
 /// The closure form is intentional: many ratatui widgets borrow their data.
 /// Captured owned data can be borrowed while constructing the widget inside
@@ -27,7 +181,7 @@ enum Measure {
 
 impl<F> RatatuiView<F>
 where
-    F: Fn(Rect, &mut Buffer),
+    F: Fn(ForeignRect, &mut ForeignBuffer),
 {
     /// Create a view that requests all space offered by its parent.
     ///
@@ -57,7 +211,7 @@ where
 
 impl<F> View for RatatuiView<F>
 where
-    F: Fn(Rect, &mut Buffer),
+    F: Fn(ForeignRect, &mut ForeignBuffer),
 {
     fn measure(&self, available: Size, _ctx: &RenderCtx) -> Size {
         match self.measure {
@@ -77,6 +231,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::style::Style;
     use crate::style::Theme;
     use crate::tests::support::row;
 
@@ -91,5 +246,102 @@ mod tests {
         let theme = Theme::default();
         let rendered = crate::testing::render(&view, 4, 1, &theme);
         assert_ne!(row(&rendered, 0), "");
+    }
+
+    /// The conversion is only sound while the two bit layouts agree; this is the
+    /// assertion that catches an upstream reordering instead of shipping bold
+    /// text rendered as dim.
+    #[test]
+    fn modifier_bits_line_up() {
+        for (own, foreign) in [
+            (Modifier::BOLD, ForeignModifier::BOLD),
+            (Modifier::DIM, ForeignModifier::DIM),
+            (Modifier::ITALIC, ForeignModifier::ITALIC),
+            (Modifier::UNDERLINED, ForeignModifier::UNDERLINED),
+            (Modifier::SLOW_BLINK, ForeignModifier::SLOW_BLINK),
+            (Modifier::RAPID_BLINK, ForeignModifier::RAPID_BLINK),
+            (Modifier::REVERSED, ForeignModifier::REVERSED),
+            (Modifier::HIDDEN, ForeignModifier::HIDDEN),
+            (Modifier::CROSSED_OUT, ForeignModifier::CROSSED_OUT),
+        ] {
+            assert_eq!(own.bits(), foreign.bits(), "{own:?} vs {foreign:?}");
+        }
+    }
+
+    #[test]
+    fn every_color_survives_a_round_trip() {
+        let colors = [
+            Color::Reset,
+            Color::Black,
+            Color::Red,
+            Color::Green,
+            Color::Yellow,
+            Color::Blue,
+            Color::Magenta,
+            Color::Cyan,
+            Color::Gray,
+            Color::DarkGray,
+            Color::LightRed,
+            Color::LightGreen,
+            Color::LightYellow,
+            Color::LightBlue,
+            Color::LightMagenta,
+            Color::LightCyan,
+            Color::White,
+            Color::Rgb(1, 2, 3),
+            Color::Indexed(42),
+        ];
+        for color in colors {
+            assert_eq!(from_ratatui_color(to_ratatui_color(color)), color);
+        }
+    }
+
+    #[test]
+    fn every_modifier_survives_a_round_trip() {
+        let all = Modifier::all();
+        assert_eq!(from_ratatui_modifier(to_ratatui_modifier(all)), all);
+        assert_eq!(
+            from_ratatui_modifier(to_ratatui_modifier(Modifier::empty())),
+            Modifier::empty()
+        );
+    }
+
+    /// Symbols, colors and attributes all have to survive the trip, or a widget
+    /// would render with the right glyphs and the wrong paint.
+    #[test]
+    fn a_buffer_survives_a_round_trip() {
+        let mut original = Buffer::empty(Rect::new(0, 0, 3, 1));
+        original.set_string(
+            0,
+            0,
+            "ab",
+            Style::new()
+                .fg(Color::Rgb(9, 9, 9))
+                .bg(Color::Indexed(4))
+                .bold(),
+        );
+
+        let foreign = to_ratatui_buffer(&original);
+        let mut restored = Buffer::empty(Rect::new(0, 0, 3, 1));
+        from_ratatui_buffer(&foreign, &mut restored);
+
+        assert_eq!(restored[(0, 0)].symbol(), "a");
+        assert_eq!(restored[(0, 0)].fg, Color::Rgb(9, 9, 9));
+        assert_eq!(restored[(0, 0)].bg, Color::Indexed(4));
+        assert!(restored[(0, 0)].modifier.contains(Modifier::BOLD));
+    }
+
+    /// A widget that grows its buffer must not grow the destination — that is
+    /// the containment guarantee `render_scratch` exists to provide.
+    #[test]
+    fn a_larger_foreign_buffer_cannot_enlarge_the_destination() {
+        let foreign = ForeignBuffer::filled(
+            ForeignRect::new(0, 0, 8, 4),
+            ratatui_core::buffer::Cell::new("x"),
+        );
+        let mut destination = Buffer::empty(Rect::new(0, 0, 2, 1));
+        from_ratatui_buffer(&foreign, &mut destination);
+        assert_eq!(destination.area, Rect::new(0, 0, 2, 1));
+        assert_eq!(destination[(0, 0)].symbol(), "x");
     }
 }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Range;
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use super::geometry::{Axis, Padding, Size};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod anim;
+pub mod buffer;
 mod clock;
 pub mod components;
 pub mod dock;
@@ -92,6 +93,8 @@ pub mod framebuffer;
 pub mod geometry;
 pub mod highlight;
 pub mod host;
+#[cfg(feature = "ratatui")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ratatui")))]
 pub mod interop;
 pub mod keymap;
 pub mod layout;
@@ -109,18 +112,23 @@ pub mod style;
 pub mod surface;
 pub mod term;
 pub mod testing;
+pub mod text;
 pub mod themes;
 pub mod view;
 pub mod width;
 
-/// Backend UI vocabulary re-exported for custom [`View`] implementations.
+/// The cell-grid vocabulary, in one place for custom [`View`] implementations.
 ///
-/// Applications can use these canonical types without depending on
-/// `ratatui-core` directly. More specialized backend internals remain private.
+/// These are tuika's own types; nothing here is a re-export of another crate,
+/// so a host writing a `View` takes no rendering dependency beyond tuika
+/// itself. Each also has a canonical home module ([`geometry`], [`style`],
+/// [`text`], [`buffer`]) — this module is the convenience path, and what
+/// [`prelude`] pulls in.
 pub mod ui {
-    pub use ratatui_core::layout::Rect;
-    pub use ratatui_core::style::{Color, Modifier, Style};
-    pub use ratatui_core::text::{Line, Span};
+    pub use crate::buffer::{Buffer, Cell, CellDiffOption};
+    pub use crate::geometry::{Position, Rect};
+    pub use crate::style::{Color, Modifier, Style};
+    pub use crate::text::{Alignment, Line, Span};
 }
 
 // The framework spine: the types a host composes with on essentially every

--- a/src/live.rs
+++ b/src/live.rs
@@ -12,7 +12,7 @@ use std::task::Waker;
 #[cfg(feature = "async")]
 use std::task::{Context, Poll};
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::{Element, RenderCtx, Size, Surface, View};
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -185,11 +185,11 @@ macro_rules! view {
 #[cfg(test)]
 mod tests {
     use crate::components::{Boxed, Flex, Spacer, Text};
+    use crate::geometry::Rect;
+    use crate::style::Style;
     use crate::tests::support::render_el;
     use crate::view::{Element, RenderCtx, View, element};
     use crate::{Size, Surface};
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::Style;
 
     #[test]
     fn view_macro_matches_builder() {
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn view_macro_forwards_border_color() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         // `border_color =` folds to `Boxed::border_color`, rendering identically
         // to the builder form.
         let built: Element =

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -24,9 +24,9 @@
 //! `Down`+`Up`, a swipe is `ScrollUp`/`ScrollDown` or a `Drag`), so touch input
 //! flows through this same path — there is no separate touch event to model.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::{Position, Rect};
-use ratatui_core::style::Style;
+use crate::buffer::Buffer;
+use crate::geometry::{Position, Rect};
+use crate::style::Style;
 use std::time::{Duration, Instant};
 
 use crate::event::{Mouse, MouseButton, MouseKind};
@@ -582,9 +582,9 @@ mod tests {
     use super::*;
     use crate::components::Text;
     use crate::event::{Mouse, MouseButton, MouseKind};
+    use crate::geometry::Rect;
     use crate::style::Theme;
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::{Color, Style};
+    use crate::style::{Color, Style};
 
     fn down(col: u16, row: u16) -> Mouse {
         Mouse::at(MouseKind::Down(MouseButton::Left), col, row)
@@ -605,7 +605,7 @@ mod tests {
         let area = Rect::new(0, 0, width, rows.len() as u16);
         let mut buffer = Buffer::empty(area);
         for (y, row) in rows.iter().enumerate() {
-            buffer.set_string(0, y as u16, *row, Style::default());
+            buffer.set_string(0, y as u16, row, Style::default());
         }
         buffer
     }
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn selected_text_spans_rows_linearly() {
-        use ratatui_core::text::Line;
+        use crate::text::Line;
         let theme = Theme::default();
         let lines = vec![Line::from("hello"), Line::from("world")];
         let buf = crate::testing::render(&Text::new(lines), 5, 2, &theme);

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,8 +2,8 @@
 
 use std::io::{self, Write};
 
-use ratatui_core::style::{Color, Style};
-use ratatui_core::text::{Line, Span};
+use crate::style::{Color, Style};
+use crate::text::{Line, Span};
 
 use crate::testing;
 use crate::view::{AvailableSpace, MeasureRequest, RenderCtx, View};
@@ -115,11 +115,7 @@ pub fn write_once(
     out.flush()
 }
 
-fn cell_style(
-    foreground: Color,
-    background: Color,
-    modifier: ratatui_core::style::Modifier,
-) -> Style {
+fn cell_style(foreground: Color, background: Color, modifier: crate::style::Modifier) -> Style {
     Style::default()
         .fg(foreground)
         .bg(background)
@@ -130,7 +126,7 @@ fn cell_style(
 mod tests {
     use super::*;
     use crate::components::Text;
-    use ratatui_core::style::{Color, Modifier};
+    use crate::style::{Color, Modifier};
 
     struct FailingWriter;
 
@@ -176,7 +172,7 @@ mod tests {
             .fg(Color::Indexed(201))
             .add_modifier(Modifier::BOLD);
         let view = crate::view::DrawView::new(
-            move |area: ratatui_core::layout::Rect, surface: &mut crate::Surface, _: &RenderCtx| {
+            move |area: crate::geometry::Rect, surface: &mut crate::Surface, _: &RenderCtx| {
                 surface.set_string(area.x, area.y, "styled", style);
             },
         )

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -13,7 +13,7 @@
 //! answers with a `Rect`; an [`Overlay`] pairs that resolved rect with the view
 //! to paint into it, and is what [`paint`](crate::host::paint) consumes.
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use super::geometry::Size;
 use super::view::View;
@@ -195,7 +195,7 @@ impl Extent {
 ///
 /// ```
 /// use tuika::OverlaySpec;
-/// use ratatui_core::layout::Rect;
+/// use tuika::ui::Rect;
 ///
 /// // A centered dialog at 50% × 40% of a 100 × 40 screen, never smaller than 34 × 7.
 /// let rect = OverlaySpec::centered(50, 40).min_size(34, 7).resolve(Rect::new(0, 0, 100, 40));
@@ -423,7 +423,7 @@ fn align_axis(start: i32, end: i32, extent: i32, align: TargetAlign) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui_core::layout::Rect;
+    use crate::geometry::Rect;
 
     #[test]
     fn overlay_centered_percentage() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -30,6 +30,7 @@ pub use crate::anim::{Easing, Repeat, Timeline, Transition};
 pub use crate::components::*;
 pub use crate::focus::FocusRegistry;
 pub use crate::highlight::{CodeHighlighter, Highlighter, PlainHighlighter};
+#[cfg(feature = "ratatui")]
 pub use crate::interop::RatatuiView;
 pub use crate::keymap::{Binding, Chord, Dispatch, Hint, KeySequence, Keymap, Layer};
 pub use crate::live::{Live, LiveView, RedrawHandle};

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -23,7 +23,7 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use crate::geometry::Size;
 use crate::surface::Surface;
@@ -93,9 +93,9 @@ impl<V: View> View for Probe<V> {
 mod tests {
     use super::*;
     use crate::components::{Flex, Text};
+    use crate::geometry::Rect;
     use crate::style::Theme;
     use crate::view::element;
-    use ratatui_core::layout::Rect;
 
     #[test]
     fn probe_reports_the_rect_a_view_was_painted_into() {

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -63,9 +63,9 @@ use std::time::Duration;
 
 use super::stream::{self, Stream};
 use crate::term::backend::CrosstermBackend;
+use crate::term::terminal::{Terminal, TerminalOptions};
+use crate::term::traits::Backend;
 use crossterm::event::EventStream;
-use ratatui_core::backend::Backend;
-use ratatui_core::terminal::{Terminal, TerminalOptions};
 use tokio::time::{Instant as TokioInstant, MissedTickBehavior, interval, sleep_until};
 
 use super::{
@@ -482,7 +482,7 @@ impl AsyncRunner {
     ///
     /// This is the loop itself, and what [`run`](Self::run) builds on. The boundary
     /// tests drive it against a
-    /// [`TestBackend`](ratatui_core::backend::TestBackend) with scripted
+    /// [`TestBackend`](crate::term::testbackend::TestBackend) with scripted
     /// streams; hosts that already own their terminal and event source (or want
     /// a non-crossterm one) can call it directly. Pass [`no_messages`] when
     /// there is no application stream.
@@ -490,7 +490,7 @@ impl AsyncRunner {
     /// The backend error and both stream errors share one type `Er`, which is
     /// the run's error type: for the real terminal that is [`io::Error`], but
     /// leaving it generic lets an infallible backend
-    /// ([`TestBackend`](ratatui_core::backend::TestBackend), whose error is
+    /// ([`TestBackend`](crate::term::testbackend::TestBackend), whose error is
     /// [`Infallible`]) pair with infallible streams.
     ///
     /// `events` yields already-translated tuika [`Event`]s. An `Err` item from
@@ -788,9 +788,9 @@ mod tests {
     use crate::ScreenMode;
     use crate::components::Text;
     use crate::event::{Key, KeyCode, Mouse, MouseButton, MouseKind};
+    use crate::geometry::Rect;
+    use crate::term::testbackend::TestBackend;
     use crate::view::element;
-    use ratatui_core::backend::TestBackend;
-    use ratatui_core::layout::Rect;
 
     use crate::View;
     use crate::geometry::Size;
@@ -1186,8 +1186,8 @@ mod tests {
     // the scrollback above it, and the footer is repainted afterwards.
     #[tokio::test]
     async fn split_footer_publishes_above_a_pinned_footer() {
+        use crate::geometry::Position;
         use crate::screen::ScreenMode;
-        use ratatui_core::layout::Position;
 
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
@@ -1216,8 +1216,8 @@ mod tests {
                     &mut state,
                     |_state, _frame| {
                         element(Text::new(vec![
-                            ratatui_core::text::Line::from("FOOTER"),
-                            ratatui_core::text::Line::from("FOOTER"),
+                            crate::text::Line::from("FOOTER"),
+                            crate::text::Line::from("FOOTER"),
                         ]))
                     },
                     async |_state, signal| match signal {
@@ -1252,8 +1252,8 @@ mod tests {
     // its blocks published without touching the runner's state.
     #[tokio::test]
     async fn a_background_task_publishes_while_the_loop_runs() {
+        use crate::geometry::Position;
         use crate::screen::ScreenMode;
-        use ratatui_core::layout::Position;
 
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_millis(5),
@@ -1367,8 +1367,8 @@ mod tests {
     // given rect and never touches the terminal.
     #[tokio::test]
     async fn stream_error_propagates() {
+        use crate::geometry::Rect;
         use crate::term::backend::CrosstermBackend;
-        use ratatui_core::layout::Rect;
 
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
@@ -1377,7 +1377,7 @@ mod tests {
         let mut terminal = Terminal::with_options(
             CrosstermBackend::new(Vec::<u8>::new()),
             TerminalOptions {
-                viewport: ratatui_core::terminal::Viewport::Fixed(Rect::new(0, 0, 10, 1)),
+                viewport: crate::term::terminal::Viewport::Fixed(Rect::new(0, 0, 10, 1)),
             },
         )
         .expect("test terminal");
@@ -1573,7 +1573,7 @@ mod tests {
         let mut terminal = Terminal::with_options(
             CrosstermBackend::new(Vec::<u8>::new()),
             TerminalOptions {
-                viewport: ratatui_core::terminal::Viewport::Fixed(Rect::new(0, 0, 10, 1)),
+                viewport: crate::term::terminal::Viewport::Fixed(Rect::new(0, 0, 10, 1)),
             },
         )
         .expect("test terminal");

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -42,7 +42,7 @@
 //! `run_driven_by` is the loop with nothing around it: no session, no terminal
 //! construction, no stdout-facing work. Both runners build their other entry
 //! points on it, and a test can drive a whole application through it over a
-//! [`TestBackend`](ratatui_core::backend::TestBackend) — with
+//! [`TestBackend`](crate::term::testbackend::TestBackend) — with
 //! [`scripted_events`] on the synchronous side — so the loop is testable
 //! without a tty.
 //!
@@ -93,12 +93,12 @@ use std::io::{self, Write};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
 use crate::term::backend::CrosstermBackend;
+use crate::term::terminal::{Terminal, TerminalOptions};
+use crate::term::traits::Backend;
 use crossterm::event;
-use ratatui_core::backend::Backend;
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
-use ratatui_core::terminal::{Terminal, TerminalOptions};
 
 use crate::host::paint_with_context_and_selection;
 use crate::live::RedrawHandle;
@@ -375,7 +375,7 @@ where
 /// finite script.
 /// `Er` is the run's error type, shared with the backend: for the real terminal
 /// that is [`io::Error`], but leaving it generic lets an infallible backend
-/// ([`TestBackend`](ratatui_core::backend::TestBackend), whose error is
+/// ([`TestBackend`](crate::term::testbackend::TestBackend), whose error is
 /// [`Infallible`]) pair with an infallible source.
 pub trait EventSource<Er = io::Error> {
     /// Wait up to `timeout` for the next event.
@@ -423,8 +423,8 @@ pub struct ScriptedEvents<I> {
 /// ```
 /// use tuika::prelude::*;
 /// use tuika::runner::scripted_events;
-/// use ratatui::backend::TestBackend;
-/// use ratatui::Terminal;
+/// use tuika::term::testbackend::TestBackend;
+/// use tuika::term::terminal::Terminal;
 ///
 /// # fn main() {
 /// let mut terminal = Terminal::new(TestBackend::new(20, 1)).unwrap();
@@ -702,7 +702,7 @@ impl Runner {
     /// [`AsyncRunner::run_driven_by`](crate::AsyncRunner::run_driven_by). A host
     /// that already owns its terminal and input can call it directly, and a test
     /// can drive a whole application over a
-    /// [`TestBackend`](ratatui_core::backend::TestBackend) with
+    /// [`TestBackend`](crate::term::testbackend::TestBackend) with
     /// [`scripted_events`] — no tty, no raw mode, no real clock.
     ///
     /// It enters no [`TerminalSession`], so raw mode, the alternate screen, and
@@ -1110,7 +1110,7 @@ mod tests {
         };
         let data = crate::term::image::ImageData::from_rgba(1, 1, vec![1, 2, 3, 255]).unwrap();
         graphics.layer.record(
-            ratatui_core::layout::Rect::new(2, 3, 4, 5),
+            crate::geometry::Rect::new(2, 3, 4, 5),
             data,
             graphics.support,
         );
@@ -1325,7 +1325,7 @@ mod tests {
     // (`RunnerCore`, the clock, `RunnerSelection`) could be exercised. These
     // drive the whole thing over a `TestBackend`.
 
-    use ratatui_core::backend::TestBackend;
+    use crate::term::testbackend::TestBackend;
 
     use crate::components::Text;
     use crate::event::KeyCode;
@@ -1345,7 +1345,7 @@ mod tests {
             .buffer()
             .content()
             .iter()
-            .map(ratatui_core::buffer::Cell::symbol)
+            .map(crate::buffer::Cell::symbol)
             .collect()
     }
 
@@ -1650,7 +1650,7 @@ mod tests {
 
     #[test]
     fn a_split_footer_publishes_above_the_pinned_footer() {
-        use ratatui_core::layout::Position;
+        use crate::geometry::Position;
 
         let runner = Runner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
@@ -1678,8 +1678,8 @@ mod tests {
                     &mut state,
                     |(), _frame| {
                         element(Text::new(vec![
-                            ratatui_core::text::Line::from("FOOTER"),
-                            ratatui_core::text::Line::from("FOOTER"),
+                            crate::text::Line::from("FOOTER"),
+                            crate::text::Line::from("FOOTER"),
                         ]))
                     },
                     |(), signal| match signal {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -17,7 +17,7 @@
 //! # Borrowed application data with an owned dialog
 //!
 //! ```
-//! use ratatui_core::layout::Rect;
+//! use tuika::ui::Rect;
 //! use tuika::prelude::*;
 //!
 //! struct Dashboard<'data> {
@@ -57,7 +57,7 @@
 //! mutating the host state, then build the next frame from a fresh borrow:
 //!
 //! ```
-//! use ratatui_core::layout::Rect;
+//! use tuika::ui::Rect;
 //! use tuika::prelude::*;
 //!
 //! struct Count<'data>(&'data [String]);
@@ -91,8 +91,8 @@
 //! }
 //! ```
 
-use ratatui_core::layout::Rect;
-use ratatui_core::style::{Modifier, Style};
+use crate::geometry::Rect;
+use crate::style::{Modifier, Style};
 
 use crate::focus::FocusRegistry;
 use crate::geometry::Size;
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn dim_backdrop_respects_the_parent_surface_clip() {
-        use ratatui_core::buffer::{Buffer, Cell};
+        use crate::buffer::{Buffer, Cell};
 
         let mut buffer = Buffer::filled(Rect::new(0, 0, 6, 1), Cell::new("#"));
         let scene = Scene::new(element(Text::raw("base"))).overlay(
@@ -560,7 +560,7 @@ mod tests {
 
     #[test]
     fn scoped_dim_backdrop_respects_the_parent_surface_clip() {
-        use ratatui_core::buffer::{Buffer, Cell};
+        use crate::buffer::{Buffer, Cell};
 
         let mut buffer = Buffer::filled(Rect::new(0, 0, 6, 1), Cell::new("#"));
         let root = Text::raw("base");

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -64,10 +64,10 @@
 
 use std::sync::{Arc, Mutex};
 
-use ratatui_core::backend::Backend;
-use ratatui_core::buffer::Buffer;
-use ratatui_core::terminal::{Terminal, Viewport};
-use ratatui_core::text::Line;
+use crate::buffer::Buffer;
+use crate::term::terminal::{Terminal, Viewport};
+use crate::term::traits::Backend;
+use crate::text::Line;
 
 use crate::components::Text;
 use crate::geometry::Size;
@@ -405,14 +405,14 @@ pub fn close_footer<B: Backend>(terminal: &mut Terminal<B>) -> Result<(), B::Err
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::geometry::{Position, Rect};
     use crate::style::StyleSheet;
+    use crate::style::{Color, Style};
+    use crate::term::terminal::TerminalOptions;
+    use crate::term::testbackend::TestBackend;
     use crate::tests::support::rainbow_theme;
+    use crate::text::Span;
     use crate::view::element;
-    use ratatui_core::backend::TestBackend;
-    use ratatui_core::layout::{Position, Rect};
-    use ratatui_core::style::{Color, Style};
-    use ratatui_core::terminal::TerminalOptions;
-    use ratatui_core::text::Span;
 
     /// An inline terminal whose viewport is anchored at `cursor_row`, i.e. what
     /// a host gets when it starts a footer partway down a used screen.

--- a/src/style/attrs.rs
+++ b/src/style/attrs.rs
@@ -1,0 +1,435 @@
+//! Cell attributes: [`Color`], [`Modifier`], and [`Style`].
+//!
+//! These are tuika's own types rather than re-exports, so `ratatui-core` does
+//! not appear in tuika's public API. The variants and the patch semantics match
+//! ratatui's deliberately: the two are converted at the interop boundary
+//! ([`Surface::render_ratatui`](crate::Surface::render_ratatui)) under the
+//! `ratatui` feature, and a mismatch there would be a silent rendering
+//! difference rather than a compile error.
+
+use core::fmt;
+
+/// A terminal color.
+///
+/// `Reset` returns the cell to the terminal's own default rather than painting
+/// a color, which is what makes a scrollback block published under
+/// [`ScreenMode::SplitFooter`](crate::ScreenMode) read as part of the
+/// surrounding session.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Color {
+    /// Reset to the terminal's default foreground or background.
+    #[default]
+    Reset,
+    /// ANSI black (fg 30 / bg 40).
+    Black,
+    /// ANSI red (fg 31 / bg 41).
+    Red,
+    /// ANSI green (fg 32 / bg 42).
+    Green,
+    /// ANSI yellow (fg 33 / bg 43).
+    Yellow,
+    /// ANSI blue (fg 34 / bg 44).
+    Blue,
+    /// ANSI magenta (fg 35 / bg 45).
+    Magenta,
+    /// ANSI cyan (fg 36 / bg 46).
+    Cyan,
+    /// ANSI white (fg 37 / bg 47) — the dim one; [`Color::White`] is the bright.
+    Gray,
+    /// ANSI bright black (fg 90 / bg 100).
+    DarkGray,
+    /// ANSI bright red (fg 91 / bg 101).
+    LightRed,
+    /// ANSI bright green (fg 92 / bg 102).
+    LightGreen,
+    /// ANSI bright yellow (fg 93 / bg 103).
+    LightYellow,
+    /// ANSI bright blue (fg 94 / bg 104).
+    LightBlue,
+    /// ANSI bright magenta (fg 95 / bg 105).
+    LightMagenta,
+    /// ANSI bright cyan (fg 96 / bg 106).
+    LightCyan,
+    /// ANSI bright white (fg 97 / bg 107).
+    White,
+    /// A 24-bit truecolor value. Terminals without truecolor support render
+    /// this unpredictably; [`term::capabilities`](crate::term::capabilities)
+    /// is how a host detects that before choosing a theme.
+    Rgb(u8, u8, u8),
+    /// An 8-bit indexed color from the 256-color palette.
+    Indexed(u8),
+}
+
+/// Text attributes, composable as bitflags.
+///
+/// A [`Style`] carries two of these — one to add and one to remove — so a style
+/// patched over another can turn an attribute *off* as well as on.
+///
+/// Hand-rolled rather than pulled from `bitflags`: nine flags and the four set
+/// operations tuika uses are less code than justifying the dependency, and the
+/// `NAMED` table below is what gives [`Debug`] its readable output.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct Modifier(u16);
+
+impl Modifier {
+    /// Bold.
+    pub const BOLD: Self = Self(0b0000_0000_0001);
+    /// Dim / faint.
+    pub const DIM: Self = Self(0b0000_0000_0010);
+    /// Italic.
+    pub const ITALIC: Self = Self(0b0000_0000_0100);
+    /// Underlined.
+    pub const UNDERLINED: Self = Self(0b0000_0000_1000);
+    /// Slow blink.
+    pub const SLOW_BLINK: Self = Self(0b0000_0001_0000);
+    /// Rapid blink.
+    pub const RAPID_BLINK: Self = Self(0b0000_0010_0000);
+    /// Swap foreground and background.
+    pub const REVERSED: Self = Self(0b0000_0100_0000);
+    /// Hidden / concealed.
+    pub const HIDDEN: Self = Self(0b0000_1000_0000);
+    /// Struck through.
+    pub const CROSSED_OUT: Self = Self(0b0001_0000_0000);
+
+    /// Every flag paired with its name, for [`Debug`] and for `all()`.
+    const NAMED: [(&'static str, Self); 9] = [
+        ("BOLD", Self::BOLD),
+        ("DIM", Self::DIM),
+        ("ITALIC", Self::ITALIC),
+        ("UNDERLINED", Self::UNDERLINED),
+        ("SLOW_BLINK", Self::SLOW_BLINK),
+        ("RAPID_BLINK", Self::RAPID_BLINK),
+        ("REVERSED", Self::REVERSED),
+        ("HIDDEN", Self::HIDDEN),
+        ("CROSSED_OUT", Self::CROSSED_OUT),
+    ];
+
+    /// No attributes.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Every attribute.
+    pub const fn all() -> Self {
+        Self(0b0001_1111_1111)
+    }
+
+    /// Whether no attribute is set.
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Whether every flag in `other` is set here.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// The flags set in either.
+    #[must_use = "returns a new Modifier"]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// The flags set in both.
+    #[must_use = "returns a new Modifier"]
+    pub const fn intersection(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    /// The flags set here but not in `other`.
+    #[must_use = "returns a new Modifier"]
+    pub const fn difference(self, other: Self) -> Self {
+        Self(self.0 & !other.0)
+    }
+
+    /// The raw bits, for a backend translating to terminal attributes.
+    pub const fn bits(self) -> u16 {
+        self.0
+    }
+}
+
+impl core::ops::BitOr for Modifier {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self {
+        self.union(rhs)
+    }
+}
+
+impl core::ops::BitOrAssign for Modifier {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+impl core::ops::BitAnd for Modifier {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self {
+        self.intersection(rhs)
+    }
+}
+
+impl core::ops::Sub for Modifier {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        self.difference(rhs)
+    }
+}
+
+/// The appearance of a run of cells.
+///
+/// Every field is optional, which is what makes styles *composable*: a
+/// component resolves a [`Role`](crate::style::Role) from the theme and then
+/// patches a caller's override on top, and only the fields the override sets
+/// are replaced. [`patch`](Self::patch) is that operation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Style {
+    /// Foreground color, or `None` to inherit.
+    pub fg: Option<Color>,
+    /// Background color, or `None` to inherit.
+    pub bg: Option<Color>,
+    /// Underline color, or `None` to inherit. Honored only by terminals that
+    /// implement the extended underline SGR.
+    pub underline_color: Option<Color>,
+    /// Attributes this style turns on.
+    pub add_modifier: Modifier,
+    /// Attributes this style turns off. Applied after `add_modifier`, so
+    /// removing an attribute wins over adding it in the same style.
+    pub sub_modifier: Modifier,
+}
+
+impl Style {
+    /// A style that changes nothing.
+    pub const fn new() -> Self {
+        Self {
+            fg: None,
+            bg: None,
+            underline_color: None,
+            add_modifier: Modifier::empty(),
+            sub_modifier: Modifier::empty(),
+        }
+    }
+
+    /// A style that resets every attribute to the terminal default.
+    ///
+    /// Distinct from [`new`](Self::new): `new` inherits what is already there,
+    /// `reset` actively clears it.
+    pub const fn reset() -> Self {
+        Self {
+            fg: Some(Color::Reset),
+            bg: Some(Color::Reset),
+            underline_color: Some(Color::Reset),
+            add_modifier: Modifier::empty(),
+            sub_modifier: Modifier::all(),
+        }
+    }
+
+    /// Set the foreground color.
+    #[must_use = "returns a new Style"]
+    pub const fn fg(mut self, color: Color) -> Self {
+        self.fg = Some(color);
+        self
+    }
+
+    /// Set the background color.
+    #[must_use = "returns a new Style"]
+    pub const fn bg(mut self, color: Color) -> Self {
+        self.bg = Some(color);
+        self
+    }
+
+    /// Set the underline color.
+    #[must_use = "returns a new Style"]
+    pub const fn underline_color(mut self, color: Color) -> Self {
+        self.underline_color = Some(color);
+        self
+    }
+
+    /// Turn `modifier` on, and stop turning it off.
+    #[must_use = "returns a new Style"]
+    pub const fn add_modifier(mut self, modifier: Modifier) -> Self {
+        self.sub_modifier = self.sub_modifier.difference(modifier);
+        self.add_modifier = self.add_modifier.union(modifier);
+        self
+    }
+
+    /// Turn `modifier` off, and stop turning it on.
+    #[must_use = "returns a new Style"]
+    pub const fn remove_modifier(mut self, modifier: Modifier) -> Self {
+        self.add_modifier = self.add_modifier.difference(modifier);
+        self.sub_modifier = self.sub_modifier.union(modifier);
+        self
+    }
+
+    /// Whether this style turns `modifier` on.
+    pub const fn has_modifier(self, modifier: Modifier) -> bool {
+        self.add_modifier.contains(modifier)
+    }
+
+    /// Bold. Shorthand for `add_modifier(Modifier::BOLD)`.
+    #[must_use = "returns a new Style"]
+    pub const fn bold(self) -> Self {
+        self.add_modifier(Modifier::BOLD)
+    }
+
+    /// Dim. Shorthand for `add_modifier(Modifier::DIM)`.
+    #[must_use = "returns a new Style"]
+    pub const fn dim(self) -> Self {
+        self.add_modifier(Modifier::DIM)
+    }
+
+    /// Italic. Shorthand for `add_modifier(Modifier::ITALIC)`.
+    #[must_use = "returns a new Style"]
+    pub const fn italic(self) -> Self {
+        self.add_modifier(Modifier::ITALIC)
+    }
+
+    /// Underlined. Shorthand for `add_modifier(Modifier::UNDERLINED)`.
+    #[must_use = "returns a new Style"]
+    pub const fn underlined(self) -> Self {
+        self.add_modifier(Modifier::UNDERLINED)
+    }
+
+    /// Reversed. Shorthand for `add_modifier(Modifier::REVERSED)`.
+    #[must_use = "returns a new Style"]
+    pub const fn reversed(self) -> Self {
+        self.add_modifier(Modifier::REVERSED)
+    }
+
+    /// Struck through. Shorthand for `add_modifier(Modifier::CROSSED_OUT)`.
+    #[must_use = "returns a new Style"]
+    pub const fn crossed_out(self) -> Self {
+        self.add_modifier(Modifier::CROSSED_OUT)
+    }
+
+    /// Layer `other` on top of `self`.
+    ///
+    /// Fields `other` leaves unset keep `self`'s value; modifiers accumulate,
+    /// with `other`'s removals applied last. This is the operation that lets a
+    /// theme role and a per-call override compose without either needing to
+    /// know about the other.
+    #[must_use = "returns a new Style"]
+    pub fn patch<S: Into<Self>>(mut self, other: S) -> Self {
+        let other = other.into();
+        self.fg = other.fg.or(self.fg);
+        self.bg = other.bg.or(self.bg);
+        self.underline_color = other.underline_color.or(self.underline_color);
+        self.add_modifier = self.add_modifier.difference(other.sub_modifier);
+        self.add_modifier = self.add_modifier.union(other.add_modifier);
+        self.sub_modifier = self.sub_modifier.difference(other.add_modifier);
+        self.sub_modifier = self.sub_modifier.union(other.sub_modifier);
+        self
+    }
+}
+
+impl From<Color> for Style {
+    /// A color used where a `Style` is expected sets the foreground.
+    fn from(color: Color) -> Self {
+        Self::new().fg(color)
+    }
+}
+
+impl From<Modifier> for Style {
+    fn from(modifier: Modifier) -> Self {
+        Self::new().add_modifier(modifier)
+    }
+}
+
+impl fmt::Debug for Modifier {
+    /// Print `NONE` for the empty set rather than `Modifier(0x0)`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return f.write_str("NONE");
+        }
+        let mut first = true;
+        for (name, bit) in Self::NAMED {
+            if self.contains(bit) {
+                if !first {
+                    f.write_str(" | ")?;
+                }
+                f.write_str(name)?;
+                first = false;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The composition law components rely on: unset fields inherit, set fields
+    /// win. Asserted field by field rather than on a whole `Style` so a
+    /// regression names the field that broke.
+    #[test]
+    fn patch_keeps_unset_fields_and_replaces_set_ones() {
+        let base = Style::new().fg(Color::Red).bg(Color::Blue);
+        let over = Style::new().fg(Color::Green);
+        let merged = base.patch(over);
+        assert_eq!(merged.fg, Some(Color::Green));
+        assert_eq!(merged.bg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn patch_accumulates_added_modifiers() {
+        let merged = Style::new()
+            .add_modifier(Modifier::BOLD)
+            .patch(Style::new().add_modifier(Modifier::ITALIC));
+        assert!(merged.add_modifier.contains(Modifier::BOLD));
+        assert!(merged.add_modifier.contains(Modifier::ITALIC));
+    }
+
+    /// Removal has to beat an earlier add, or a theme role could never turn off
+    /// an attribute a wrapper switched on.
+    #[test]
+    fn a_later_removal_overrides_an_earlier_add() {
+        let merged = Style::new()
+            .add_modifier(Modifier::BOLD)
+            .patch(Style::new().remove_modifier(Modifier::BOLD));
+        assert!(!merged.add_modifier.contains(Modifier::BOLD));
+        assert!(merged.sub_modifier.contains(Modifier::BOLD));
+    }
+
+    /// Setting a modifier both ways on one style is a caller error; the last
+    /// call is what holds, in both directions.
+    #[test]
+    fn add_and_remove_are_mutually_exclusive_on_one_style() {
+        let removed = Style::new()
+            .add_modifier(Modifier::DIM)
+            .remove_modifier(Modifier::DIM);
+        assert!(!removed.add_modifier.contains(Modifier::DIM));
+        assert!(removed.sub_modifier.contains(Modifier::DIM));
+
+        let added = Style::new()
+            .remove_modifier(Modifier::DIM)
+            .add_modifier(Modifier::DIM);
+        assert!(added.add_modifier.contains(Modifier::DIM));
+        assert!(!added.sub_modifier.contains(Modifier::DIM));
+    }
+
+    #[test]
+    fn reset_clears_every_attribute() {
+        let reset = Style::reset();
+        assert_eq!(reset.fg, Some(Color::Reset));
+        assert_eq!(reset.bg, Some(Color::Reset));
+        assert_eq!(reset.sub_modifier, Modifier::all());
+    }
+
+    #[test]
+    fn empty_modifier_debugs_as_none() {
+        assert_eq!(format!("{:?}", Modifier::empty()), "NONE");
+        assert_eq!(format!("{:?}", Modifier::BOLD), "BOLD");
+        assert_eq!(
+            format!("{:?}", Modifier::BOLD | Modifier::ITALIC),
+            "BOLD | ITALIC"
+        );
+    }
+
+    #[test]
+    fn a_color_converts_to_a_foreground_style() {
+        assert_eq!(Style::from(Color::Red).fg, Some(Color::Red));
+    }
+}

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -1,15 +1,17 @@
 //! Styling and theming.
 //!
-//! `tuika` reuses ratatui's [`Style`], [`Color`], and [`Modifier`] rather than
-//! reinventing cell attributes, but components never hard-code colors: they
-//! pull from a [`Theme`] passed through the render context. Swapping the theme
+//! [`Style`], [`Color`], and [`Modifier`] are tuika's own cell attributes (see
+//! the `attrs` submodule), but components never hard-code colors: they pull
+//! from a [`Theme`] passed through the render context. Swapping the theme
 //! restyles every component at once, and downstream libraries can ship their
 //! own palette without touching component code.
 
-use ratatui_core::style::{Color, Modifier, Style};
-use ratatui_core::text::{Line, Span};
+mod attrs;
+
+pub use attrs::{Color, Modifier, Style};
 
 use crate::geometry::Padding;
+use crate::text::{Line, Span};
 
 /// Line-drawing style for bordered components.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -526,7 +528,7 @@ pub trait StyleResolver {
 ///
 /// ```
 /// use tuika::style::{StyleBundle, StyleSheet, Theme};
-/// use ratatui_core::style::Color;
+/// use tuika::ui::Color;
 ///
 /// let theme = Theme::default();
 /// let sheet = StyleSheet {
@@ -833,8 +835,8 @@ impl Gradient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::style::Modifier;
     use crate::tests::support::rainbow_theme;
-    use ratatui_core::style::Modifier;
 
     #[test]
     fn theme_helper_styles_map_to_slots() {
@@ -869,7 +871,7 @@ mod tests {
 
     #[test]
     fn default_theme_is_the_toolkit_identity_not_a_host_brand() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         // tuika's own look is warm red-on-dark. It is deliberately a neutral toolkit
         // identity, not any host's brand — a host with its own palette builds its own
         // `Theme` (e.g. yolop's `fullscreen::yolop_theme`) instead of inheriting this.
@@ -882,7 +884,7 @@ mod tests {
 
     #[test]
     fn bundle_apply_overrides_color_but_only_adds_modifiers() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         // A modifier-only bundle keeps the base's color and adds its modifier.
         let base = Style::default().fg(Color::Red);
         let emphasized = StyleBundle::new().italic().apply(base);
@@ -939,7 +941,7 @@ mod tests {
 
     #[test]
     fn lerp_color_blends_rgb_and_snaps_everything_else() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let a = Color::Rgb(0, 0, 0);
         let b = Color::Rgb(200, 100, 50);
         assert_eq!(lerp_color(a, b, 0.0), a);
@@ -955,7 +957,7 @@ mod tests {
 
     #[test]
     fn gradient_samples_stops_and_clamps_the_ends() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let g = Gradient::new(Color::Rgb(0, 0, 0), Color::Rgb(100, 100, 100));
         assert_eq!(g.sample(-1.0), Color::Rgb(0, 0, 0));
         assert_eq!(g.sample(0.5), Color::Rgb(50, 50, 50));
@@ -991,7 +993,7 @@ mod tests {
 
     #[test]
     fn gradient_line_sweeps_columns_and_merges_equal_runs() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let g = Gradient::new(Color::Rgb(0, 0, 0), Color::Rgb(240, 0, 0));
         let line = g.line("abcd");
         // Four columns sampled at their midpoints: 30, 90, 150, 210 red.
@@ -1029,7 +1031,7 @@ mod tests {
     #[test]
     fn gradient_line_paints_cells_through_text() {
         use crate::components::Text;
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let g = Gradient::new(Color::Rgb(0, 0, 0), Color::Rgb(240, 0, 0));
         let text = Text::new(vec![g.line("abcd")]);
         let buf = crate::testing::render(&text, 4, 1, &Theme::default());
@@ -1044,7 +1046,7 @@ mod tests {
 
     #[test]
     fn overriding_one_role_leaves_the_rest_at_theme_defaults() {
-        use ratatui_core::style::Color;
+        use crate::style::Color;
         let t = rainbow_theme();
         let sheet = StyleSheet {
             link: StyleBundle::new().fg(Color::Green).bold(),

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -1,15 +1,17 @@
-//! Clipped drawing surface over a ratatui [`Buffer`].
+//! Clipped drawing surface over the frame [`Buffer`].
 //!
 //! Components paint through a [`Surface`], which owns a mutable borrow of the
 //! frame buffer plus a clip [`Rect`]. Every write is intersected with the clip
 //! region, so a child can never scribble outside the area the layout gave it —
-//! this is what makes scroll viewports and overlays safe to compose. ratatui
-//! still owns the shadow-buffer diff against the terminal, so `tuika` pays
-//! nothing extra for dirty-cell tracking.
+//! this is what makes scroll viewports and overlays safe to compose.
+//!
+//! Nothing here tracks dirty cells: the frame is repainted in full and
+//! [`Buffer::diff`](crate::buffer::Buffer::diff) decides what reaches the
+//! terminal.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
+use crate::style::Style;
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::style::BorderGlyphs;
@@ -54,30 +56,33 @@ impl<'a> Surface<'a> {
         }
     }
 
-    /// Render one or more ratatui widgets without giving them unrestricted
-    /// access to the frame buffer.
+    /// Hand a callback a private scratch [`Buffer`] instead of the frame's own.
     ///
-    /// The callback receives a temporary [`Buffer`] covering `area`. Existing
-    /// cells are copied into it first, so widgets that only patch styles retain
-    /// the surrounding background. After the callback returns, only cells in
-    /// this surface's clip are composited back. A widget that writes outside
-    /// its assigned area therefore cannot overwrite a sibling or an overlay.
+    /// The callback receives a temporary buffer covering `area`, seeded with the
+    /// cells already there — so a painter that only patches styles keeps the
+    /// surrounding background. When it returns, only cells inside this surface's
+    /// clip are composited back, so a callback that writes outside its assigned
+    /// area cannot overwrite a sibling or an overlay.
+    ///
+    /// This is the escape hatch for anything that wants unrestricted buffer
+    /// access without actually getting it — including
+    /// [`render_ratatui`](Self::render_ratatui), which is this plus a type
+    /// conversion.
     ///
     /// # Example
     ///
     /// ```
-    /// use ratatui::widgets::{Sparkline, Widget};
     /// use tuika::Surface;
+    /// use tuika::ui::Style;
     ///
     /// # fn draw(surface: &mut Surface<'_>) {
-    /// let values = [1, 4, 2, 8];
     /// let area = surface.area();
-    /// surface.render_ratatui(area, |area, buffer| {
-    ///     Sparkline::default().data(&values).render(area, buffer);
+    /// surface.render_scratch(area, |area, buffer| {
+    ///     buffer.set_string(area.x, area.y, "scratch", Style::default());
     /// });
     /// # }
     /// ```
-    pub fn render_ratatui(&mut self, area: Rect, render: impl FnOnce(Rect, &mut Buffer)) {
+    pub fn render_scratch(&mut self, area: Rect, render: impl FnOnce(Rect, &mut Buffer)) {
         let render_area = area.intersection(self.buffer.area);
         if render_area.is_empty() {
             return;
@@ -103,6 +108,46 @@ impl<'a> Surface<'a> {
                 }
             }
         }
+    }
+
+    /// Render one or more ratatui widgets without giving them unrestricted
+    /// access to the frame buffer.
+    ///
+    /// Same containment as [`render_scratch`](Self::render_scratch) — the
+    /// callback gets a private buffer, and only the clipped region is
+    /// composited back — with the scratch converted to and from ratatui's
+    /// [`Buffer`](ratatui_core::buffer::Buffer) around the call. tuika no longer
+    /// shares a cell type with ratatui, so the conversion is what keeps every
+    /// existing ratatui widget usable.
+    ///
+    /// Requires the `ratatui` feature.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ratatui::widgets::{Sparkline, Widget};
+    /// use tuika::Surface;
+    ///
+    /// # fn draw(surface: &mut Surface<'_>) {
+    /// let values = [1, 4, 2, 8];
+    /// let area = surface.area();
+    /// surface.render_ratatui(area, |area, buffer| {
+    ///     Sparkline::default().data(&values).render(area, buffer);
+    /// });
+    /// # }
+    /// ```
+    #[cfg(feature = "ratatui")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ratatui")))]
+    pub fn render_ratatui(
+        &mut self,
+        area: Rect,
+        render: impl FnOnce(ratatui_core::layout::Rect, &mut ratatui_core::buffer::Buffer),
+    ) {
+        self.render_scratch(area, |area, scratch| {
+            let mut foreign = crate::interop::to_ratatui_buffer(scratch);
+            render(crate::interop::to_ratatui_rect(area), &mut foreign);
+            crate::interop::from_ratatui_buffer(&foreign, scratch);
+        });
     }
 
     fn contains(&self, x: u16, y: u16) -> bool {
@@ -224,23 +269,23 @@ impl<'a> Surface<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::buffer::Buffer;
     use crate::components::{Boxed, Text};
+    use crate::geometry::Rect;
+    use crate::style::Style;
     use crate::style::Theme;
     use crate::tests::support::{buffer, row};
     use crate::view::{RenderCtx, View, element};
-    use ratatui_core::buffer::Buffer;
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::Style;
 
     #[test]
-    fn ratatui_rendering_preserves_clip_even_if_buffer_expands() {
-        let mut buf = Buffer::filled(Rect::new(0, 0, 12, 3), ratatui_core::buffer::Cell::new("#"));
+    fn scratch_rendering_preserves_clip_even_if_buffer_expands() {
+        let mut buf = Buffer::filled(Rect::new(0, 0, 12, 3), crate::buffer::Cell::new("#"));
         let clip = Rect::new(4, 1, 4, 1);
         {
             let mut surface = Surface::new(&mut buf, clip);
-            surface.render_ratatui(Rect::new(2, 0, 8, 3), |_area, scratch| {
+            surface.render_scratch(Rect::new(2, 0, 8, 3), |_area, scratch| {
                 let expanded =
-                    Buffer::filled(Rect::new(0, 0, 12, 3), ratatui_core::buffer::Cell::new("x"));
+                    Buffer::filled(Rect::new(0, 0, 12, 3), crate::buffer::Cell::new("x"));
                 scratch.merge(&expanded);
             });
         }
@@ -258,16 +303,16 @@ mod tests {
     }
 
     #[test]
-    fn ratatui_rendering_starts_with_existing_cells() {
-        use ratatui_core::style::Color;
+    fn scratch_rendering_starts_with_existing_cells() {
+        use crate::style::Color;
 
-        let mut cell = ratatui_core::buffer::Cell::new(".");
+        let mut cell = crate::buffer::Cell::new(".");
         cell.set_bg(Color::Blue);
         let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), cell);
         let area = buf.area;
         {
             let mut surface = Surface::new(&mut buf, area);
-            surface.render_ratatui(area, |_area, scratch| {
+            surface.render_scratch(area, |_area, scratch| {
                 scratch[(1, 0)].set_char('x');
             });
         }
@@ -276,21 +321,21 @@ mod tests {
     }
 
     #[test]
-    fn ratatui_rendering_limits_scratch_to_the_frame() {
+    fn scratch_rendering_limits_scratch_to_the_frame() {
         let mut buf = buffer(3, 2);
         let area = buf.area;
         let mut surface = Surface::new(&mut buf, area);
-        surface.render_ratatui(Rect::new(0, 0, u16::MAX, u16::MAX), |actual, _| {
+        surface.render_scratch(Rect::new(0, 0, u16::MAX, u16::MAX), |actual, _| {
             assert_eq!(actual, Rect::new(0, 0, 3, 2));
         });
     }
 
     #[test]
-    fn ratatui_rendering_tolerates_a_callback_that_resizes_its_buffer() {
-        let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui_core::buffer::Cell::new("#"));
+    fn scratch_rendering_tolerates_a_callback_that_resizes_its_buffer() {
+        let mut buf = Buffer::filled(Rect::new(0, 0, 4, 1), crate::buffer::Cell::new("#"));
         let area = buf.area;
         let mut surface = Surface::new(&mut buf, area);
-        surface.render_ratatui(area, |_area, scratch| {
+        surface.render_scratch(area, |_area, scratch| {
             scratch.resize(Rect::new(0, 0, 1, 1));
             scratch[(0, 0)].set_char('x');
         });
@@ -302,7 +347,7 @@ mod tests {
         // A ZWJ family (multiple scalars) is a single grapheme: it must occupy one
         // cell and advance the cursor by 2, not scatter one component per cell.
         const FAMILY: &str = "👨\u{200D}👩\u{200D}👧";
-        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui_core::buffer::Cell::new("."));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), crate::buffer::Cell::new("."));
         let end = {
             let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 6, 1));
             surface.set_string(0, 0, &format!("{FAMILY}x"), Style::default())
@@ -319,7 +364,7 @@ mod tests {
 
     #[test]
     fn set_string_drops_a_wide_cluster_that_cannot_fit_the_clip() {
-        let mut buf = Buffer::filled(Rect::new(0, 0, 3, 1), ratatui_core::buffer::Cell::new("."));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 3, 1), crate::buffer::Cell::new("."));
         let end = {
             let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 1, 1));
             surface.set_string(0, 0, "界", Style::default())
@@ -332,7 +377,7 @@ mod tests {
     fn set_string_skip_pans_and_carries_across_calls() {
         // "abcdef" drawn with a running skip of 2: "ab" dropped, "cdef" drawn
         // from x=0. A second call keeps consuming from the same skip.
-        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), ratatui_core::buffer::Cell::new("."));
+        let mut buf = Buffer::filled(Rect::new(0, 0, 6, 1), crate::buffer::Cell::new("."));
         let mut surface = Surface::new(&mut buf, Rect::new(0, 0, 6, 1));
         let mut skip = 2u16;
         let end = surface.set_string_skip(0, 0, "abcdef", Style::default(), &mut skip);
@@ -343,7 +388,7 @@ mod tests {
 
         // With skip still set, a whole short span is consumed without drawing and
         // the skip carries to the next call.
-        let mut buf2 = Buffer::filled(Rect::new(0, 0, 4, 1), ratatui_core::buffer::Cell::new("."));
+        let mut buf2 = Buffer::filled(Rect::new(0, 0, 4, 1), crate::buffer::Cell::new("."));
         let mut s2 = Surface::new(&mut buf2, Rect::new(0, 0, 4, 1));
         let mut skip = 3u16;
         let x = s2.set_string_skip(0, 0, "ab", Style::default(), &mut skip); // fully skipped
@@ -359,8 +404,7 @@ mod tests {
     fn set_string_skip_zero_matches_set_string() {
         // The flush-left fast path: skip == 0 must be identical to set_string.
         let render = |use_skip: bool| {
-            let mut buf =
-                Buffer::filled(Rect::new(0, 0, 8, 1), ratatui_core::buffer::Cell::new("."));
+            let mut buf = Buffer::filled(Rect::new(0, 0, 8, 1), crate::buffer::Cell::new("."));
             let end = {
                 let mut s = Surface::new(&mut buf, Rect::new(0, 0, 8, 1));
                 if use_skip {

--- a/src/term/backend.rs
+++ b/src/term/backend.rs
@@ -17,6 +17,10 @@
 
 use std::io::{self, Write};
 
+use crate::buffer::Cell;
+use crate::geometry::{Position, Size};
+use crate::style::{Color, Modifier};
+use crate::term::traits::{Backend, ClearType, WindowSize};
 use crossterm::cursor::{Hide, MoveTo, Show};
 use crossterm::queue;
 use crossterm::style::{
@@ -24,27 +28,25 @@ use crossterm::style::{
     SetBackgroundColor, SetColors, SetForegroundColor, SetUnderlineColor,
 };
 use crossterm::terminal::{self, Clear};
-use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::Cell;
-use ratatui_core::layout::{Position, Size};
-use ratatui_core::style::{Color, Modifier};
 
 use super::hyperlink::to_ct_color;
 
-/// A ratatui [`Backend`] that draws through crossterm.
+/// A [`Backend`] that draws through crossterm.
 ///
-/// Internal: hosts reach the terminal through
-/// [`Runner`](crate::Runner)/[`AsyncRunner`](crate::AsyncRunner), or wrap their
-/// own writer in [`HyperlinkBackend`](super::hyperlink::HyperlinkBackend). A
-/// host that wants a bare backend still has ratatui's own.
-pub(crate) struct CrosstermBackend<W: Write> {
+/// Most hosts never name this: [`Runner`](crate::Runner) and
+/// [`AsyncRunner`](crate::AsyncRunner) build one, and a host wanting OSC 8
+/// hyperlinks wraps its writer in
+/// [`HyperlinkBackend`](super::hyperlink::HyperlinkBackend) instead. It is
+/// public for the host that drives
+/// [`Terminal`](crate::term::terminal::Terminal) itself.
+pub struct CrosstermBackend<W: Write> {
     writer: W,
 }
 
 impl<W: Write> CrosstermBackend<W> {
     /// Draw into `writer` — in production the process's stdout, in tests a
     /// `Vec<u8>` the assertions read back.
-    pub(crate) const fn new(writer: W) -> Self {
+    pub const fn new(writer: W) -> Self {
         Self { writer }
     }
 }
@@ -331,7 +333,7 @@ impl crossterm::Command for ScrollInRegion {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui_core::style::Style;
+    use crate::style::Style;
 
     /// Draw `cells` at consecutive columns on row 0 and return the byte stream.
     fn drawn(cells: &[(&'static str, Style)]) -> String {
@@ -424,6 +426,11 @@ mod tests {
     /// backend would plausibly drift — cursor elision, the shared
     /// intensity/blink SGR slots, indexed and truecolor pairs, underline color,
     /// and wide/zero-width symbols.
+    ///
+    /// Gated on the `ratatui` feature because the comparison needs the cell
+    /// conversion in [`crate::interop`], which is what that feature turns on.
+    /// CI runs `--all-features`, so the proof still runs on every change.
+    #[cfg(feature = "ratatui")]
     #[test]
     fn the_byte_stream_matches_ratatui_crossterm_exactly() {
         use ratatui::backend::CrosstermBackend as Reference;
@@ -461,11 +468,15 @@ mod tests {
         let mut ours = CrosstermBackend::new(Vec::<u8>::new());
         ours.draw(cells.iter().map(|(x, y, cell)| (*x, *y, cell)))
             .expect("draw");
+        let foreign: Vec<(u16, u16, ratatui_core::buffer::Cell)> = cells
+            .iter()
+            .map(|(x, y, cell)| (*x, *y, crate::interop::to_ratatui_cell(cell)))
+            .collect();
         let mut expected = Vec::<u8>::new();
         let mut reference = Reference::new(&mut expected);
         ratatui::backend::Backend::draw(
             &mut reference,
-            cells.iter().map(|(x, y, cell)| (*x, *y, cell)),
+            foreign.iter().map(|(x, y, cell)| (*x, *y, cell)),
         )
         .expect("draw");
 

--- a/src/term/hyperlink.rs
+++ b/src/term/hyperlink.rs
@@ -25,16 +25,16 @@ use std::io::{self, Write};
 use std::num::NonZeroU16;
 
 use super::backend::CrosstermBackend;
+use crate::buffer::{Buffer, Cell, CellDiffOption};
+use crate::geometry::{Position, Rect, Size};
+use crate::style::{Color, Modifier};
+use crate::term::traits::{Backend, ClearType, WindowSize};
+use crate::text::{Line, Span};
 use crossterm::queue;
 use crossterm::style::{
     Attribute, Color as CtColor, Print, ResetColor, SetAttribute, SetBackgroundColor,
     SetForegroundColor,
 };
-use ratatui_core::backend::{Backend, ClearType, WindowSize};
-use ratatui_core::buffer::{Buffer, Cell, CellDiffOption};
-use ratatui_core::layout::{Position, Rect, Size};
-use ratatui_core::style::{Color, Modifier};
-use ratatui_core::text::{Line, Span};
 
 /// String terminator for an OSC sequence: `ESC \`.
 const ST: &str = "\x1b\\";
@@ -844,7 +844,7 @@ mod tests {
     fn write_line_emits_color_and_underline_then_resets() {
         let line = Line::from(Span::styled(
             "https://a.dev",
-            ratatui_core::style::Style::default()
+            crate::style::Style::default()
                 .fg(Color::Rgb(45, 91, 158))
                 .add_modifier(Modifier::UNDERLINED),
         ));
@@ -870,8 +870,10 @@ mod tests {
 
     #[test]
     fn ctrl_click_returns_visible_url_under_pointer() {
+        use crate::buffer::Buffer;
+        use crate::geometry::Rect;
+        use crate::style::Style;
         use crate::{Mouse, MouseButton, MouseKind};
-        use ratatui_core::{buffer::Buffer, layout::Rect, style::Style};
         let area = Rect::new(3, 2, 40, 1);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 50, 5));
         buffer.set_string(
@@ -890,8 +892,10 @@ mod tests {
 
     #[test]
     fn ctrl_click_ignores_plain_clicks_and_non_url_text() {
+        use crate::buffer::Buffer;
+        use crate::geometry::Rect;
+        use crate::style::Style;
         use crate::{Mouse, MouseButton, MouseKind};
-        use ratatui_core::{buffer::Buffer, layout::Rect, style::Style};
         let area = Rect::new(0, 0, 30, 1);
         let mut buffer = Buffer::empty(area);
         buffer.set_string(0, 0, "https://example.com plain", Style::default());
@@ -989,7 +993,7 @@ mod tests {
     /// Render a row of single-char cells through a backend built with `policy`
     /// and return the emitted bytes.
     fn draw_row_with(text: &str, policy: LinkPolicy) -> String {
-        use ratatui_core::buffer::Cell;
+        use crate::buffer::Cell;
         let cells: Vec<(u16, u16, Cell)> = text
             .chars()
             .enumerate()
@@ -1071,8 +1075,8 @@ mod tests {
         // Reproduction: a markdown `[label](url)` paints only the label. Without
         // carrying the destination into the buffer, Ctrl+click / Ghostty OSC 8
         // has nothing to open. apply_buffer_links embeds the target.
+        use crate::style::Style;
         use crate::{Mouse, MouseButton, MouseKind};
-        use ratatui_core::style::Style;
         let area = Rect::new(2, 1, 20, 1);
         let mut buffer = Buffer::empty(Rect::new(0, 0, 30, 4));
         buffer.set_string(area.x, area.y, "see docs here", Style::default());
@@ -1107,7 +1111,7 @@ mod tests {
 
     #[test]
     fn apply_buffer_links_respects_none_policy() {
-        use ratatui_core::style::Style;
+        use crate::style::Style;
         let mut buffer = Buffer::empty(Rect::new(0, 0, 10, 1));
         buffer.set_string(0, 0, "docs", Style::default());
         apply_buffer_links(

--- a/src/term/image.rs
+++ b/src/term/image.rs
@@ -40,7 +40,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 /// String terminator for an APC sequence: `ESC \`.
 const ST: &str = "\x1b\\";

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -32,7 +32,7 @@
 //! host-initiated, run once at startup in raw mode, and share a single fenced
 //! round-trip — see [`capabilities::Capabilities::query_with_palette`].
 
-pub(crate) mod backend;
+pub mod backend;
 pub mod capabilities;
 pub mod clipboard;
 pub mod hyperlink;
@@ -40,3 +40,6 @@ pub mod image;
 pub mod palette;
 pub mod pointer;
 pub mod progress;
+pub mod terminal;
+pub mod testbackend;
+pub mod traits;

--- a/src/term/palette.rs
+++ b/src/term/palette.rs
@@ -47,7 +47,7 @@
 //! tuika already makes (see
 //! [`Capabilities::query_with_palette`](crate::term::capabilities::Capabilities::query_with_palette)).
 
-use ratatui_core::style::Color;
+use crate::style::Color;
 
 use crate::style::{CodeTheme, Theme};
 

--- a/src/term/terminal.rs
+++ b/src/term/terminal.rs
@@ -1,0 +1,889 @@
+//! The render loop: [`Terminal`], [`Viewport`], and [`Frame`].
+//!
+//! `Terminal` owns two [`Buffer`]s and alternates between them. Each
+//! [`draw`](Terminal::draw) paints the whole frame into the back buffer, diffs
+//! it against the front one, and hands only the changed cells to the
+//! [`Backend`]. That diff is the *only* reconciliation in tuika — it is what
+//! makes rebuilding every `View` from application state each frame affordable,
+//! and why there is no retained widget tree above it.
+//!
+//! # Viewports
+//!
+//! [`Viewport::Fullscreen`] owns the whole screen and follows resizes.
+//! [`Viewport::Fixed`] owns a rectangle and never moves on its own.
+//!
+//! [`Viewport::Inline`] is the interesting one and the basis of
+//! [`ScreenMode::SplitFooter`](crate::ScreenMode): the viewport is anchored to
+//! the cursor row where it was created and spans the full width, with ordinary
+//! terminal output continuing to scroll *above* it.
+//! [`insert_before`](Terminal::insert_before) publishes a block into that
+//! region, which is how a footer stays pinned while finished output becomes
+//! real scrollback.
+
+use crate::buffer::Buffer;
+use crate::geometry::{Position, Rect, Size};
+use crate::term::traits::{Backend, ClearType};
+
+/// What part of the screen a [`Terminal`] draws into.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Viewport {
+    /// The whole terminal. Resizes automatically.
+    #[default]
+    Fullscreen,
+    /// A full-width strip of `height` rows, anchored to the cursor row it was
+    /// created at, with normal output scrolling above it.
+    Inline(u16),
+    /// A fixed rectangle. Never resized automatically; the host calls
+    /// [`Terminal::resize`] if the region should change.
+    Fixed(Rect),
+}
+
+/// How to construct a [`Terminal`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct TerminalOptions {
+    /// The viewport to draw into.
+    pub viewport: Viewport,
+}
+
+/// One frame being composed.
+///
+/// Handed to the [`draw`](Terminal::draw) callback; everything painted through
+/// it lands in the back buffer and is diffed when the callback returns.
+pub struct Frame<'a> {
+    area: Rect,
+    buffer: &'a mut Buffer,
+    cursor_position: Option<Position>,
+    count: usize,
+}
+
+impl Frame<'_> {
+    /// The region this frame covers. For an inline viewport the origin is the
+    /// viewport's real screen row, not `(0, 0)`.
+    pub fn area(&self) -> Rect {
+        self.area
+    }
+
+    /// The cell grid to paint into.
+    pub fn buffer_mut(&mut self) -> &mut Buffer {
+        self.buffer
+    }
+
+    /// Show the cursor at `position` after this frame is flushed.
+    ///
+    /// Left unset the cursor stays hidden — which is what a full-screen app
+    /// wants; a text input calls this to put the caret where it belongs.
+    pub fn set_cursor_position<P: Into<Position>>(&mut self, position: P) {
+        self.cursor_position = Some(position.into());
+    }
+
+    /// How many frames have been drawn, for animation and for tests that need a
+    /// deterministic tick.
+    pub fn count(&self) -> usize {
+        self.count
+    }
+}
+
+/// The render loop over a [`Backend`].
+#[derive(Debug)]
+pub struct Terminal<B: Backend> {
+    backend: B,
+    /// Front and back; `current` selects which is being painted.
+    buffers: [Buffer; 2],
+    current: usize,
+    hidden_cursor: bool,
+    viewport: Viewport,
+    viewport_area: Rect,
+    /// The screen size as of the last resize check, so `autoresize` can notice
+    /// a change without re-laying out every frame.
+    last_known_area: Rect,
+    /// Where the cursor was left, which an inline viewport needs in order to
+    /// re-anchor itself across a resize.
+    last_known_cursor_pos: Position,
+    frame_count: usize,
+}
+
+impl<B: Backend> Terminal<B> {
+    /// A full-screen terminal over `backend`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error if the screen size cannot be read.
+    pub fn new(backend: B) -> Result<Self, B::Error> {
+        Self::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fullscreen,
+            },
+        )
+    }
+
+    /// A terminal with an explicit viewport.
+    ///
+    /// An [`Inline`](Viewport::Inline) viewport is anchored here: the backend is
+    /// asked where the cursor is, and lines are appended if there is not enough
+    /// room below it for the requested height.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error if the screen size or cursor position cannot
+    /// be read.
+    pub fn with_options(mut backend: B, options: TerminalOptions) -> Result<Self, B::Error> {
+        let area: Rect = match options.viewport {
+            Viewport::Fullscreen | Viewport::Inline(_) => {
+                let size = backend.size()?;
+                Rect::new(0, 0, size.width, size.height)
+            }
+            Viewport::Fixed(area) => area,
+        };
+        let (viewport_area, cursor_pos) = match options.viewport {
+            Viewport::Fullscreen => (area, Position::ORIGIN),
+            Viewport::Inline(height) => {
+                compute_inline_size(&mut backend, height, area.as_size(), 0)?
+            }
+            Viewport::Fixed(area) => (area, area.as_position()),
+        };
+        Ok(Self {
+            backend,
+            buffers: [Buffer::empty(viewport_area), Buffer::empty(viewport_area)],
+            current: 0,
+            hidden_cursor: false,
+            viewport: options.viewport,
+            viewport_area,
+            last_known_area: area,
+            last_known_cursor_pos: cursor_pos,
+            frame_count: 0,
+        })
+    }
+
+    /// The backend, for a caller that needs to emit escapes tuika does not
+    /// model — an image transmission, an OSC progress update.
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Mutable access to the backend.
+    pub fn backend_mut(&mut self) -> &mut B {
+        &mut self.backend
+    }
+
+    /// The viewport this terminal draws into.
+    pub fn viewport(&self) -> Viewport {
+        self.viewport
+    }
+
+    /// A [`Frame`] over the back buffer without drawing it.
+    ///
+    /// Useful for reading the area a frame *would* have — the split-footer code
+    /// uses it to measure before publishing.
+    pub fn get_frame(&mut self) -> Frame<'_> {
+        let count = self.frame_count;
+        Frame {
+            area: self.viewport_area,
+            buffer: &mut self.buffers[self.current],
+            cursor_position: None,
+            count,
+        }
+    }
+
+    /// The current back buffer.
+    pub fn current_buffer_mut(&mut self) -> &mut Buffer {
+        &mut self.buffers[self.current]
+    }
+
+    /// The screen size in cells.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn size(&self) -> Result<Size, B::Error> {
+        self.backend.size()
+    }
+
+    /// Compose one frame and flush it.
+    ///
+    /// Resizes first if the terminal changed size, runs `render`, diffs the
+    /// result against the previous frame, writes only what changed, and then
+    /// positions the cursor — hiding it unless `render` asked for it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error if any stage fails.
+    pub fn draw<F>(&mut self, render: F) -> Result<(), B::Error>
+    where
+        F: FnOnce(&mut Frame<'_>),
+    {
+        self.autoresize()?;
+
+        let mut frame = self.get_frame();
+        render(&mut frame);
+        let cursor_position = frame.cursor_position;
+
+        self.flush()?;
+
+        match cursor_position {
+            None => self.hide_cursor()?,
+            Some(position) => {
+                self.show_cursor()?;
+                self.set_cursor_position(position)?;
+            }
+        }
+
+        self.swap_buffers();
+        self.backend.flush()?;
+        self.frame_count = self.frame_count.wrapping_add(1);
+        Ok(())
+    }
+
+    /// Diff the back buffer against the front one and write the difference.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn flush(&mut self) -> Result<(), B::Error> {
+        let previous = &self.buffers[1 - self.current];
+        let current = &self.buffers[self.current];
+        let updates = previous.diff(current);
+        if let Some((x, y, _)) = updates.last() {
+            self.last_known_cursor_pos = Position { x: *x, y: *y };
+        }
+        self.backend.draw(updates.into_iter())
+    }
+
+    /// Make the back buffer current and blank the one just shown.
+    fn swap_buffers(&mut self) {
+        self.buffers[1 - self.current].reset();
+        self.current = 1 - self.current;
+    }
+
+    /// Move the viewport to `area`, discarding both buffers.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn resize(&mut self, area: Rect) -> Result<(), B::Error> {
+        let (mut next_area, cursor_to_restore) = match self.viewport {
+            Viewport::Inline(height) => {
+                let offset = self
+                    .last_known_cursor_pos
+                    .y
+                    .saturating_sub(self.viewport_area.top());
+                let (next_area, cursor) =
+                    compute_inline_size(&mut self.backend, height, area.as_size(), offset)?;
+                (next_area, Some(cursor))
+            }
+            Viewport::Fixed(_) | Viewport::Fullscreen => (area, None),
+        };
+
+        // A narrower screen re-wraps everything already on it, so the old rows
+        // cannot be trusted as a diff baseline — start from a cleared screen.
+        if next_area.width < self.viewport_area.width {
+            next_area.y = 0;
+            self.backend.clear_region(ClearType::All)?;
+        }
+
+        self.set_viewport_area(next_area);
+        self.clear()?;
+        if let Some(cursor) = cursor_to_restore {
+            self.backend.set_cursor_position(cursor)?;
+        }
+        self.last_known_area = area;
+        Ok(())
+    }
+
+    /// Resize if the terminal changed size since the last check.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn autoresize(&mut self) -> Result<(), B::Error> {
+        if matches!(self.viewport, Viewport::Fullscreen | Viewport::Inline(_)) {
+            let size = self.backend.size()?;
+            let area = Rect::new(0, 0, size.width, size.height);
+            if area != self.last_known_area {
+                self.resize(area)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn set_viewport_area(&mut self, area: Rect) {
+        self.buffers[self.current].resize(area);
+        self.buffers[1 - self.current].resize(area);
+        self.viewport_area = area;
+    }
+
+    /// Blank *this terminal's own region* and drop the diff baseline, so the
+    /// next frame repaints in full.
+    ///
+    /// Scoping the erase to the viewport is load-bearing for an inline
+    /// viewport: everything above it is the user's scrollback, including blocks
+    /// [`insert_before`](Self::insert_before) just published, and a full-screen
+    /// erase would wipe them.
+    ///
+    /// Resetting the previous buffer matters just as much — without it the next
+    /// diff would compare against rows no longer on screen and elide them as
+    /// unchanged, leaving the viewport blank.
+    pub fn clear(&mut self) -> Result<(), B::Error> {
+        match self.viewport {
+            Viewport::Fullscreen => self.backend.clear_region(ClearType::All)?,
+            Viewport::Inline(_) => {
+                self.backend
+                    .set_cursor_position(self.viewport_area.as_position())?;
+                self.backend.clear_region(ClearType::AfterCursor)?;
+            }
+            Viewport::Fixed(area) => {
+                // No escape erases an arbitrary rectangle, so blank it by
+                // painting spaces over exactly the cells it owns.
+                let blank = Buffer::empty(area);
+                let cells: Vec<_> = blank
+                    .content
+                    .iter()
+                    .enumerate()
+                    .map(|(i, cell)| {
+                        let width = area.width.max(1) as usize;
+                        (
+                            area.x + (i % width) as u16,
+                            area.y + (i / width) as u16,
+                            cell,
+                        )
+                    })
+                    .collect();
+                self.backend.draw(cells.into_iter())?;
+            }
+        }
+        self.buffers[1 - self.current].reset();
+        Ok(())
+    }
+
+    /// Hide the cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn hide_cursor(&mut self) -> Result<(), B::Error> {
+        self.backend.hide_cursor()?;
+        self.hidden_cursor = true;
+        Ok(())
+    }
+
+    /// Show the cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn show_cursor(&mut self) -> Result<(), B::Error> {
+        self.backend.show_cursor()?;
+        self.hidden_cursor = false;
+        Ok(())
+    }
+
+    /// Where the cursor is.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn get_cursor_position(&mut self) -> Result<Position, B::Error> {
+        self.backend.get_cursor_position()
+    }
+
+    /// Move the cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), B::Error> {
+        let position = position.into();
+        self.backend.set_cursor_position(position)?;
+        self.last_known_cursor_pos = position;
+        Ok(())
+    }
+
+    /// Publish `height` rows of content directly above an inline viewport,
+    /// pushing earlier output into scrollback.
+    ///
+    /// A no-op for any other viewport: there is nothing "above" a full-screen
+    /// app. This is the mechanism behind
+    /// [`Scrollback`](crate::Scrollback) — finished output becomes real
+    /// terminal scrollback the user can select and scroll, while the footer
+    /// stays pinned below it.
+    ///
+    /// The implementation is deliberately the *portable* one: draw the block,
+    /// scroll only as far as needed, then repaint the viewport. A DECSTBM
+    /// scrolling region would avoid the repaint, but rows leaving such a region
+    /// are discarded by the terminal rather than entering scrollback — which
+    /// would defeat the whole point. See the `scrolling-regions` note on
+    /// [`ScreenMode`](crate::ScreenMode).
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend's error.
+    pub fn insert_before<F>(&mut self, height: u16, draw: F) -> Result<(), B::Error>
+    where
+        F: FnOnce(&mut Buffer),
+    {
+        if !matches!(self.viewport, Viewport::Inline(_)) {
+            return Ok(());
+        }
+        #[cfg(feature = "scrolling-regions")]
+        return self.insert_before_scrolling_regions(height, draw);
+        #[cfg(not(feature = "scrolling-regions"))]
+        self.insert_before_portable(height, draw)
+    }
+
+    /// Publish by drawing the block and repainting the viewport beneath it.
+    ///
+    /// Portable to any terminal, and the only path that puts the displaced rows
+    /// into scrollback.
+    #[cfg_attr(feature = "scrolling-regions", allow(dead_code))]
+    fn insert_before_portable<F>(&mut self, height: u16, draw: F) -> Result<(), B::Error>
+    where
+        F: FnOnce(&mut Buffer),
+    {
+        let width = self.viewport_area.width;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, width, height));
+        draw(&mut buffer);
+        let mut cells = buffer.content.as_slice();
+
+        // Signed arithmetic throughout: the intermediate sums genuinely go
+        // negative, and clamping them at zero as u16 would silently mis-scroll.
+        let mut drawn_height = i32::from(self.viewport_area.top());
+        let mut remaining = i32::from(height);
+        let viewport_height = i32::from(self.viewport_area.height);
+        let screen_height = i32::from(self.last_known_area.height);
+
+        // Draw a screenful at a time until what is left of the block plus the
+        // viewport fits, so the tail can go out in one final write.
+        while remaining + viewport_height > screen_height {
+            let to_draw = remaining.min(screen_height);
+            let scroll_up = 0.max(drawn_height + to_draw - screen_height);
+            self.scroll_up(scroll_up as u16)?;
+            cells = self.draw_lines((drawn_height - scroll_up) as u16, to_draw as u16, cells)?;
+            drawn_height += to_draw - scroll_up;
+            remaining -= to_draw;
+        }
+
+        // Scroll just enough that the viewport ends up back at the bottom.
+        let scroll_up = 0.max(drawn_height + remaining + viewport_height - screen_height);
+        self.scroll_up(scroll_up as u16)?;
+        self.draw_lines((drawn_height - scroll_up) as u16, remaining as u16, cells)?;
+        drawn_height += remaining - scroll_up;
+
+        self.set_viewport_area(Rect {
+            y: drawn_height as u16,
+            ..self.viewport_area
+        });
+
+        // Cleared only now: the block's cells are dense, so they already
+        // overwrote the screen, and clearing before scrolling pushes garbage
+        // into tmux's scrollback.
+        self.clear()?;
+        Ok(())
+    }
+
+    /// Publish using DECSTBM scrolling regions, which move only the rows above
+    /// the viewport and so leave the footer painted.
+    ///
+    /// Faster than the portable path — no viewport repaint — but the rows it
+    /// displaces are *discarded* by the terminal rather than entering
+    /// scrollback. That trade is why this is behind a feature; see the
+    /// `scrolling-regions` note on [`ScreenMode`](crate::ScreenMode).
+    #[cfg(feature = "scrolling-regions")]
+    fn insert_before_scrolling_regions<F>(
+        &mut self,
+        mut height: u16,
+        draw: F,
+    ) -> Result<(), B::Error>
+    where
+        F: FnOnce(&mut Buffer),
+    {
+        let width = self.viewport_area.width;
+        let mut buffer = Buffer::empty(Rect::new(0, 0, width, height));
+        draw(&mut buffer);
+        let mut cells = buffer.content.as_slice();
+
+        // A viewport filling the screen leaves no region to scroll into, so
+        // borrow its top row: draw one line there, scroll that single row into
+        // scrollback, repeat, then repaint the row from the front buffer.
+        if self.viewport_area.height == self.last_known_area.height {
+            let mut first = true;
+            while !cells.is_empty() {
+                cells = if first {
+                    self.draw_lines(0, 1, cells)?
+                } else {
+                    self.draw_lines_over_cleared(0, 1, cells)?
+                };
+                first = false;
+                self.backend.scroll_region_up(0..1, 1)?;
+            }
+            let width = self.viewport_area.width as usize;
+            let top = self.buffers[1 - self.current].content[0..width].to_vec();
+            self.draw_lines_over_cleared(0, 1, &top)?;
+            return Ok(());
+        }
+
+        // While there is room below, push the viewport down and fill the gap
+        // rather than scrolling anything off the top.
+        {
+            let top = self.viewport_area.top();
+            let bottom = self.viewport_area.bottom();
+            let screen_bottom = self.last_known_area.bottom();
+            if bottom < screen_bottom {
+                let to_draw = height.min(screen_bottom - bottom);
+                self.backend
+                    .scroll_region_down(top..bottom + to_draw, to_draw)?;
+                cells = self.draw_lines_over_cleared(top, to_draw, cells)?;
+                self.set_viewport_area(Rect {
+                    y: top + to_draw,
+                    ..self.viewport_area
+                });
+                height -= to_draw;
+            }
+        }
+
+        // The rest scrolls the region above the viewport up.
+        let top = self.viewport_area.top();
+        while height > 0 && top > 0 {
+            let to_draw = height.min(top);
+            self.backend.scroll_region_up(0..top, to_draw)?;
+            cells = self.draw_lines_over_cleared(top - to_draw, to_draw, cells)?;
+            height -= to_draw;
+        }
+        Ok(())
+    }
+
+    /// Like [`draw_lines`](Self::draw_lines) but diffing against blank cells, so
+    /// a row the terminal just cleared is written in full.
+    #[cfg(feature = "scrolling-regions")]
+    fn draw_lines_over_cleared<'a>(
+        &mut self,
+        y: u16,
+        count: u16,
+        cells: &'a [crate::buffer::Cell],
+    ) -> Result<&'a [crate::buffer::Cell], B::Error> {
+        let width = self.last_known_area.width as usize;
+        let split = (width * count as usize).min(cells.len());
+        let (to_draw, remainder) = cells.split_at(split);
+        if count > 0 && width > 0 {
+            let area = Rect::new(0, y, width as u16, count);
+            let blank = Buffer::empty(area);
+            let next = Buffer {
+                area,
+                content: to_draw.to_vec(),
+            };
+            let updates = blank.diff(&next);
+            self.backend.draw(updates.into_iter())?;
+            self.backend.flush()?;
+        }
+        Ok(remainder)
+    }
+
+    /// Write `count` rows of `cells` starting at screen row `y`.
+    fn draw_lines<'a>(
+        &mut self,
+        y: u16,
+        count: u16,
+        cells: &'a [crate::buffer::Cell],
+    ) -> Result<&'a [crate::buffer::Cell], B::Error> {
+        let width = self.last_known_area.width as usize;
+        let split = (width * count as usize).min(cells.len());
+        let (to_draw, remainder) = cells.split_at(split);
+        if count > 0 && width > 0 {
+            let updates = to_draw
+                .iter()
+                .enumerate()
+                .map(|(i, cell)| ((i % width) as u16, y + (i / width) as u16, cell));
+            self.backend.draw(updates)?;
+            self.backend.flush()?;
+        }
+        Ok(remainder)
+    }
+
+    /// Scroll the screen up by `lines`, pushing the top into scrollback.
+    fn scroll_up(&mut self, lines: u16) -> Result<(), B::Error> {
+        if lines > 0 {
+            self.backend.set_cursor_position(Position::new(
+                0,
+                self.last_known_area.height.saturating_sub(1),
+            ))?;
+            self.backend.append_lines(lines)?;
+        }
+        Ok(())
+    }
+}
+
+/// Where an inline viewport of `height` rows should sit, given the cursor.
+///
+/// Appends lines when the cursor is too near the bottom for the viewport to
+/// fit, and reports the cursor position from *before* that scroll so the caller
+/// can put it back. `offset_in_previous_viewport` keeps a resize anchored to the
+/// same relative row rather than jumping.
+fn compute_inline_size<B: Backend>(
+    backend: &mut B,
+    height: u16,
+    size: Size,
+    offset_in_previous_viewport: u16,
+) -> Result<(Rect, Position), B::Error> {
+    let position = backend.get_cursor_position()?;
+    let mut row = position.y;
+    let max_height = size.height.min(height);
+
+    let lines_after_cursor = height
+        .saturating_sub(offset_in_previous_viewport)
+        .saturating_sub(1);
+    backend.append_lines(lines_after_cursor)?;
+
+    let available = size.height.saturating_sub(row).saturating_sub(1);
+    let missing = lines_after_cursor.saturating_sub(available);
+    if missing > 0 {
+        row = row.saturating_sub(missing);
+    }
+    row = row.saturating_sub(offset_in_previous_viewport);
+
+    Ok((
+        Rect {
+            x: 0,
+            y: row,
+            width: size.width,
+            height: max_height,
+        },
+        position,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::Style;
+    use crate::term::testbackend::TestBackend;
+
+    fn terminal(width: u16, height: u16) -> Terminal<TestBackend> {
+        Terminal::new(TestBackend::new(width, height)).unwrap()
+    }
+
+    #[test]
+    fn a_new_terminal_covers_the_whole_screen() {
+        let terminal = terminal(10, 4);
+        assert_eq!(terminal.viewport_area, Rect::new(0, 0, 10, 4));
+        assert_eq!(terminal.viewport(), Viewport::Fullscreen);
+    }
+
+    #[test]
+    fn draw_paints_into_the_backend() {
+        let mut terminal = terminal(5, 1);
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                frame.buffer_mut().set_string(0, 0, "hi", Style::default());
+                assert_eq!(area, Rect::new(0, 0, 5, 1));
+            })
+            .unwrap();
+        assert_eq!(terminal.backend().rows(), vec!["hi   ".to_string()]);
+    }
+
+    /// The property the whole immediate-mode model rests on: painting the same
+    /// content twice writes nothing the second time.
+    #[test]
+    fn an_unchanged_frame_writes_nothing() {
+        let mut terminal = terminal(4, 1);
+        let paint = |frame: &mut Frame<'_>| {
+            frame.buffer_mut().set_string(0, 0, "ab", Style::default());
+        };
+        terminal.draw(paint).unwrap();
+
+        // Paint the same content into the back buffer but stop short of
+        // flushing, so the two buffers can be compared the way `flush` would.
+        {
+            let mut frame = terminal.get_frame();
+            paint(&mut frame);
+        }
+        let previous = &terminal.buffers[1 - terminal.current];
+        let current = &terminal.buffers[terminal.current];
+        assert!(
+            previous.diff(current).is_empty(),
+            "an identical frame must produce no writes"
+        );
+    }
+
+    #[test]
+    fn a_changed_cell_is_written() {
+        let mut terminal = terminal(3, 1);
+        terminal
+            .draw(|f| {
+                f.buffer_mut().set_string(0, 0, "ab", Style::default());
+            })
+            .unwrap();
+        terminal
+            .draw(|f| {
+                f.buffer_mut().set_string(0, 0, "xb", Style::default());
+            })
+            .unwrap();
+        assert_eq!(terminal.backend().rows(), vec!["xb ".to_string()]);
+    }
+
+    #[test]
+    fn the_cursor_is_hidden_unless_the_frame_asks_for_it() {
+        let mut terminal = terminal(3, 1);
+        terminal.draw(|_| {}).unwrap();
+        assert!(!terminal.backend().cursor_visible());
+
+        terminal
+            .draw(|frame| frame.set_cursor_position((1, 0)))
+            .unwrap();
+        assert!(terminal.backend().cursor_visible());
+        assert_eq!(
+            terminal.backend_mut().get_cursor_position().unwrap(),
+            Position::new(1, 0)
+        );
+    }
+
+    #[test]
+    fn frame_count_advances() {
+        let mut terminal = terminal(2, 1);
+        assert_eq!(terminal.get_frame().count(), 0);
+        terminal.draw(|_| {}).unwrap();
+        assert_eq!(terminal.get_frame().count(), 1);
+    }
+
+    #[test]
+    fn autoresize_follows_the_backend() {
+        let mut terminal = terminal(4, 2);
+        terminal.backend_mut().resize(6, 3);
+        terminal.autoresize().unwrap();
+        assert_eq!(terminal.viewport_area, Rect::new(0, 0, 6, 3));
+    }
+
+    #[test]
+    fn a_fixed_viewport_does_not_autoresize() {
+        let backend = TestBackend::new(10, 10);
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(2, 2, 3, 3)),
+            },
+        )
+        .unwrap();
+        terminal.backend_mut().resize(20, 20);
+        terminal.autoresize().unwrap();
+        assert_eq!(terminal.viewport_area, Rect::new(2, 2, 3, 3));
+    }
+
+    /// An inline viewport starts at the cursor row when there is room below it.
+    #[test]
+    fn an_inline_viewport_anchors_to_the_cursor_row() {
+        let mut backend = TestBackend::new(10, 10);
+        backend.set_cursor_position((0, 3)).unwrap();
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(4),
+            },
+        )
+        .unwrap();
+        assert_eq!(terminal.viewport_area, Rect::new(0, 3, 10, 4));
+    }
+
+    /// Near the bottom there is not enough room, so the screen scrolls and the
+    /// viewport lands higher than the cursor row it was asked for.
+    #[test]
+    fn an_inline_viewport_scrolls_to_make_room() {
+        let mut backend = TestBackend::new(10, 6);
+        backend.set_cursor_position((0, 5)).unwrap();
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(3),
+            },
+        )
+        .unwrap();
+        assert_eq!(terminal.viewport_area, Rect::new(0, 3, 10, 3));
+    }
+
+    #[test]
+    fn an_inline_viewport_is_clamped_to_the_screen_height() {
+        let backend = TestBackend::new(4, 2);
+        let terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(9),
+            },
+        )
+        .unwrap();
+        assert_eq!(terminal.viewport_area.height, 2);
+    }
+
+    /// The split-footer contract: the published block ends up in scrollback and
+    /// the viewport stays the same height, below it.
+    #[test]
+    fn insert_before_publishes_above_an_inline_viewport() {
+        let mut backend = TestBackend::new(6, 6);
+        backend.set_cursor_position((0, 3)).unwrap();
+        let mut terminal = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Inline(2),
+            },
+        )
+        .unwrap();
+        terminal
+            .draw(|f| {
+                f.buffer_mut().set_string(0, 0, "FOOT", Style::default());
+            })
+            .unwrap();
+
+        terminal
+            .insert_before(1, |buffer| {
+                buffer.set_string(0, 0, "BLOCK", Style::default());
+            })
+            .unwrap();
+
+        assert_eq!(terminal.viewport_area.height, 2, "footer keeps its height");
+        let published = terminal
+            .backend()
+            .rows()
+            .iter()
+            .any(|row| row.starts_with("BLOCK"))
+            || terminal
+                .backend()
+                .scrollback()
+                .iter()
+                .any(|row| row.first().is_some_and(|c| c.symbol() == "B"));
+        assert!(published, "the block must reach the screen or scrollback");
+    }
+
+    #[test]
+    fn insert_before_is_a_no_op_for_a_fullscreen_viewport() {
+        let mut terminal = terminal(4, 2);
+        let before = terminal.viewport_area;
+        terminal
+            .insert_before(1, |buffer| {
+                buffer.set_string(0, 0, "x", Style::default());
+            })
+            .unwrap();
+        assert_eq!(terminal.viewport_area, before);
+    }
+
+    #[test]
+    fn clear_drops_the_diff_baseline_so_the_next_frame_repaints() {
+        let mut terminal = terminal(3, 1);
+        terminal
+            .draw(|f| {
+                f.buffer_mut().set_string(0, 0, "ab", Style::default());
+            })
+            .unwrap();
+        terminal.clear().unwrap();
+        assert!(
+            terminal.buffers[1 - terminal.current]
+                .content
+                .iter()
+                .all(|cell| cell.symbol() == " "),
+            "the previous buffer must be blank after clear"
+        );
+    }
+
+    #[test]
+    fn a_zero_size_screen_does_not_panic() {
+        let mut terminal = Terminal::new(TestBackend::new(0, 0)).unwrap();
+        terminal.draw(|_| {}).unwrap();
+        assert_eq!(terminal.viewport_area, Rect::new(0, 0, 0, 0));
+    }
+}

--- a/src/term/testbackend.rs
+++ b/src/term/testbackend.rs
@@ -1,0 +1,414 @@
+//! An in-memory [`Backend`] for the hermetic test suite.
+//!
+//! Everything tuika renders is asserted by painting into a [`TestBackend`] and
+//! reading cells back, so the whole suite runs without a terminal — see
+//! [`testing`](crate::testing) for the consumer-facing wrappers around it.
+//!
+//! It is a real backend, not a stub: it applies the same cell updates a
+//! terminal would, so a diffing bug shows up here rather than only under the
+//! PTY smoke tests.
+
+use std::convert::Infallible;
+
+use crate::buffer::{Buffer, Cell};
+use crate::geometry::{Position, Rect, Size};
+use crate::term::traits::{Backend, ClearType, WindowSize};
+
+/// A backend that paints into a [`Buffer`] instead of a terminal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TestBackend {
+    buffer: Buffer,
+    cursor: Position,
+    cursor_visible: bool,
+    /// Rows scrolled off the top by [`append_lines`](Backend::append_lines),
+    /// oldest first — the in-memory stand-in for terminal scrollback, and what
+    /// lets a split-footer test assert what was published.
+    scrollback: Vec<Vec<Cell>>,
+}
+
+impl TestBackend {
+    /// A blank screen `width × height` cells.
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            buffer: Buffer::empty(Rect::new(0, 0, width, height)),
+            cursor: Position::ORIGIN,
+            cursor_visible: true,
+            scrollback: Vec::new(),
+        }
+    }
+
+    /// The current screen contents.
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
+
+    /// Mutable access, for a test that needs to seed the screen.
+    pub fn buffer_mut(&mut self) -> &mut Buffer {
+        &mut self.buffer
+    }
+
+    /// Where the cursor is, without the `&mut` a [`Backend`] query needs.
+    pub fn cursor_position(&self) -> Position {
+        self.cursor
+    }
+
+    /// Whether the cursor is currently shown.
+    pub fn cursor_visible(&self) -> bool {
+        self.cursor_visible
+    }
+
+    /// Rows that have scrolled off the top, oldest first.
+    pub fn scrollback(&self) -> &[Vec<Cell>] {
+        &self.scrollback
+    }
+
+    /// Resize the screen, discarding contents the way a real resize does.
+    ///
+    /// The cursor is clamped into the new bounds. A real terminal does this, and
+    /// without it a shrink would leave the cursor off-screen — which an inline
+    /// viewport then re-anchors itself against, landing the footer below the
+    /// bottom row.
+    pub fn resize(&mut self, width: u16, height: u16) {
+        self.buffer.resize(Rect::new(0, 0, width, height));
+        self.cursor.x = self.cursor.x.min(width.saturating_sub(1));
+        self.cursor.y = self.cursor.y.min(height.saturating_sub(1));
+    }
+
+    /// The screen as one string per row, trailing spaces intact.
+    pub fn rows(&self) -> Vec<String> {
+        (0..self.buffer.area.height)
+            .map(|y| {
+                (0..self.buffer.area.width)
+                    .map(|x| self.buffer[(x, y)].symbol().to_string())
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+impl Backend for TestBackend {
+    /// In-memory writes cannot fail, and saying so in the type removes the
+    /// error handling a test would otherwise carry.
+    type Error = Infallible;
+
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        for (x, y, cell) in content {
+            if let Some(target) = self.buffer.cell_mut((x, y)) {
+                *target = cell.clone();
+            }
+        }
+        Ok(())
+    }
+
+    fn append_lines(&mut self, n: u16) -> Result<(), Self::Error> {
+        let height = self.buffer.area.height;
+        let width = self.buffer.area.width;
+        if height == 0 || n == 0 {
+            return Ok(());
+        }
+        let shift = n.min(height);
+
+        for y in 0..shift {
+            let row: Vec<Cell> = (0..width).map(|x| self.buffer[(x, y)].clone()).collect();
+            self.scrollback.push(row);
+        }
+        for y in 0..height.saturating_sub(shift) {
+            for x in 0..width {
+                let source = self.buffer[(x, y + shift)].clone();
+                self.buffer[(x, y)] = source;
+            }
+        }
+        for y in height.saturating_sub(shift)..height {
+            for x in 0..width {
+                self.buffer[(x, y)].reset();
+            }
+        }
+        // A real terminal leaves the cursor on the last row after scrolling.
+        self.cursor.y = height.saturating_sub(1);
+        Ok(())
+    }
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+        self.cursor_visible = false;
+        Ok(())
+    }
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
+        self.cursor_visible = true;
+        Ok(())
+    }
+
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+        Ok(self.cursor)
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error> {
+        self.cursor = position.into();
+        Ok(())
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        self.clear_region(ClearType::All)
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+        let area = self.buffer.area;
+        let Position { x: cx, y: cy } = self.cursor;
+        let mut reset = |x: u16, y: u16| {
+            if let Some(cell) = self.buffer.cell_mut((x, y)) {
+                cell.reset();
+            }
+        };
+        match clear_type {
+            ClearType::All => {
+                for y in 0..area.height {
+                    for x in 0..area.width {
+                        reset(x, y);
+                    }
+                }
+            }
+            ClearType::AfterCursor => {
+                for x in cx..area.width {
+                    reset(x, cy);
+                }
+                for y in cy.saturating_add(1)..area.height {
+                    for x in 0..area.width {
+                        reset(x, y);
+                    }
+                }
+            }
+            ClearType::BeforeCursor => {
+                for y in 0..cy {
+                    for x in 0..area.width {
+                        reset(x, y);
+                    }
+                }
+                for x in 0..=cx.min(area.width.saturating_sub(1)) {
+                    reset(x, cy);
+                }
+            }
+            ClearType::CurrentLine => {
+                for x in 0..area.width {
+                    reset(x, cy);
+                }
+            }
+            ClearType::UntilNewLine => {
+                for x in cx..area.width {
+                    reset(x, cy);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn size(&self) -> Result<Size, Self::Error> {
+        Ok(self.buffer.area.as_size())
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+        Ok(WindowSize {
+            columns_rows: self.buffer.area.as_size(),
+            // A cell is assumed 8×16 px, the common default. Tests that care
+            // about pixel geometry state their own expectation against this.
+            pixels: Size::new(
+                self.buffer.area.width.saturating_mul(8),
+                self.buffer.area.height.saturating_mul(16),
+            ),
+        })
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(
+        &mut self,
+        region: core::ops::Range<u16>,
+        line_count: u16,
+    ) -> Result<(), Self::Error> {
+        let width = self.buffer.area.width;
+        let end = region.end.min(self.buffer.area.height);
+        let start = region.start.min(end);
+        let rows = end - start;
+        let shift = line_count.min(rows);
+
+        // Rows leaving a region anchored at the top enter scrollback; rows
+        // leaving a region below it are discarded, which is what terminals do.
+        if start == 0 {
+            for y in start..start + shift {
+                let row: Vec<Cell> = (0..width).map(|x| self.buffer[(x, y)].clone()).collect();
+                self.scrollback.push(row);
+            }
+        }
+        for y in start..end.saturating_sub(shift) {
+            for x in 0..width {
+                let source = self.buffer[(x, y + shift)].clone();
+                self.buffer[(x, y)] = source;
+            }
+        }
+        for y in end.saturating_sub(shift)..end {
+            for x in 0..width {
+                self.buffer[(x, y)].reset();
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(
+        &mut self,
+        region: core::ops::Range<u16>,
+        line_count: u16,
+    ) -> Result<(), Self::Error> {
+        let width = self.buffer.area.width;
+        let end = region.end.min(self.buffer.area.height);
+        let start = region.start.min(end);
+        let rows = end - start;
+        let shift = line_count.min(rows);
+
+        for y in (start + shift..end).rev() {
+            for x in 0..width {
+                let source = self.buffer[(x, y - shift)].clone();
+                self.buffer[(x, y)] = source;
+            }
+        }
+        for y in start..(start + shift).min(end) {
+            for x in 0..width {
+                self.buffer[(x, y)].reset();
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::Style;
+
+    fn seeded(width: u16, height: u16) -> TestBackend {
+        let mut backend = TestBackend::new(width, height);
+        for y in 0..height {
+            let row = format!("{y}").repeat(width as usize);
+            backend
+                .buffer_mut()
+                .set_string(0, y, &row, Style::default());
+        }
+        backend
+    }
+
+    #[test]
+    fn draw_applies_cells_at_absolute_positions() {
+        let mut backend = TestBackend::new(3, 2);
+        let cell = Cell::new("x");
+        backend.draw([(1u16, 1u16, &cell)].into_iter()).unwrap();
+        assert_eq!(backend.rows(), vec!["   ".to_string(), " x ".to_string()]);
+    }
+
+    #[test]
+    fn draw_ignores_cells_outside_the_screen() {
+        let mut backend = TestBackend::new(2, 1);
+        let cell = Cell::new("x");
+        backend.draw([(9u16, 9u16, &cell)].into_iter()).unwrap();
+        assert_eq!(backend.rows(), vec!["  ".to_string()]);
+    }
+
+    /// The scrollback path a split footer depends on: rows leaving the top are
+    /// kept, the rest shift up, and the freed rows come back blank.
+    #[test]
+    fn append_lines_scrolls_the_top_into_scrollback() {
+        let mut backend = seeded(2, 3);
+        backend.append_lines(1).unwrap();
+        assert_eq!(
+            backend.rows(),
+            vec!["11".to_string(), "22".to_string(), "  ".to_string()]
+        );
+        assert_eq!(backend.scrollback().len(), 1);
+        assert_eq!(backend.scrollback()[0][0].symbol(), "0");
+    }
+
+    #[test]
+    fn append_lines_past_the_screen_height_clears_it() {
+        let mut backend = seeded(2, 2);
+        backend.append_lines(9).unwrap();
+        assert_eq!(backend.rows(), vec!["  ".to_string(), "  ".to_string()]);
+        assert_eq!(backend.scrollback().len(), 2);
+    }
+
+    #[test]
+    fn append_lines_of_zero_is_a_no_op() {
+        let mut backend = seeded(2, 2);
+        backend.append_lines(0).unwrap();
+        assert_eq!(backend.rows(), vec!["00".to_string(), "11".to_string()]);
+        assert!(backend.scrollback().is_empty());
+    }
+
+    #[test]
+    fn clear_region_after_cursor_leaves_earlier_rows() {
+        let mut backend = seeded(2, 3);
+        backend.set_cursor_position((1, 1)).unwrap();
+        backend.clear_region(ClearType::AfterCursor).unwrap();
+        assert_eq!(
+            backend.rows(),
+            vec!["00".to_string(), "1 ".to_string(), "  ".to_string()]
+        );
+    }
+
+    #[test]
+    fn clear_region_before_cursor_leaves_later_rows() {
+        let mut backend = seeded(2, 3);
+        backend.set_cursor_position((0, 1)).unwrap();
+        backend.clear_region(ClearType::BeforeCursor).unwrap();
+        assert_eq!(
+            backend.rows(),
+            vec!["  ".to_string(), " 1".to_string(), "22".to_string()]
+        );
+    }
+
+    #[test]
+    fn clear_region_current_line_clears_only_that_row() {
+        let mut backend = seeded(2, 2);
+        backend.set_cursor_position((1, 0)).unwrap();
+        backend.clear_region(ClearType::CurrentLine).unwrap();
+        assert_eq!(backend.rows(), vec!["  ".to_string(), "11".to_string()]);
+    }
+
+    #[test]
+    fn cursor_visibility_is_tracked() {
+        let mut backend = TestBackend::new(1, 1);
+        assert!(backend.cursor_visible());
+        backend.hide_cursor().unwrap();
+        assert!(!backend.cursor_visible());
+        backend.show_cursor().unwrap();
+        assert!(backend.cursor_visible());
+    }
+
+    #[test]
+    fn resize_reports_the_new_size() {
+        let mut backend = TestBackend::new(2, 2);
+        backend.resize(5, 3);
+        assert_eq!(backend.size().unwrap(), Size::new(5, 3));
+    }
+
+    /// A shrink must pull the cursor back on screen, or an inline viewport
+    /// re-anchors against a row that no longer exists.
+    #[test]
+    fn resize_clamps_the_cursor_into_the_new_bounds() {
+        let mut backend = TestBackend::new(10, 10);
+        backend.set_cursor_position((9, 9)).unwrap();
+        backend.resize(4, 3);
+        assert_eq!(backend.cursor_position(), Position::new(3, 2));
+    }
+
+    #[test]
+    fn resize_to_zero_does_not_underflow_the_cursor() {
+        let mut backend = TestBackend::new(4, 4);
+        backend.set_cursor_position((3, 3)).unwrap();
+        backend.resize(0, 0);
+        assert_eq!(backend.cursor_position(), Position::ORIGIN);
+    }
+}

--- a/src/term/traits.rs
+++ b/src/term/traits.rs
@@ -1,0 +1,125 @@
+//! The [`Backend`] boundary: what [`Terminal`](crate::term::terminal::Terminal)
+//! needs from whatever is actually driving the screen.
+//!
+//! Two implementations ship with tuika:
+//! [`CrosstermBackend`](super::backend::CrosstermBackend) writes real escape
+//! sequences, and [`TestBackend`](super::testbackend::TestBackend) keeps a cell
+//! grid in memory so the suite can assert on rendered output without a
+//! terminal. A host can add its own — the trait is public precisely so
+//! `Runner::run_on` can drive one.
+//!
+//! The trait is deliberately small. Everything above it — layout, overlays,
+//! diffing — is tuika's; everything below is escape sequences.
+
+use crate::buffer::Cell;
+use crate::geometry::{Position, Size};
+
+/// How much of the screen [`Backend::clear_region`] should erase.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ClearType {
+    /// Every cell of the visible area.
+    All,
+    /// From the cursor (inclusive) to the end of the screen.
+    AfterCursor,
+    /// From the start of the screen to the cursor (inclusive).
+    BeforeCursor,
+    /// The cursor's whole line.
+    CurrentLine,
+    /// From the cursor (inclusive) to the end of its line.
+    UntilNewLine,
+}
+
+/// The terminal's size in both cells and pixels.
+///
+/// Both come from one syscall, and the pixel size is what
+/// [`term::image`](crate::term::image) needs to scale a picture to a cell box —
+/// so they are reported together rather than through two calls.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WindowSize {
+    /// Size in character cells.
+    pub columns_rows: Size,
+    /// Size in pixels. Terminals that do not report this return `0×0`.
+    pub pixels: Size,
+}
+
+/// Something that can paint cells onto a screen.
+///
+/// Implementors own escape sequences and cursor state; they are handed only the
+/// cells that changed, already diffed.
+pub trait Backend {
+    /// How this backend fails. `io::Error` for anything writing to a terminal;
+    /// [`Infallible`](core::convert::Infallible) for an in-memory one.
+    type Error: core::error::Error;
+
+    /// Paint `content` — the `(x, y, cell)` triples a diff produced.
+    ///
+    /// Coordinates are absolute screen positions and arrive in row-major order,
+    /// which is what lets an implementation elide a cursor move for a
+    /// contiguous run.
+    fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>;
+
+    /// Scroll `n` blank lines in at the bottom, pushing the top into
+    /// scrollback. This is how an inline viewport publishes a block.
+    fn append_lines(&mut self, _n: u16) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Hide the cursor.
+    fn hide_cursor(&mut self) -> Result<(), Self::Error>;
+
+    /// Show the cursor.
+    fn show_cursor(&mut self) -> Result<(), Self::Error>;
+
+    /// Where the cursor currently is.
+    ///
+    /// On a real terminal this is a *query* — it writes a request and blocks on
+    /// the reply — which is how an inline viewport learns the row it must
+    /// anchor itself to.
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error>;
+
+    /// Move the cursor.
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error>;
+
+    /// Erase the visible area, leaving the cursor where it is.
+    fn clear(&mut self) -> Result<(), Self::Error>;
+
+    /// Erase the part of the screen `clear_type` names.
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error>;
+
+    /// The screen size in cells.
+    fn size(&self) -> Result<Size, Self::Error>;
+
+    /// The screen size in cells and pixels.
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error>;
+
+    /// Push anything buffered out to the screen.
+    ///
+    /// Distinct from [`Terminal::flush`](crate::term::terminal::Terminal::flush),
+    /// which computes the diff; this one only empties the write buffer.
+    fn flush(&mut self) -> Result<(), Self::Error>;
+
+    /// Scroll rows `region` up by `line_count`, pushing rows off the top into
+    /// scrollback when the region starts at row 0.
+    ///
+    /// Optional: the default reports that the backend does not implement it, and
+    /// callers fall back to a portable repaint. See the `scrolling-regions`
+    /// note in [`ScreenMode`](crate::ScreenMode) for why the fallback is the
+    /// right default under a split footer.
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_up(
+        &mut self,
+        region: core::ops::Range<u16>,
+        line_count: u16,
+    ) -> Result<(), Self::Error>;
+
+    /// Scroll rows `region` down by `line_count`. Rows pushed off the bottom are
+    /// discarded — terminals do not put them in scrollback.
+    #[cfg(feature = "scrolling-regions")]
+    fn scroll_region_down(
+        &mut self,
+        region: core::ops::Range<u16>,
+        line_count: u16,
+    ) -> Result<(), Self::Error>;
+}

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,7 +1,7 @@
 //! Public helpers for hermetic view and resize tests.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
 
 use crate::{
     Application, Element, Event, RenderCtx, Signal, StyleSheet, Theme, UpdateResult, View, paint,

--- a/src/tests/fuzz.rs
+++ b/src/tests/fuzz.rs
@@ -32,10 +32,10 @@
 //! Everything here is deterministic: proptest is seeded from its own regression
 //! file, and the sweeps enumerate fixed combinations.
 
+use crate::geometry::Rect;
+use crate::style::Style;
+use crate::text::{Line, Span};
 use proptest::prelude::*;
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Style;
-use ratatui_core::text::{Line, Span};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::components::text::{wrap_lines, wrap_str};
@@ -182,9 +182,9 @@ proptest! {
     ) {
         let styles = [
             Style::default(),
-            Style::default().fg(ratatui_core::style::Color::Red),
-            Style::default().bg(ratatui_core::style::Color::Blue),
-            Style::default().add_modifier(ratatui_core::style::Modifier::BOLD),
+            Style::default().fg(crate::style::Color::Red),
+            Style::default().bg(crate::style::Color::Blue),
+            Style::default().add_modifier(crate::style::Modifier::BOLD),
         ];
         let line = Line::from(
             parts
@@ -283,12 +283,12 @@ fn assert_inside(view: &dyn View, width: u16, height: u16) -> Result<(), TestCas
     let theme = Theme::default();
     let outer = Rect::new(0, 0, width + MARGIN * 2, height + MARGIN * 2);
     let inner = Rect::new(MARGIN, MARGIN, width, height);
-    let mut buffer = ratatui_core::buffer::Buffer::empty(outer);
+    let mut buffer = crate::buffer::Buffer::empty(outer);
     crate::paint(&mut buffer, inner, &theme, view, &[]);
-    let untouched = ratatui_core::buffer::Cell::default();
+    let untouched = crate::buffer::Cell::default();
     for y in outer.top()..outer.bottom() {
         for x in outer.left()..outer.right() {
-            if inner.contains(ratatui_core::layout::Position::new(x, y)) {
+            if inner.contains(crate::geometry::Position::new(x, y)) {
                 continue;
             }
             prop_assert_eq!(

--- a/src/tests/integration.rs
+++ b/src/tests/integration.rs
@@ -5,7 +5,7 @@
 //! no single owner: composing a real tree, and surviving tiny/degenerate
 //! screens where scroll and overlay resolution interact.
 
-use ratatui_core::text::{Line, Span};
+use crate::text::{Line, Span};
 
 use crate::components::{Boxed, Flex, Scroll, ScrollState, StatusBar, Text};
 use crate::overlay::OverlaySpec;
@@ -23,7 +23,7 @@ use crate::view::{RenderCtx, View, element};
 /// point is that the *terminal* resolves them.
 #[test]
 fn an_inherited_theme_reaches_the_painted_cells() {
-    use ratatui_core::style::Color;
+    use crate::style::Color;
 
     use crate::term::palette::TerminalPalette;
     use crate::themes;
@@ -104,7 +104,7 @@ fn an_inherited_theme_reaches_the_painted_cells() {
 
 #[test]
 fn scroll_and_overlay_survive_tiny_screens() {
-    use ratatui_core::layout::Rect;
+    use crate::geometry::Rect;
 
     // A tall scroll region rendered into a 1×1 viewport.
     let lines: Vec<Line<'static>> = (0..50).map(|i| Line::from(format!("l{i}"))).collect();
@@ -159,9 +159,10 @@ fn nested_flex_tree_lays_out_status_and_body() {
 /// it alone.
 #[test]
 fn a_split_footer_composes_components_over_published_markdown() {
-    use ratatui_core::backend::{Backend, TestBackend};
-    use ratatui_core::layout::Position;
-    use ratatui_core::terminal::{Terminal, TerminalOptions};
+    use crate::geometry::Position;
+    use crate::term::terminal::{Terminal, TerminalOptions};
+    use crate::term::testbackend::TestBackend;
+    use crate::term::traits::Backend;
 
     use crate::components::Markdown;
     use crate::screen::{ScreenMode, Scrollback, close_footer, pin_footer};

--- a/src/tests/proptests.rs
+++ b/src/tests/proptests.rs
@@ -9,11 +9,12 @@
 //! footer height, and publishing history, the footer must end up on the last
 //! rows with its own content intact.
 
+use crate::geometry::{Position, Rect};
+use crate::term::terminal::{Terminal, TerminalOptions};
+use crate::term::testbackend::TestBackend;
+use crate::term::traits::Backend;
+use crate::text::Line;
 use proptest::prelude::*;
-use ratatui_core::backend::{Backend, TestBackend};
-use ratatui_core::layout::{Position, Rect};
-use ratatui_core::terminal::{Terminal, TerminalOptions};
-use ratatui_core::text::Line;
 
 use crate::components::{Grid, Text};
 use crate::geometry::{Axis, Padding, Size};

--- a/src/tests/snapshots.rs
+++ b/src/tests/snapshots.rs
@@ -7,9 +7,9 @@
 //! To (re)generate after an intentional change:
 //! `UPDATE_SNAPSHOTS=1 cargo test --all-features tests::snapshots`.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
-use ratatui_core::text::{Line, Span};
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
+use crate::text::{Line, Span};
 
 use crate::components::{
     Boxed, Flex, ProgressBar, Scroll, ScrollState, SelectList, SelectState, Spinner, SpinnerStyle,

--- a/src/tests/support.rs
+++ b/src/tests/support.rs
@@ -6,9 +6,9 @@
 //! identifiable "rainbow" theme, rendering an element to text — live here so
 //! they are defined once.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
-use ratatui_core::style::Color;
+use crate::buffer::Buffer;
+use crate::geometry::Rect;
+use crate::style::Color;
 
 use crate::Surface;
 use crate::style::Theme;

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,401 @@
+//! Styled text: [`Span`], [`Line`], and [`Alignment`].
+//!
+//! A [`Span`] is a run of text with one [`Style`]; a [`Line`] is a row of spans
+//! with an optional line-level style and alignment. Components take `Line` in
+//! their constructors because it is the smallest unit that can carry mixed
+//! styling — a markdown paragraph with a bold word in it is one `Line` of three
+//! spans, not three separate strings the caller has to place.
+//!
+//! Both borrow: `Span<'a>` holds a [`Cow<'a, str>`], so building a line from
+//! `&str` allocates nothing while `Line<'static>` can own its content when a
+//! component needs to keep it across frames.
+//!
+//! Widths here are counted in tuika's grapheme-aware display columns
+//! ([`width::str_cols`](crate::width::str_cols)), not per `char` — the whole
+//! toolkit measures the same way, so a line's reported width matches what
+//! [`Surface`](crate::Surface) will actually paint.
+
+use std::borrow::Cow;
+
+use crate::style::Style;
+use crate::width::str_cols;
+
+/// Horizontal placement of a line within the area it is drawn into.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum Alignment {
+    /// Against the left edge.
+    #[default]
+    Left,
+    /// Centered, with any odd cell going to the right.
+    Center,
+    /// Against the right edge.
+    Right,
+}
+
+/// A run of text sharing one style.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Span<'a> {
+    /// The text itself.
+    pub content: Cow<'a, str>,
+    /// How to paint it. Patched over the owning [`Line`]'s style at render.
+    pub style: Style,
+}
+
+impl<'a> Span<'a> {
+    /// An unstyled span.
+    pub fn raw<T: Into<Cow<'a, str>>>(content: T) -> Self {
+        Self {
+            content: content.into(),
+            style: Style::default(),
+        }
+    }
+
+    /// A span with `style` applied.
+    pub fn styled<T: Into<Cow<'a, str>>, S: Into<Style>>(content: T, style: S) -> Self {
+        Self {
+            content: content.into(),
+            style: style.into(),
+        }
+    }
+
+    /// Replace the style, returning the span.
+    #[must_use = "returns a new Span"]
+    pub fn style<S: Into<Style>>(mut self, style: S) -> Self {
+        self.style = style.into();
+        self
+    }
+
+    /// Layer `style` on top of the current one.
+    #[must_use = "returns a new Span"]
+    pub fn patch_style<S: Into<Style>>(mut self, style: S) -> Self {
+        self.style = self.style.patch(style);
+        self
+    }
+
+    /// Display width in cells.
+    pub fn width(&self) -> u16 {
+        str_cols(self.content.as_ref())
+    }
+
+    /// Detach from the borrowed source, cloning the content if needed.
+    pub fn into_owned(self) -> Span<'static> {
+        Span {
+            content: Cow::Owned(self.content.into_owned()),
+            style: self.style,
+        }
+    }
+}
+
+impl<'a, T> From<T> for Span<'a>
+where
+    T: Into<Cow<'a, str>>,
+{
+    fn from(content: T) -> Self {
+        Self::raw(content)
+    }
+}
+
+impl std::fmt::Display for Span<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.content.as_ref())
+    }
+}
+
+/// Split content into one span per line, dropping the breaks.
+///
+/// Borrows through when there is exactly one line, so the common case still
+/// allocates nothing.
+fn split_lines(content: Cow<'_, str>) -> Vec<Span<'_>> {
+    match content {
+        Cow::Borrowed(text) => text.lines().map(Span::raw).collect(),
+        Cow::Owned(text) => {
+            let mut lines = text.lines();
+            match (lines.next(), lines.next()) {
+                (None, _) => Vec::new(),
+                (Some(only), None) if only.len() == text.len() => {
+                    vec![Span::raw(Cow::Owned(text))]
+                }
+                _ => text
+                    .lines()
+                    .map(|line| Span::raw(Cow::Owned(line.to_owned())))
+                    .collect(),
+            }
+        }
+    }
+}
+
+/// A row of styled spans.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Line<'a> {
+    /// The spans, left to right.
+    pub spans: Vec<Span<'a>>,
+    /// A style applied beneath every span's own style.
+    pub style: Style,
+    /// Where to place the line horizontally. `None` lets the drawing component
+    /// decide — which is what makes a `Line` reusable across a left-aligned
+    /// list and a centered dialog without rebuilding it.
+    pub alignment: Option<Alignment>,
+}
+
+impl<'a> Line<'a> {
+    /// An unstyled line.
+    ///
+    /// Content is split on line breaks into one span per line, and the breaks
+    /// themselves are dropped — a `Line` is a single row, so an embedded
+    /// newline cannot be honored and silently keeping it would put a control
+    /// character into a cell. Empty input therefore yields *no* spans.
+    pub fn raw<T: Into<Cow<'a, str>>>(content: T) -> Self {
+        Self {
+            spans: split_lines(content.into()),
+            style: Style::default(),
+            alignment: None,
+        }
+    }
+
+    /// Like [`raw`](Self::raw), with `style` applied at the line level.
+    pub fn styled<T: Into<Cow<'a, str>>, S: Into<Style>>(content: T, style: S) -> Self {
+        Self {
+            spans: split_lines(content.into()),
+            style: style.into(),
+            alignment: None,
+        }
+    }
+
+    /// Replace the line-level style.
+    #[must_use = "returns a new Line"]
+    pub fn style<S: Into<Style>>(mut self, style: S) -> Self {
+        self.style = style.into();
+        self
+    }
+
+    /// Layer `style` on top of the line-level style.
+    #[must_use = "returns a new Line"]
+    pub fn patch_style<S: Into<Style>>(mut self, style: S) -> Self {
+        self.style = self.style.patch(style);
+        self
+    }
+
+    /// Set the alignment.
+    #[must_use = "returns a new Line"]
+    pub fn alignment(mut self, alignment: Alignment) -> Self {
+        self.alignment = Some(alignment);
+        self
+    }
+
+    /// Align left.
+    #[must_use = "returns a new Line"]
+    pub fn left_aligned(self) -> Self {
+        self.alignment(Alignment::Left)
+    }
+
+    /// Center.
+    #[must_use = "returns a new Line"]
+    pub fn centered(self) -> Self {
+        self.alignment(Alignment::Center)
+    }
+
+    /// Align right.
+    #[must_use = "returns a new Line"]
+    pub fn right_aligned(self) -> Self {
+        self.alignment(Alignment::Right)
+    }
+
+    /// Append a span.
+    pub fn push_span<S: Into<Span<'a>>>(&mut self, span: S) {
+        self.spans.push(span.into());
+    }
+
+    /// Total display width in cells, saturating.
+    pub fn width(&self) -> u16 {
+        self.spans
+            .iter()
+            .map(Span::width)
+            .fold(0, u16::saturating_add)
+    }
+
+    /// The spans, left to right.
+    pub fn iter(&self) -> std::slice::Iter<'_, Span<'a>> {
+        self.spans.iter()
+    }
+
+    /// Detach from the borrowed source, cloning content as needed.
+    pub fn into_owned(self) -> Line<'static> {
+        Line {
+            spans: self.spans.into_iter().map(Span::into_owned).collect(),
+            style: self.style,
+            alignment: self.alignment,
+        }
+    }
+}
+
+impl<'a> From<Span<'a>> for Line<'a> {
+    fn from(span: Span<'a>) -> Self {
+        Self {
+            spans: vec![span],
+            style: Style::default(),
+            alignment: None,
+        }
+    }
+}
+
+impl<'a> From<Vec<Span<'a>>> for Line<'a> {
+    fn from(spans: Vec<Span<'a>>) -> Self {
+        Self {
+            spans,
+            style: Style::default(),
+            alignment: None,
+        }
+    }
+}
+
+impl From<String> for Line<'_> {
+    fn from(content: String) -> Self {
+        Self::raw(content)
+    }
+}
+
+impl<'a> From<&'a str> for Line<'a> {
+    fn from(content: &'a str) -> Self {
+        Self::raw(content)
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Line<'a> {
+    fn from(content: Cow<'a, str>) -> Self {
+        Self::raw(content)
+    }
+}
+
+impl<'a> FromIterator<Span<'a>> for Line<'a> {
+    fn from_iter<I: IntoIterator<Item = Span<'a>>>(iter: I) -> Self {
+        Self::from(iter.into_iter().collect::<Vec<_>>())
+    }
+}
+
+impl<'a> IntoIterator for Line<'a> {
+    type Item = Span<'a>;
+    type IntoIter = std::vec::IntoIter<Span<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.spans.into_iter()
+    }
+}
+
+impl<'a, 'b> IntoIterator for &'b Line<'a> {
+    type Item = &'b Span<'a>;
+    type IntoIter = std::slice::Iter<'b, Span<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.spans.iter()
+    }
+}
+
+impl std::fmt::Display for Line<'_> {
+    /// The visible text, spans concatenated and styling dropped. This is what
+    /// makes `line.to_string()` usable for assertions and for the plain-text
+    /// [`render_once`](crate::render_once) path.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for span in &self.spans {
+            f.write_str(span.content.as_ref())?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::style::{Color, Modifier};
+
+    #[test]
+    fn a_str_becomes_a_one_span_line() {
+        let line = Line::from("hello");
+        assert_eq!(line.spans.len(), 1);
+        assert_eq!(line.to_string(), "hello");
+        assert_eq!(line.alignment, None);
+    }
+
+    /// A `Line` is one row, so embedded breaks become separate spans rather
+    /// than control characters in a cell — and empty content is no spans at all.
+    #[test]
+    fn raw_splits_on_line_breaks() {
+        assert!(Line::raw("").spans.is_empty());
+        assert!(Line::raw(String::new()).spans.is_empty());
+        assert_eq!(Line::raw("one").spans.len(), 1);
+
+        let split = Line::raw("a\nb");
+        assert_eq!(split.spans.len(), 2);
+        assert_eq!(split.to_string(), "ab");
+        assert_eq!(Line::raw(String::from("a\nb")).spans.len(), 2);
+    }
+
+    #[test]
+    fn display_concatenates_spans_and_drops_styling() {
+        let line = Line::from(vec![
+            Span::styled("bo", Style::new().add_modifier(Modifier::BOLD)),
+            Span::raw("ld"),
+        ]);
+        assert_eq!(line.to_string(), "bold");
+    }
+
+    /// Width is grapheme-aware, not per-`char`: a ZWJ family is one cluster two
+    /// columns wide, and counting its `char`s would report far more.
+    #[test]
+    fn width_counts_display_columns_not_chars() {
+        let family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+        assert_eq!(Span::raw(family).width(), 2);
+        assert_eq!(Span::raw("abc").width(), 3);
+        assert_eq!(Line::from(family).width(), 2);
+    }
+
+    #[test]
+    fn line_width_sums_its_spans() {
+        let line = Line::from(vec![Span::raw("ab"), Span::raw("cde")]);
+        assert_eq!(line.width(), 5);
+    }
+
+    #[test]
+    fn width_saturates_rather_than_overflowing() {
+        let wide = "x".repeat(u16::MAX as usize);
+        let line = Line::from(vec![Span::raw(wide.clone()), Span::raw(wide)]);
+        assert_eq!(line.width(), u16::MAX);
+    }
+
+    #[test]
+    fn alignment_helpers_set_the_field() {
+        assert_eq!(Line::raw("x").centered().alignment, Some(Alignment::Center));
+        assert_eq!(
+            Line::raw("x").right_aligned().alignment,
+            Some(Alignment::Right)
+        );
+        assert_eq!(
+            Line::raw("x").left_aligned().alignment,
+            Some(Alignment::Left)
+        );
+    }
+
+    /// A span's own style layers *over* the line's, which is what lets a themed
+    /// line carry a differently-colored word.
+    #[test]
+    fn span_style_patches_over_line_style() {
+        let line =
+            Line::styled("x", Style::new().fg(Color::Red)).style(Style::new().fg(Color::Red));
+        let span = Span::styled("x", Style::new().fg(Color::Blue));
+        assert_eq!(line.style.patch(span.style).fg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn into_owned_detaches_from_the_borrow() {
+        let owned = {
+            let text = String::from("borrowed");
+            Line::raw(text.as_str()).into_owned()
+        };
+        assert_eq!(owned.to_string(), "borrowed");
+    }
+
+    #[test]
+    fn collecting_spans_builds_a_line() {
+        let line: Line = vec![Span::raw("a"), Span::raw("b")].into_iter().collect();
+        assert_eq!(line.to_string(), "ab");
+    }
+}

--- a/src/themes.rs
+++ b/src/themes.rs
@@ -18,7 +18,7 @@
 //! its own slots (`background`, `surface`, `accent`, the [`CodeTheme`] syntax
 //! roles); it does not reproduce every upstream UI element.
 
-use ratatui_core::style::Color;
+use crate::style::Color;
 
 use crate::style::{CodeTheme, Theme};
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -12,7 +12,7 @@
 
 use std::cell::RefCell;
 
-use ratatui_core::layout::Rect;
+use crate::geometry::Rect;
 
 use super::geometry::Size;
 use super::style::{StyleBundle, StyleResolver, StyleRole, StyleSheet, Theme};
@@ -464,9 +464,9 @@ pub type CanvasView<F> = DrawView<F>;
 mod draw_view_tests {
     use super::*;
     use crate::Theme;
+    use crate::style::Color;
     use crate::style::{StyleBundle, StyleResolver, StyleRole};
     use crate::testing::{grid, render, render_with_context};
-    use ratatui_core::style::Color;
 
     const METRIC: StyleRole = StyleRole::new("example.metric");
 
@@ -522,7 +522,7 @@ mod draw_view_tests {
         assert!(
             buffer[(0, 0)]
                 .modifier
-                .contains(ratatui_core::style::Modifier::BOLD)
+                .contains(crate::style::Modifier::BOLD)
         );
         assert_eq!(buffer[(1, 0)].fg, Color::Yellow);
         assert_eq!(

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -236,9 +236,9 @@ fn components_are_reachable_flat() {
 /// remain an explicit view-module escape hatch rather than growing the prelude.
 #[test]
 fn scene_and_custom_drawing_follow_the_surface_policy() {
-    use ratatui_core::layout::Rect;
     use tuika::overlay::Extent;
     use tuika::probe::RectProbe;
+    use tuika::ui::Rect;
     use tuika::view::{CanvasView, DrawView};
 
     let canvas: CanvasView<_> = DrawView::new(
@@ -321,11 +321,11 @@ fn component_modules_own_their_constants_and_free_functions() {
             &self,
             block: MarkdownBlock<'_>,
             _context: MarkdownBlockContext<'_>,
-        ) -> Option<Vec<ratatui_core::text::Line<'static>>> {
+        ) -> Option<Vec<tuika::ui::Line<'static>>> {
             let MarkdownBlock::Fenced { language, .. } = block else {
                 return None;
             };
-            (language == "demo").then(|| vec![ratatui_core::text::Line::raw("rendered")])
+            (language == "demo").then(|| vec![tuika::ui::Line::raw("rendered")])
         }
     }
     assert_eq!(
@@ -349,9 +349,8 @@ fn component_modules_own_their_constants_and_free_functions() {
             &self,
             block: MarkdownBlock<'_>,
             _context: MarkdownBlockContext<'_>,
-        ) -> Option<Vec<ratatui_core::text::Line<'static>>> {
-            matches!(block, MarkdownBlock::Html { .. })
-                .then(|| vec![ratatui_core::text::Line::raw("html")])
+        ) -> Option<Vec<tuika::ui::Line<'static>>> {
+            matches!(block, MarkdownBlock::Html { .. }).then(|| vec![tuika::ui::Line::raw("html")])
         }
     }
     let lines = markdown::to_lines_with(
@@ -411,10 +410,10 @@ fn term_groups_the_out_of_band_escapes() {
 /// The paths that used to collide at the crate root now name one thing each.
 #[test]
 fn the_former_root_collisions_resolve() {
-    use ratatui_core::buffer::Buffer;
-    use ratatui_core::layout::Rect;
-    use ratatui_core::style::{Color, Style};
     use tuika::mouse::{SelectionRange, paint_selection};
+    use tuika::ui::Buffer;
+    use tuika::ui::Rect;
+    use tuika::ui::{Color, Style};
 
     // `tuika::highlight` is the Highlighter boundary, and nothing else.
     let _: &dyn tuika::highlight::Highlighter = &PlainHighlighter;
@@ -476,10 +475,10 @@ fn the_screen_mode_is_reachable_from_the_prelude() {
     // The loop-driving pieces stay behind `screen::`.
     let _ = tuika::screen::DEFAULT_FOOTER_HEIGHT;
     let _: fn(
-        &mut ratatui_core::terminal::Terminal<ratatui_core::backend::TestBackend>,
+        &mut tuika::term::terminal::Terminal<tuika::term::testbackend::TestBackend>,
     ) -> Result<(), std::convert::Infallible> = tuika::screen::pin_footer;
     let _: fn(
-        &mut ratatui_core::terminal::Terminal<ratatui_core::backend::TestBackend>,
+        &mut tuika::term::terminal::Terminal<tuika::term::testbackend::TestBackend>,
     ) -> Result<(), std::convert::Infallible> = tuika::screen::close_footer;
 }
 
@@ -491,6 +490,7 @@ fn the_non_prelude_surface_keeps_its_module_path() {
     assert!(tuika::themes::by_name("gruvbox-dark").is_some());
     let _ = tuika::probe::RectProbe::new();
     let _ = tuika::framebuffer::FrameBuffer::new(1, 1);
+    #[cfg(feature = "ratatui")]
     let _ = tuika::interop::RatatuiView::sized(Size::new(1, 1), |_area, _buffer: &mut _| {});
     let _ = tuika::runner::Runner::new(RunnerConfig::default());
     // `AltScreen::enter` touches the real terminal, so only its path is pinned.

--- a/tests/robustness.rs
+++ b/tests/robustness.rs
@@ -337,14 +337,14 @@ fn assert_well_behaved(name: &str, corpus: &str, view: &dyn View, theme: &Theme)
     for &(width, height) in SIZES {
         let outer = Rect::new(0, 0, width + MARGIN * 2, height + MARGIN * 2);
         let inner = Rect::new(MARGIN, MARGIN, width, height);
-        let mut buffer = ratatui::buffer::Buffer::empty(outer);
+        let mut buffer = tuika::ui::Buffer::empty(outer);
         paint(&mut buffer, inner, theme, view, &[]);
 
-        let blank = ratatui::buffer::Cell::default();
+        let blank = tuika::ui::Cell::default();
         for y in outer.top()..outer.bottom() {
             for x in outer.left()..outer.right() {
                 let cell = &buffer[(x, y)];
-                if !inner.contains(ratatui::layout::Position::new(x, y)) {
+                if !inner.contains(tuika::ui::Position::new(x, y)) {
                     assert_eq!(
                         cell, &blank,
                         "{name}/{corpus} at {width}x{height} painted ({x}, {y}) outside {inner:?}"

--- a/tests/scoped_scene.rs
+++ b/tests/scoped_scene.rs
@@ -1,10 +1,9 @@
 //! Consumer-style coverage for painting a borrowed host root and owned dialog
 //! as one view.
 
-use ratatui_core::buffer::Buffer;
-use ratatui_core::layout::Rect;
 use tuika::prelude::*;
 use tuika::testing::grid;
+use tuika::ui::{Buffer, Rect};
 
 struct Transcript<'data> {
     messages: &'data [String],

--- a/tests/stress_ui.rs
+++ b/tests/stress_ui.rs
@@ -32,10 +32,11 @@ use std::convert::Infallible;
 use std::rc::Rc;
 use std::time::Duration;
 
-use ratatui_core::backend::{Backend, ClearType, TestBackend, WindowSize};
-use ratatui_core::buffer::Cell as BufferCell;
-use ratatui_core::layout::{Position, Size as BackendSize};
-use ratatui_core::terminal::{Terminal, TerminalOptions};
+use tuika::buffer::Cell as BufferCell;
+use tuika::geometry::{Position, Size as BackendSize};
+use tuika::term::terminal::{Terminal, TerminalOptions};
+use tuika::term::testbackend::TestBackend;
+use tuika::term::traits::{Backend, ClearType, WindowSize};
 
 use tuika::overlay::Anchor;
 use tuika::prelude::*;
@@ -1208,7 +1209,7 @@ fn assert_contained(name: &str, view: &dyn View, theme: &Theme, sheet: StyleShee
     for &(width, height) in SIZES {
         let outer = Rect::new(0, 0, width + MARGIN * 2, height + MARGIN * 2);
         let inner = Rect::new(MARGIN, MARGIN, width, height);
-        let mut first = ratatui_core::buffer::Buffer::empty(outer);
+        let mut first = tuika::buffer::Buffer::empty(outer);
         paint_with_sheet(&mut first, inner, theme, sheet, view, &[]);
 
         let blank = BufferCell::default();
@@ -1233,7 +1234,7 @@ fn assert_contained(name: &str, view: &dyn View, theme: &Theme, sheet: StyleShee
             }
         }
 
-        let mut second = ratatui_core::buffer::Buffer::empty(outer);
+        let mut second = tuika::buffer::Buffer::empty(outer);
         paint_with_sheet(&mut second, inner, theme, sheet, view, &[]);
         assert_eq!(
             first, second,
@@ -1521,7 +1522,7 @@ fn borrowed_overlays_stay_inside_the_screen_at_every_size() {
             })
             .collect();
 
-        let mut buffer = ratatui_core::buffer::Buffer::empty(outer);
+        let mut buffer = tuika::buffer::Buffer::empty(outer);
         paint_with_sheet(&mut buffer, inner, &theme, sheet, &root, &overlays);
 
         let blank = BufferCell::default();


### PR DESCRIPTION
## What changed

tuika no longer depends on ratatui. It owns `Rect`/`Position`, `Color`/`Modifier`/`Style`, `Line`/`Span`, `Buffer`/`Cell`, the `Backend` trait, `TestBackend`, and the `Terminal` render loop — including the inline viewport that `ScreenMode::SplitFooter` rides on.

For most hosts the migration is an import change; the canonical path is unchanged:

```rust
// before
use ratatui_core::layout::Rect;
use ratatui_core::style::{Color, Modifier, Style};
use ratatui_core::text::{Line, Span};

// after (or just `use tuika::prelude::*;`)
use tuika::ui::{Color, Line, Modifier, Rect, Span, Style};
```

**Ratatui interoperability survives, behind an off-by-default `ratatui` feature.** Every ratatui widget still composes:

```toml
tuika = { version = "0.10", features = ["ratatui"] }
ratatui = "0.30"
```

The boundary is no longer a shared `Buffer` — the two crates no longer share a cell type — but a cell-by-cell conversion over the *rendered area only*. That is cheap because `Surface::render_ratatui` was **already** a scratch-buffer round trip: cells were copied in and back out to enforce the clip. Only the conversion in the middle is new. The general escape hatch splits off as `Surface::render_scratch`, which needs no feature.

Two behavioral notes beyond the type moves:

- `Span::width` / `Line::width` now count grapheme-aware display columns (`width::str_cols`) rather than per-`char` widths, so they agree with what `Surface` actually paints. A line containing a ZWJ emoji measures narrower than before — and correctly.
- `Cell` stores short grapheme clusters inline instead of in a `CompactString`. `Cell::new` is no longer `const`; use `Cell::default()` for a blank cell.

## Why

**Version coupling, not size.** Every `View` signature named a `ratatui-core` type, so a major bump there was a breaking release for tuika, all four companion crates, and every host simultaneously — something `knowledge/processes/maintenance.md` already recorded as *"an interoperability event, not a routine upgrade."* Owning the vocabulary makes it a private implementation detail.

Roughly half the removed weight was for code tuika never called: `kasuari` (a Cassowary solver), `lru`, and a second `hashbrown` exist for `ratatui_core::layout::Layout`, which tuika replaced with its own flex solver on day one — plus `strum`, `compact_str`, `itertools`, `unicode-truncate`, and a second `syn` major version.

This follows the same rule as #110 (*"a dependency tuika could own in a page of code is one it should own"*), one layer down. Note the policy's carve-out — *"owning it must not mean re-implementing a domain"* — was the reason to hesitate here: `Buffer` diffing and inline-viewport anchoring **are** a domain, and the `Buffer::resize` regression below is evidence that the hesitation was warranted.

## Before / After

**Dependency graph — 55 crates → 32** (`crossterm` is 27 of the 32):

```
$ cargo tree -e normal --prefix none | sed 's/ (\*)//' | sort -u | wc -l
before: 55        after: 32
$ cargo tree -e normal | grep -c ratatui
before: 2         after: 0
```

Dropped: `ratatui-core`, `kasuari`, `lru`, `hashbrown` ×2, `strum`(+macros), `compact_str`(+`castaway`, `itoa`, `ryu`, `static_assertions`), `itertools`(+`either`), `unicode-truncate`, `thiserror`(+impl, +`syn` 3.0), `allocator-api2`, `equivalent`, `foldhash`, `heck`, `rustversion`, `critical-section`.

**Cold dependency build — ~32s → ~6s** (4 cores, debug).

**Rendering — ~6.5% cheaper.** Instruction counts vs. the baseline #112 blessed from CI:

| benchmark | before | after | diff |
|---|---:|---:|---|
| `render.small` | 861,270 | 804,465 | **−6.6%** |
| `render.large` | 861,336 | 804,531 | **−6.6%** |
| `frame_windowed.large` | 880,853 | 823,903 | **−6.5%** |
| `frame_full.large` | 81,465,395 | 80,908,588 | −0.7% |
| `paging.large` | 252,164 | 252,164 | 0.0% |
| `streaming.mixed` | 12,885,320 | 13,118,258 | +1.8% |
| `reflow.mixed` | 12,383,908 | 12,645,267 | +2.1% |
| `one_shot.large` | 6,455,060 | 6,594,912 | +2.2% |
| `one_shot.small` | 267,089 | 272,920 | +2.2% |

The gains come from inline cell symbols. The ~2% rises on the markdown paths are the deliberate cost of grapheme-aware width measurement — the same class of bug the `textwrap` removal fixed for `Paragraph`. `benches/iai-baseline.json` is re-blessed, **and CI's own iai-callgrind job passes against it**, which confirms these numbers are not a local artifact.

*Measurement note:* `paging.large` reproduces #112's CI-blessed figure exactly (252,164).

**Terminal protocol — unchanged.** The 14 PTY smoke tests drive built examples under a pseudo-terminal and assert the emitted bytes through a reference terminal parser (alt-screen lifecycle, OSC 9;4 progress, OSC 8 hyperlinks, truecolor and Braille cells, split-footer publish-and-restore, resize survival, clean exit). All pass unchanged. The differential backend test still holds tuika's byte stream **identical** to `ratatui-crossterm`'s, now via cell conversion.

## Risk

**Medium-High.** This replaces the rendering substrate.

**One real regression was found and fixed during review**, and it is the clearest illustration of where the risk lives. `Buffer::resize` was written to discard contents — documented as deliberate, since the frame is rebuilt from application state anyway. But ratatui's truncates/extends and *preserves* cells, which makes a **same-size resize a no-op**. `Terminal::autoresize` skips its repaint when dimensions are unchanged, so the wipe was never repaired: the split footer went blank on any resize event that did not actually change the size. Caught by #115's `a_split_footer_stays_pinned_to_the_bottom_at_every_screen_size` (46 of 583 assertions, every failure with start size == target size), confirmed as mine by running the same test on `origin/main` in a worktree, and fixed to match the truncate/extend semantics with four regression tests pinning it.

Remaining risk:

- **Every host that names a ratatui type in a signature** — which is essentially all of them. This is the largest breaking change tuika can make. It was taken as *one* change rather than two: decoupling the API without removing the dependency would have broken hosts once, and removing the dependency later would have broken them again.
- **The inline viewport** (`insert_before`, `pin_footer`, `SplitFooter`) is the subtlest reimplemented piece — `ratatui_core::terminal::inline` is 929 lines. Both publish paths are implemented (portable and `scrolling-regions`) and covered, but this is where residual risk concentrates.
- **Wide-grapheme and diff edge cases.** The `CellDiffOption::ForcedWidth` path that carries OSC 8 escapes without billing columns, and the trailing-column refresh when a styled wide cluster is replaced by a narrow one, are both reimplemented and both directly tested.
- **`Line::raw("")` now yields a line with no spans** (matching what it replaced). A caller indexing `spans[0]` unconditionally would panic; one such assumption in `Gradient::line` was caught by the existing suite.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

**CI is fully green** on Linux, macOS, and Windows `Build + Tests`, iai-callgrind, Rustdoc, Format + Clippy, MSRV 1.88, Docs boundary, and CodeQL.

Test evidence — **1072 tests** pass workspace-wide under both `--all-features` and default features:

- New suites for `Buffer`/`Cell` diffing and wide graphemes, `Rect`/`Position` saturation, `Line`/`Span`, `Style` patch semantics, `TestBackend`, and the `Terminal` render loop.
- **main's own adversarial suites pass against the rewritten renderer** — #113's `src/tests/fuzz.rs` and `tests/robustness.rs`, and #115's `tests/stress_ui.rs`. All three were written against the ratatui-backed renderer, so they are independent verification by suites that predate this change. #115's found the `resize` bug above; the other two passed unchanged.
- Property tests, golden snapshots, resize sweep from `0×0`, cross-module integration, packaging test, `demo -- check` (42 scenes in sync), 14 PTY smoke tests.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` and the same on default features, `RUSTDOCFLAGS="-D warnings" cargo doc` and the nightly `--cfg docsrs` build, `cargo +1.88 build --workspace --all-targets --all-features`: all clean.

Rebased onto `1866e1b` (current main). Fixes from both intervening PRs are preserved, with conflicts resolved in favour of main's fix in each case: #113's `apply_buffer_links_in` (clipping OSC 8 markers to the component's area) and #115's two split-footer orderings (`autoresize()` before `pin_footer` and before draining the publish queue).

## Knowledge

Updated:

- `knowledge/specs/architecture.md` — *"Why the `ratatui-core` boundary, not the umbrella"* replaced by *"Why tuika owns the cell grid"*, covering the version-coupling motive, the dependency accounting, the preserved interop path, and the accepted cost. The stale *"ratatui diffs the buffer"* claims elsewhere in the file are corrected.
- `knowledge/specs/goal.md` — dependency list, purpose statement, and the **positioning claim** (see below).
- `knowledge/log.md` — new entry covering the decision, the 72% regression the IAI gate caught, and the reasoning behind the single `unsafe`. #113's and #115's entries are preserved alongside it.

**Reviewer attention, please:** `goal.md` previously said *"Additive, never a replacement… with ratatui still underneath."* That is no longer true, so it was rewritten rather than quietly dropped. The replacement is deliberately non-adversarial — tuika is an alternative in dependency terms, ratatui is why the Rust TUI ecosystem exists, and its widgets still compose. **This is a product decision, not a technical one.** It is one claim in three places (`goal.md`, the README lede, the README Compatibility section), all changed together; the coupling is recorded in `knowledge/log.md` so a future edit changes all three.

## Security

**One `unsafe` block added** — the only security-relevant change in the diff.

`Symbol::as_str` in `src/buffer.rs` uses `std::str::from_utf8_unchecked` on the inline byte array. Justification:

- **The invariant is local and airtight.** `Symbol` is a private type; the only way to populate `Inline` is `Symbol::new`, which copies a whole `&str`'s bytes and records that exact length. Nothing else writes the array, and `len` is never modified independently of it.
- **The cost of not doing it is real.** Re-validating on every read is ~10% of the render benchmarks' instructions, because this runs for every cell on every diff.
- **It is guarded.** A `debug_assert!` re-validates in test and debug builds, so any future break of the invariant fails the suite rather than becoming UB. #113's fuzz suite exercises this path with adversarial text.

No other threat-model category is touched: no new input parsing, no network or filesystem I/O, no credential handling, no deserialization. The OSC 8 URL sanitization in `term::hyperlink` (control-character stripping and scheme allow-listing) is unchanged and still covered.

## Follow-ups

- **The commit on this branch is unsigned** (`%G? = N`). The build container's configured SSH signing key is a 0-byte file with no private key, and the Doppler CLI is unavailable, so neither signing path in `AGENTS.md` was reachable. This was flagged and the maintainer chose to push anyway. **It must be re-signed before merge** — squash-and-merge will produce a new commit, so signing that one resolves it.
- **`pty_palette::a_terminals_answer_becomes_the_theme` is flaky on macOS**, unrelated to this change. It failed once here and passed on re-run, then passed first time on the next push. Evidence it is timing, not logic: Windows passed the same test on the same commit, it passes 15/15 locally on Linux, main's macOS job is green, and this PR's only edit to that path is a single import line swapping a variant-identical `Color` enum. The captured output showed the reply stream starting mid-token (`b:8888/…`, missing its `\x1b]10;rgb` prefix) while the probe reported "the terminal answered nothing" — a read/write race. Likely the harness's 20 ms poll granularity in `tests/pty_palette.rs` racing the probe's read timeout in `src/term/capabilities.rs`. Both files are outside this PR's scope and could not be validated without a macOS runner, so no speculative fix was pushed. Worth hardening separately — the handshake could wait on the probe's *read* rather than polling after the DA request.
- `docs/` guides beyond the README (`docs/components/*.md`, `docs/markdown.md`, `docs/layout.md`) were not swept for stale ratatui references. No committed demo recording changes, and `demo -- check` passes, so nothing is broken — but a follow-up pass for prose accuracy is worth doing before the next release.
- The companion crates still carry `"ratatui"` in their `keywords`, which is now only true via the optional feature. Harmless for discovery; worth revisiting at their next version bump.