### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,32 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
-## [Unreleased]
+## [0.11.0] - 2026-08-22
+
+Released alongside `tuika-charts` 0.1.2, `tuika-codeformatters` 0.5.0,
+`tuika-html` 0.1.4, and `tuika-mermaid` 0.3.2. Their tuika dependency
+requirements now track 0.11.
+
+### Highlights
+
+**One route for every event** — a host registers each surface once and every
+`Event` kind (key, paste, mouse, focus) follows the same path to whichever
+surface owns input this frame, so a paste can no longer take a different route
+from a key and land behind an open overlay. `Router` resolves stages in a fixed
+order and `Delivery` reports which surface received what, including the case
+where nothing did.
+
+**Streaming markdown renders identically to a one-shot render** — two cache
+boundaries that only misfired at particular chunk splits are fixed, so a
+document fed in as it arrives renders exactly like the same document rendered
+whole.
+
+![markdown demo](https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/demos/markdown.gif)
+
+- **Binary size**: a default `tuika-codeformatters` build measured ~24.0 MiB on
+  a highlighting probe binary; a `rust` + `python` build is ~4.8 MiB. A tuika
+  host that places no images drops ~8.4 KiB of graphics encoders.
+- **Dependencies**: 66 crates to 55 (the `async` graph, 71 to 59).
 
 ### Breaking Changes
 
@@ -159,6 +184,13 @@ described in the release process begins with the entry below.
 
   Both were found by a new streaming/one-shot fuzz differential, and both
   depended on where the stream's chunk boundaries happened to fall.
+
+- **A link's underline stops at the URL.** When markdown wrapped a run of spans,
+  the space it re-inserted between two words inherited the style and OSC 8
+  target of the word *before* it, so the underline and the link's hit area ran
+  one cell past a `[label](url)` or a bare URL into the text that followed. The
+  separator now carries the style of the source whitespace it stands for, and a
+  boundary with no whitespace behind it no longer has a space invented for it.
 
 ## [0.10.0] - 2026-08-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-charts"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "ratatui",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-codeformatters"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "crossterm",
@@ -2342,7 +2342,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-html"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "html5ever",
  "markup5ever_rcdom",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "tuika-mermaid"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "mmdflux",
  "ratatui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.10.0"
+version = "0.11.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.10.0/logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
+  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
 </p>
 
 <h1 align="center">tuika</h1>
