### PR TITLE
fix(markdown): stop link underline at URL boundary

### DIFF
--- a/src/components/markdown/flatten.rs
+++ b/src/components/markdown/flatten.rs
@@ -244,9 +244,15 @@ pub(super) fn wrap_rich(spans: &[RichSpan], width: u16) -> Vec<(Vec<RichSpan>, V
     let n = cells.len();
     let is_break = |g: &str| g.chars().all(char::is_whitespace);
     while i < n {
-        if is_break(cells[i].0) {
+        let mut separator = None;
+        while i < n && is_break(cells[i].0) {
+            // A separator may sit outside the preceding style scope (`[link] next`).
+            // Preserve its own style and href when collapsing whitespace.
+            separator.get_or_insert((cells[i].1, cells[i].2));
             i += 1;
-            continue;
+        }
+        if i == n {
+            break;
         }
         let start = i;
         let mut word_w = 0u16;
@@ -255,10 +261,10 @@ pub(super) fn wrap_rich(spans: &[RichSpan], width: u16) -> Vec<(Vec<RichSpan>, V
             i += 1;
         }
         let word = &cells[start..i];
-        let sep = u16::from(!cur.is_empty());
+        let sep = u16::from(!cur.is_empty() && separator.is_some());
         if word_w <= width && cur_w + sep + word_w <= width {
             if sep == 1 {
-                let (_, st, href) = *cur.last().expect("sep implies non-empty cur");
+                let (st, href) = separator.expect("sep implies source whitespace");
                 cur.push((" ", st, href));
                 cur_w += 1;
             }

--- a/src/components/markdown/mod.rs
+++ b/src/components/markdown/mod.rs
@@ -713,6 +713,37 @@ mod tests {
     }
 
     #[test]
+    fn bare_url_does_not_underline_the_following_space() {
+        let theme = Theme::default();
+        let source = "Fetched **https://everruns.com/** and saved a durable summary to:";
+        let (lines, links) = to_linked_lines(
+            source,
+            80,
+            &theme,
+            &StyleSheet::from_theme(&theme),
+            CodeHighlighter::Plain,
+        );
+        let url = "https://everruns.com/";
+        let url_span = lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content.starts_with(url))
+            .expect("url span");
+
+        assert_eq!(url_span.content.as_ref(), url);
+        let link = links.iter().find(|link| link.url == url).expect("url link");
+        assert_eq!(link.end_col - link.start_col, url.len() as u16);
+
+        let buffer = crate::testing::render(&Markdown::new(source), 80, 1, &theme);
+        let following_space = link.end_col;
+        assert!(
+            !buffer[(following_space, 0)]
+                .modifier
+                .contains(Modifier::UNDERLINED)
+        );
+    }
+
+    #[test]
     fn labeled_markdown_link_preserves_destination_for_ctrl_click() {
         // Reproduction of the Ghostty Ctrl+click failure: `[label](url)` was
         // only styled — the destination was dropped — so OSC 8 / ctrl_click had


### PR DESCRIPTION
## What changed

Markdown wrapping now preserves a separator's own style and hyperlink target instead of inheriting both from the preceding word. A space after a bare or labeled URL therefore renders as ordinary text and is no longer part of the clickable link.

No public API changed.

## Why

The wrapper discarded source whitespace and reconstructed one collapsed space from the preceding word's style. After a URL, this extended the underline and OSC 8 target one cell beyond the URL.

## Before / After

The reported input is covered directly:

```markdown
Fetched **https://everruns.com/** and saved a durable summary to:
```

Before, the regression assertion observed:

```text
left:  "https://everruns.com/ "
right: "https://everruns.com/"
```

After, the URL span is exactly `https://everruns.com/`, the hyperlink width ends at `/`, and the following rendered buffer cell explicitly lacks `UNDERLINED`.

Real-terminal smoke: the streaming `markdown` example rendered links and exited with terminal state restored.

## Risk

- Low.
- Limited to collapsed whitespace styling during rich-text wrapping. Text content and wrapping width remain unchanged.
- Existing streaming/one-shot fuzz differentials, PTY tests, robustness sweeps, and stress tests all pass.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered — no API or source compatibility change
- [x] Knowledge concepts updated, or no update required with a reason

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env -u NO_COLOR cargo test --workspace --all-features`
- `cargo run --example demo -- check`
- Real PTY: `env -u NO_COLOR cargo run --example markdown`

## Knowledge

No knowledge update required — this restores the documented link/style boundary and does not change durable architecture, policy, terminology, or public behavior intent.

No demo asset update required — none of the registered scenes contains the affected styled-whitespace boundary; `demo -- check` confirms all 42 scenes and references remain in sync.

## Security

- **TM-PARSE:** reviewed. The updated whitespace scan remains linear in the existing parsed cell count; no recursion, unbounded nesting, or input-reachable panic was introduced. The `expect` is guarded by the local `sep` invariant.
- **TM-CLIP:** reviewed. The wrapper still emits at most one collapsed separator and the regression asserts the final painted buffer cell.
- **TM-ESC / TM-STATE:** no escape encoder or terminal lifecycle code changed. The corrected link range reduces the OSC 8 target by the unintended trailing cell.
- **TM-DEP:** no dependency changes.

## Follow-ups

No follow-ups.