@@ -11,25 +11,25 @@
 [![downloads](https://img.shields.io/crates/d/tuika.svg)](https://crates.io/crates/tuika)
 [![license](https://img.shields.io/crates/l/tuika.svg)](https://github.com/everruns/tuika/blob/main/LICENSE)
 ![msrv](https://img.shields.io/badge/rust-1.88%2B-blue.svg) \
-[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](https://github.com/everruns/tuika/blob/v0.10.0/docs/getting-started.md) · [Components](https://github.com/everruns/tuika/blob/v0.10.0/docs/components.md) · [Layout](https://github.com/everruns/tuika/blob/v0.10.0/docs/layout.md) ·
-[Markdown](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md) · [Charts](https://github.com/everruns/tuika/blob/v0.10.0/docs/charts.md) ·
-[Terminal features](https://github.com/everruns/tuika/blob/v0.10.0/docs/features.md) ·
-[Keymap](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md) · [Input routing](https://github.com/everruns/tuika/blob/v0.10.0/docs/routing.md) ·
-[Styling](https://github.com/everruns/tuika/blob/v0.10.0/docs/styling.md) ·
-[Themes](https://github.com/everruns/tuika/blob/v0.10.0/docs/themes.md) \
-[Showcases](https://github.com/everruns/tuika/blob/v0.10.0/docs/showcases.md) · [Examples](#runnable-examples) ·
+[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](https://github.com/everruns/tuika/blob/v0.11.0/docs/getting-started.md) · [Components](https://github.com/everruns/tuika/blob/v0.11.0/docs/components.md) · [Layout](https://github.com/everruns/tuika/blob/v0.11.0/docs/layout.md) ·
+[Markdown](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) · [Charts](https://github.com/everruns/tuika/blob/v0.11.0/docs/charts.md) ·
+[Terminal features](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md) ·
+[Keymap](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md) · [Input routing](https://github.com/everruns/tuika/blob/v0.11.0/docs/routing.md) ·
+[Styling](https://github.com/everruns/tuika/blob/v0.11.0/docs/styling.md) ·
+[Themes](https://github.com/everruns/tuika/blob/v0.11.0/docs/themes.md) \
+[Showcases](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) · [Examples](#runnable-examples) ·
 [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) ·
 [Report a bug](https://github.com/everruns/tuika/issues)
 
 </div>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.10.0/docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
+  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
 </p>
 
 <div align="center">
 
-### tuika's goal is to become the default TUI [application](https://github.com/everruns/tuika/blob/v0.10.0/docs/showcases.md) framework for Rust
+### tuika's goal is to become the default TUI [application](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) framework for Rust
 
 **Build the app, not the render loop.**
 
@@ -71,14 +71,14 @@ You write views; tuika owns the rest:
 
 - **A whole app, not a widget set** — [flexbox layout](#model), anchored
   [overlays](#owned-scenes-dialogs-and-forms), focus, a declarative
-  [keymap](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md), [themes and stylesheets](#theming), and a
+  [keymap](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md), [themes and stylesheets](#theming), and a
   [runner](#screen-modes-lifecycle-and-runner) that owns raw mode, the alternate
   screen (or a [split footer](#screen-modes-lifecycle-and-runner) over live
   scrollback), and event translation.
 - **Batteries the terminal era expects** — [30+ components](#components)
-  including streaming [Markdown](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md) with pluggable syntax
+  including streaming [Markdown](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) with pluggable syntax
   highlighting, [images](#images) over Kitty/iTerm2/Sixel, adaptive
-  [charts](https://github.com/everruns/tuika/blob/v0.10.0/docs/charts.md), mermaid diagrams,
+  [charts](https://github.com/everruns/tuika/blob/v0.11.0/docs/charts.md), mermaid diagrams,
   [mouse selection and clipboard](#mouse-selection-and-clipboard), and
   [native OSC 9;4 progress](#native-terminal-progress).
 - **No lock-in** — it is additive to ratatui, not a replacement: wrap any
@@ -105,7 +105,7 @@ ratatui widget it likes (see [Compatibility](#compatibility)). (The optional
 `async` feature adds Tokio for [`AsyncRunner`](#screen-modes-lifecycle-and-runner);
 it is off by default.)
 
-See what that buys in practice: the [showcases](https://github.com/everruns/tuika/blob/v0.10.0/docs/showcases.md) are
+See what that buys in practice: the [showcases](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) are
 recordings of real applications running on tuika (also listed under
 [Used in](#used-in)), and the [`codex` example](examples/codex) is a whole
 coding-agent UI built with nothing else.
@@ -133,7 +133,7 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Live data** (`Live` / `LiveView`) is shared application state read at render
   time. Updates request a redraw from the runner; Tuika does not spawn data
   sources or reconcile a retained widget tree.
-- **Layout** is an [integer-native flexbox subset](https://github.com/everruns/tuika/blob/v0.10.0/docs/layout.md) (`layout`): wrapped flex lines,
+- **Layout** is an [integer-native flexbox subset](https://github.com/everruns/tuika/blob/v0.11.0/docs/layout.md) (`layout`): wrapped flex lines,
   independent basis/grow/shrink/min/max child styles, cross-line alignment, and
   exact boundary rounding over one direction-agnostic solver. `Flow` packages
   intrinsic wrapping; `Grid` is the smaller equal-column, row-major alternative
@@ -141,21 +141,21 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Overlays** (`overlay`) anchor a view over the base tree; the **host**
   (`host`) owns the alternate screen, translates crossterm input, and
   composites the frame.
-- **Keymap** ([`keymap`](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md)) resolves declarative key bindings to
+- **Keymap** ([`keymap`](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md)) resolves declarative key bindings to
   named commands: chords (`ctrl+r`) and multi-stroke sequences (`g g`) grouped
   into prioritized, mode-gated `Layer`s, dispatched from a translated `Key` and
   queryable for help/`KeyHints` surfaces. Character chords are exact logical
   text (`A`, `?`, `ж`), so the active keyboard layout is applied before
   matching; Shift stays explicit for non-character keys such as `Shift+Enter`.
   Host-agnostic, so it unit-tests without a terminal. See the
-  [keymap guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/keymap.md).
-- **Input routing** ([`routing`](https://github.com/everruns/tuika/blob/v0.10.0/docs/routing.md)) delivers an event to the
+  [keymap guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md).
+- **Input routing** ([`routing`](https://github.com/everruns/tuika/blob/v0.11.0/docs/routing.md)) delivers an event to the
   surface that owns input this frame — every event kind through one
   registration, so a paste cannot take a different path from a key. `Router`
   reads the focus registry an overlay-bearing `Scene` already synchronized, and
   reports through `Delivery` which surface received what, including the case
   where nothing did. See the
-  [routing guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/routing.md).
+  [routing guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/routing.md).
 - **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
   `term::progress::TerminalProgress`) animates from a host-supplied frame counter and
   can drive the terminal's own OSC 9;4 progress indicator. `anim::Timeline` adds
@@ -190,50 +190,50 @@ path always means "you will use this constantly".
 
 ## Components
 
-See the [component gallery](https://github.com/everruns/tuika/blob/v0.10.0/docs/components.md) for an animated demo of each
+See the [component gallery](https://github.com/everruns/tuika/blob/v0.11.0/docs/components.md) for an animated demo of each
 component. Linked names below jump straight to their demo.
 
 | Component | Purpose |
 | --- | --- |
-| [`Text`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
+| [`Text`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
 | `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
-| [`Markdown`](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md) |
-| [`CodeBlock`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
-| [`Html`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/markdown-code.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
+| [`Markdown`](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) |
+| [`CodeBlock`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
+| [`Html`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
 | `Diff` | Line diff (LCS), unified or side-by-side, with `+`/`-` gutters and line numbers |
 | `AsciiFont` | Large "figlet-style" block-letter banner text |
 | `QrCode` (+ `QrEcc`) | QR code (byte-mode v1–4 encoder) rendered with half-blocks |
-| [`Rule`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/text.md#rule) | Horizontal separator: optional title + fill glyph to width |
-| [`Flex`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#flex) | Flexbox container (the composition primitive) |
-| [`Flow`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#flow) | Intrinsic-width items wrapped into flex lines |
-| [`Grid`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#grid) | Small equal-column, row-major terminal grid |
+| [`Rule`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/text.md#rule) | Horizontal separator: optional title + fill glyph to width |
+| [`Flex`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#flex) | Flexbox container (the composition primitive) |
+| [`Flow`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#flow) | Intrinsic-width items wrapped into flex lines |
+| [`Grid`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#grid) | Small equal-column, row-major terminal grid |
 | `Responsive` / `Constrained` | Breakpoint selection and min/max measurement |
-| [`Boxed`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#boxed) | Border + padding + title, focus-aware |
+| [`Boxed`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#boxed) | Border + padding + title, focus-aware |
 | `Scene` / `ScopedScene` / `Dialog` | Owned or frame-borrowed root + anchored overlays |
-| [`ConfirmDialog`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#dialog-presets) / `ChoiceDialog` / `MultiChoiceDialog` / `InputDialog` | Stateful presets for common modal flows |
+| [`ConfirmDialog`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#dialog-presets) / `ChoiceDialog` / `MultiChoiceDialog` / `InputDialog` | Stateful presets for common modal flows |
 | `Spacer` | Flexible filler |
-| [`Scroll`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
-| [`ItemScroll`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
+| [`Scroll`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
+| [`ItemScroll`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
 | `Viewport` | Two-dimensional clipping/panning over any child view |
-| [`Scrollbar`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#scrollbar--virtualwindow) / `VirtualWindow` | Reusable bars and clamped ranges for virtualized collections |
+| [`Scrollbar`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#scrollbar--virtualwindow) / `VirtualWindow` | Reusable bars and clamped ranges for virtualized collections |
 | `Form` / `FormField` (+ `FormState`) | Responsive labeled controls and validation |
 | `DrawView` / `CanvasView` | Closure-based custom cell drawing |
-| [`SelectList`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
-| [`TreeList`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#treelist--treestate) (+ `TreeState`) | Stable-id expandable tree over host-provided rows |
-| [`SelectionScreen`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#selectionscreen) | Responsive full-screen action/agent/permission pickers |
-| [`KeyedTable`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
-| [`CompletionPalette`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
+| [`SelectList`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
+| [`TreeList`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#treelist--treestate) (+ `TreeState`) | Stable-id expandable tree over host-provided rows |
+| [`SelectionScreen`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#selectionscreen) | Responsive full-screen action/agent/permission pickers |
+| [`KeyedTable`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
+| [`CompletionPalette`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
 | `Slider` (+ `SliderState`) | One-row value picker over a numeric range |
-| [`TextInput`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |
-| [`StatusBar`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/layout.md#statusbar) | One-row left/right status segments |
-| [`Tabs`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/interactive.md#tabs--tabsstate) / `KeyHints` | Host-state tab navigation and command hints |
+| [`TextInput`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |
+| [`StatusBar`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#statusbar) | One-row left/right status segments |
+| [`Tabs`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#tabs--tabsstate) / `KeyHints` | Host-state tab navigation and command hints |
 | `TabSelect` (+ `TabSelectState`) | Value-selecting segmented control |
 | `Toasts` / `ToastList` | Transient notification stack with frame-driven expiry |
 | `Console` (+ `ConsoleLog`) | Captured stdout/log ring buffer + tailing overlay view |
-| [`Spinner`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/motion.md#spinner) | Frame-cycled activity glyph |
-| [`ProgressBar`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/motion.md#progressbar) | Determinate (sub-cell) / indeterminate bar |
-| [`ActivityList`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/motion.md#activitylist) | Multi-step lifecycle status with optional per-step progress |
-| [`Loader`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/motion.md#loader) | Spinner + message + hint row |
+| [`Spinner`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#spinner) | Frame-cycled activity glyph |
+| [`ProgressBar`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#progressbar) | Determinate (sub-cell) / indeterminate bar |
+| [`ActivityList`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#activitylist) | Multi-step lifecycle status with optional per-step progress |
+| [`Loader`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#loader) | Spinner + message + hint row |
 
 ## Example
 
@@ -493,10 +493,10 @@ HTML parser is a dependency tuika will not carry. Attach a
 same ordered renderer chain handles fenced diagrams and block HTML with one
 context, including the active stylesheet.
 [`tuika-html`](crates/tuika-html/) is the ready-made one, and it also supplies
-the [`Html`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/markdown-code.md#html) component for markup that is not inside
+the [`Html`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#html) component for markup that is not inside
 markdown at all. See the markdown guide for
-[inline HTML](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md#inline-html) and
-[block HTML](https://github.com/everruns/tuika/blob/v0.10.0/docs/markdown.md#block-html).
+[inline HTML](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md#inline-html) and
+[block HTML](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md#block-html).
 
 ## Theming
 
@@ -515,7 +515,7 @@ let b = tuika::Theme::gruvbox_dark();                  // named constructor
 let c = tuika::themes::by_name("gruvbox-dark").unwrap(); // config / --theme
 ```
 
-See the [theme gallery](https://github.com/everruns/tuika/blob/v0.10.0/docs/themes.md) for a screenshot of each bundled
+See the [theme gallery](https://github.com/everruns/tuika/blob/v0.11.0/docs/themes.md) for a screenshot of each bundled
 palette, or `themes::PRESETS` to enumerate them for a picker.
 
 An app can also inherit the palette the user already configured in their
@@ -523,7 +523,7 @@ terminal, rather than bringing its own — either implicitly with `themes::TERMI
 (ANSI slots, no I/O) or by asking the terminal for its actual colors and deriving
 a full theme from the reply. It is opt-in: tuika never probes unless a host asks
 it to. The query lives with the other out-of-band escapes, in `term::palette`. See
-[inheriting the terminal's colors](https://github.com/everruns/tuika/blob/v0.10.0/docs/features.md#inheriting-the-terminals-colors).
+[inheriting the terminal's colors](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md#inheriting-the-terminals-colors).
 
 Where a `Theme` is the color *tokens*, a `StyleSheet` is the *rules* — a mapping
 from a semantic role (heading, link, inline code, a panel's border and fill, …)
@@ -531,7 +531,7 @@ onto the style it draws with. Override a role in one place and every element wit
 that role restyles at once; markdown, toast severities, diff rows, and key hints
 are role-driven too. Companion crates and applications can define namespaced
 `StyleRole`s and install a `StyleResolver` without expanding tuika's closed data
-model. See the [styling guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/styling.md). `StyleBundle::padding` is layout, not a
+model. See the [styling guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/styling.md). `StyleBundle::padding` is layout, not a
 paint-only hint: `Boxed` resolves panel padding during both measurement and
 rendering; an explicit `Boxed::padding` remains the per-instance override.
 
@@ -667,7 +667,7 @@ threads, tasks, retries, and lifecycle.
   shape for a long-running tool with a live composer, status line, or progress
   panel over output the user wants to keep.
 
-The [screen-modes guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/features.md#screen-modes-alternate-screen--split-footer)
+The [screen-modes guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md#screen-modes-alternate-screen--split-footer)
 shows the mode in motion and covers its terminal contract in detail.
 
 In split-footer mode a host must not `println!` — the footer owns the cursor.
@@ -836,7 +836,7 @@ cells it reserves, using whichever terminal graphics protocol
 **iTerm2**, or **Sixel** (foot, xterm +sixel, mlterm, contour). Terminals with
 none show the alt text, so the same view tree renders everywhere.
 
-<img src="https://raw.githubusercontent.com/everruns/tuika/v0.10.0/docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
+<img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
 
 Decoding stays in the host — a heavy dependency, kept out like the highlighter
 boundary — so you hand in raw RGBA via `ImageData::from_rgba` and `tuika` owns the
@@ -920,7 +920,7 @@ selection — so a host should act on `plain()` left-drags.
 `Down`+`Up` and a swipe to scroll or a drag, so touch flows through this same
 path — there is no separate touch event to handle.
 
-> See the [terminal features guide](https://github.com/everruns/tuika/blob/v0.10.0/docs/features.md) for these
+> See the [terminal features guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md) for these
 > terminal-integration capabilities — OSC 8 hyperlinks, mouse selection and
 > clicks, OSC 52 clipboard, OSC 9;4 progress, and Kitty/iTerm2/Sixel images —
 > plus `Capabilities` detection, with demos and runnable examples.
@@ -962,7 +962,7 @@ not enter raw mode, capture input, hide the cursor, or own a screen.
 - [**LLMSim**](https://github.com/chaliy/llmsim) — an LLM traffic simulator whose
   live stats dashboard is a tuika screen.
 
-See the [showcases](https://github.com/everruns/tuika/blob/v0.10.0/docs/showcases.md) for a recording of each. Building
+See the [showcases](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) for a recording of each. Building
 something on tuika? Open a PR adding it here.
 
 ## Compatibility
@@ -1014,7 +1014,7 @@ The separately published companion crates live in this repository:
   terminal diagrams through mmdflux.
 - [`tuika-html`](crates/tuika-html/) lays out block-level HTML with html5ever —
   inside Markdown through the `MarkdownBlockRenderer` boundary, or standalone
-  through its own [`Html`](https://github.com/everruns/tuika/blob/v0.10.0/docs/components/markdown-code.md#html) component.
+  through its own [`Html`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#html) component.
 
 All four keep specialized rendering and heavier parsers or grammars out of
 tuika core.

--- a/crates/tuika-charts/Cargo.toml
+++ b/crates/tuika-charts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-charts"
-version = "0.1.1"
+version = "0.1.2"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest, matching the other independently versioned companions.
 edition.workspace = true
@@ -15,7 +15,7 @@ keywords = ["terminal", "tui", "charts", "kitty", "ratatui"]
 categories = ["command-line-interface", "visualization"]
 
 [dependencies]
-tuika = { version = "0.10.0", path = "../.." }
+tuika = { version = "0.11.0", path = "../.." }
 ratatui-core = "0.1.0"
 
 [dev-dependencies]

--- a/crates/tuika-codeformatters/Cargo.toml
+++ b/crates/tuika-codeformatters/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-codeformatters"
-version = "0.4.3"
+version = "0.5.0"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -78,7 +78,7 @@ typescript = ["dep:tree-sitter-typescript"]
 zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
-tuika = { version = "0.10.0", path = "../.." }
+tuika = { version = "0.11.0", path = "../.." }
 ratatui = "0.30.2"
 tree-sitter = "0.26"
 tree-sitter-highlight = "0.26"

--- a/crates/tuika-html/Cargo.toml
+++ b/crates/tuika-html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-html"
-version = "0.1.3"
+version = "0.1.4"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -24,7 +24,7 @@ categories = ["command-line-interface", "text-processing"]
 # tuika-html cannot be published until then. `publish_order.py` publishes tuika
 # first, and
 # the release process owns the bump; see `knowledge/processes/release.md`.
-tuika = { version = "0.10.0", path = "../.." }
+tuika = { version = "0.11.0", path = "../.." }
 ratatui-core = "0.1"
 # html5ever is the whole point of this crate existing separately: a spec
 # compliant tree builder (implied end tags, `<tbody>` insertion, malformed-input

--- a/crates/tuika-mermaid/Cargo.toml
+++ b/crates/tuika-mermaid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuika-mermaid"
-version = "0.3.1"
+version = "0.3.2"
 # Identity, MSRV, and license come from `[workspace.package]` in the root
 # manifest — see the comment there for what is and isn't shared.
 edition.workspace = true
@@ -19,6 +19,6 @@ keywords = ["tui", "mermaid", "markdown", "ratatui", "diagrams"]
 categories = ["command-line-interface", "text-processing"]
 
 [dependencies]
-tuika = { version = "0.10.0", path = "../.." }
+tuika = { version = "0.11.0", path = "../.." }
 ratatui-core = "0.1"
 mmdflux = { version = "2.6.1", default-features = false }

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -169,5 +169,5 @@ routes from there.
 
 - [Keymap](keymap.md) — turning key presses into named commands, which a `pre_fn`
   or `fallback_fn` stage dispatches.
-- [`examples/codex`](https://github.com/everruns/tuika/tree/v0.10.0/examples/codex) —
+- [`examples/codex`](https://github.com/everruns/tuika/tree/v0.11.0/examples/codex) —
   a full host: a modal, a picker, a composer, and a transcript on one route.

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,18 @@
 # Knowledge Log
 
+## 2026-08-22
+
+- **A link's underline is a whitespace question, not a link question**
+  - The reported bug was a bold bare URL whose underline ran past the URL. The
+    cause was in the wrap pass: the space re-inserted between two words inherited
+    the style and href of the preceding word, so any span boundary that happened
+    to be a link leaked one cell. [Markdown](specs/markdown.md) now states the
+    rule the fix restored — the collapsed separator carries the style of the
+    source whitespace, and a boundary with no whitespace behind it gets no space.
+  - Worth keeping because the symptom and the cause sat in different concepts:
+    nothing about link handling was wrong.
+
+
 ## 2026-08-21
 
 - **A session is a test subject the component sweep cannot reach**

--- a/knowledge/specs/markdown.md
+++ b/knowledge/specs/markdown.md
@@ -52,6 +52,13 @@ The module's files follow the passes rather than the vocabulary, so a change has
 one obvious home: the intermediate form, the parse pass, the flatten pass, table
 layout, the streaming cache, the image boundary, and the view.
 
+A wrapped line's inter-word space belongs to the *source whitespace* it stands
+for, not to the word before it. Flattening collapses a run of whitespace into one
+cell, and that cell keeps the style and hyperlink target the source whitespace
+carried — which is how a link's underline and its OSC 8 hit area stop at the end
+of the URL instead of running into the following word. A word boundary with no
+whitespace behind it (`**bold**text`) gets no space invented for it.
+
 ### The settled-prefix cache
 
 The cache boundary is the last *stable block boundary*, not the last newline: a


### PR DESCRIPTION
## What changed

Cuts tuika **0.11.0** and the four companions that must track it:
`tuika-charts` 0.1.2, `tuika-codeformatters` **0.5.0** (its own breaking change),
`tuika-html` 0.1.4, `tuika-mermaid` 0.3.2. Their `tuika` requirement moves to
`0.11.0`, so a published companion resolves against the release rather than 0.10.

The release itself carries seven commits since `v0.10.0`: input routing, two
pay-for-use changes (graphics encoders, tree-sitter grammars), a three-dependency
removal, two new test layers, and the four bugs those layers found.

Also in this commit: the `CHANGELOG.md` section for 0.11.0 (the previously
`[Unreleased]` body plus the link-underline fix that had no entry), every
release-pinned URL in `README.md` and `docs/routing.md` moved from `v0.10.0` to
`v0.11.0`, and the whitespace-styling invariant behind the link fix recorded in
`knowledge/specs/markdown.md`.

## Why

Seven commits — one `feat`, two breaking `!` — have accumulated on `main` since
0.10.0, including three correctness fixes reachable by any host that renders
streaming markdown.

## Before / After

Release plumbing; no library behavior changes in this commit. The behavior the
release ships is proven by the suites that landed with it (fuzz differential,
black-box sweep, session stress) — all green here.

crates.io before: `tuika 0.10.0` · after this merge publishes: `tuika 0.11.0`.

## Risk

- Low
- What can break: a wrong `tuika` requirement on a companion would publish it
  unresolvable. Checked — all four read `0.11.0`. A publish failure rolls forward
  as a hotfix, per the release process.

## Publish-readiness

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (27 test binaries, 0 failures)
- [x] `cargo run --example demo -- check` — 42 scenes in sync
- [x] `cargo doc --all-features --no-deps`
- [x] `cargo test --test packaging`
- [x] `cargo publish --dry-run -p tuika` (companions are validated in CI after
      tuika publishes)
- [x] `python3 scripts/publish_order.py` → tuika, charts, codeformatters, html, mermaid
- [x] `python3 scripts/validate_okf.py knowledge --check-links` — 16 concepts, 0 errors
- [x] crates.io currently serves `0.10.0` → publishing `0.11.0`
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.11.0`
- [x] highlight demo embedded and pinned to `v0.11.0`

Note on the highlight recording: `docs/demos/markdown.gif` is reused as-is rather
than re-recorded. VHS/ttyd/ffmpeg are unavailable in this environment, and the
scene is unaffected by this release's markdown changes — its document contains no
bare URL, no numbered list, and no blank line inside its fenced block, so none of
the three fixed paths alters what it shows.

## Post-merge verification

- [ ] `release.yml` created tag `v0.11.0` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] crates.io serves `tuika 0.11.0`, `tuika-charts 0.1.2`,
      `tuika-codeformatters 0.5.0`, `tuika-html 0.1.4`, `tuika-mermaid 0.3.2`
- [ ] docs.rs built `tuika 0.11.0`

## Checklist

- [x] Tests added or updated — no new code; the release's own suites run green
- [x] Backward compatibility considered — breaking changes are documented under
      `### Breaking Changes` with before/after
- [x] Knowledge concepts updated

## Knowledge

`knowledge/specs/markdown.md` gained the rule the link-underline fix restored: a
collapsed inter-word space carries the style and href of the *source whitespace*,
not of the word before it, and a boundary with no whitespace behind it gets no
space invented. Logged in `knowledge/log.md`. Bundle validates with 0 errors.

## Security

No security-relevant code in this commit — version numbers, changelog, pinned
documentation URLs. The release's own security-relevant surface (parsers reading
untrusted terminal replies and adversarial text) is covered by the fuzz and
black-box suites that landed in it; the OSC 8 out-of-rect write it fixed was a
rendering-integrity bug, not an escape-injection one — no control byte reaches a
cell, asserted by the sweep.

## Follow-ups

- Re-record `docs/demos/markdown.gif` on a machine with VHS if the markdown
  scene's document is ever extended to exercise the fixed paths.

---
## `## [0.11.0] - 2026-08-22`

Released alongside `tuika-charts` 0.1.2, `tuika-codeformatters` 0.5.0,
`tuika-html` 0.1.4, and `tuika-mermaid` 0.3.2. Their tuika dependency
requirements now track 0.11.

### Highlights

**One route for every event** — a host registers each surface once and every
`Event` kind (key, paste, mouse, focus) follows the same path to whichever
surface owns input this frame, so a paste can no longer take a different route
from a key and land behind an open overlay. `Router` resolves stages in a fixed
order and `Delivery` reports which surface received what, including the case
where nothing did.

**Streaming markdown renders identically to a one-shot render** — two cache
boundaries that only misfired at particular chunk splits are fixed, so a
document fed in as it arrives renders exactly like the same document rendered
whole.

![markdown demo](https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/demos/markdown.gif)

- **Binary size**: a default `tuika-codeformatters` build measured ~24.0 MiB on
  a highlighting probe binary; a `rust` + `python` build is ~4.8 MiB. A tuika
  host that places no images drops ~8.4 KiB of graphics encoders.
- **Dependencies**: 66 crates to 55 (the `async` graph, 71 to 59).

### Breaking Changes

- **`tuika-codeformatters`**: every tree-sitter grammar now sits behind its own
  cargo feature, all fourteen on by default. A dependant already passing
  `default-features = false` must now name the languages it wants.
- **`Paragraph` and dialog copy wrap differently** — tuika's own wrap solver
  replaces `textwrap`: greedy first-fit breaks, whitespace runs collapsed to one
  space, breaks only at whitespace (a linkified URL no longer splits after its
  scheme), and grapheme-aware widths.

### Added

- **Input routing**: `routing` (`Router`, `Delivery`, `RouteStage`,
  `InputTarget`), re-exported from the crate root and the prelude.
- **`term::hyperlink::apply_buffer_links_in`**: the area-clipped counterpart to
  `apply_buffer_links`.
- Fuzz, black-box robustness, and session stress suites (test-only).

### Changed

- Graphics encoders and tree-sitter grammars are pay-for-use.
- `textwrap`, `ratatui-crossterm`, and `tokio-stream` dropped.

### Fixed

- A split footer is pinned and published at the terminal's current size.
- A component no longer stamps hyperlink markers outside its own rect.
- Streamed markdown renders identically to a one-shot render (info-string fence
  read as a closer; a blank line between list items restarting the numbering).
- A link's underline and OSC 8 hit area stop at the URL.

The full section, with the before/after snippets and the reasoning, is in
`CHANGELOG.md` in this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BT3Toyhc2CQCEdgKiz4Fkq)_