### PR TITLE
feat(mouse): confine drag selection to the panel it starts in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
+## [Unreleased]
+
+### Changed
+
+- **Runner drag selection is per panel.** A left drag that starts inside a
+  bordered `Boxed` selects only within that panel: positions clamp to its
+  inner rect, a multi-row selection wraps at the panel's edges instead of the
+  screen's, and the copied text never picks up the pane beside it. A drag that
+  starts outside every panel still spans the screen as before.
+
+### Fixed
+
+- A `SelectionRange` that reaches past the `area` handed to
+  `mouse::paint_selection`, `mouse::selected_text`, or `SelectionRange::contains`
+  now stops at that area's rows instead of indexing the buffer out of bounds.
+
+### Added
+
+- `mouse::SelectionState::confine` / `region` — restrict a gesture to a rect and
+  read it back, for hosts driving the selection primitives from their own loop.
+
 ## [0.11.0] - 2026-08-22
 
 Released alongside `tuika-charts` 0.1.2, `tuika-codeformatters` 0.5.0,
@@ -964,5 +985,5 @@ styling extras) are no longer flattened to `tuika::`. Reach them through
 * test: add a PTY smoke test and guard the published crate contents
 
 [0.6.0]: https://github.com/everruns/tuika/releases/tag/v0.6.0
-[Unreleased]: https://github.com/everruns/tuika/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/everruns/tuika/compare/v0.11.0...HEAD
 [0.10.0]: https://github.com/everruns/tuika/compare/v0.9.0...v0.10.0

--- a/docs/features.md
+++ b/docs/features.md
@@ -258,7 +258,10 @@ activation, selection, and scrolling. Capture is explicit through
 Once an app opts into capture, the terminal stops handling links and selection.
 `Runner` and `AsyncRunner` restore selection over the final cell
 frame: a plain left drag highlights text, a same-cell double click selects a
-word, and releasing copies through OSC 52. Wheel events continue to reach the
+word, and releasing copies through OSC 52. Selection is *per panel* — a drag
+that starts inside a bordered `Boxed` stays inside it, wrapping at that panel's
+edges rather than streaming across the panes beside it, so copying a sidebar
+entry never drags in the editor next to it. Wheel events continue to reach the
 application. Return
 `UpdateResult::Consumed` for a handled gesture that needs no repaint, or
 `UpdateResult::Dirty` for one that does; either result keeps draggable controls
@@ -279,7 +282,10 @@ selection, copy, and hit-testing — from tuika's enriched event model
   boundaries; `selected_text(buffer, area, range)` then reads the selected text
   back out of the rendered buffer (wide glyphs intact) and `mouse::paint_selection(buffer,
   area, range, style)` paints it in. `handle_with_clock` accepts a host `Clock`
-  for deterministic gesture timing; `handle` uses `SystemClock`.
+  for deterministic gesture timing; `handle` uses `SystemClock`. `confine(Some(rect))`
+  restricts a gesture to one panel — positions clamp into the rect, and `region()`
+  reports it back so `resolve`, `selected_text`, and `paint_selection` can be
+  given the same bounds as their `area`.
 - `ctrl_click_url(event, buffer, area)` is an application-side fallback for a
   host that opted into capture. It returns the URL under a Ctrl+left-button
   release: first an OSC 8 target embedded in the cell run (labeled markdown

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,16 @@
 
 ## 2026-08-22
 
+- **Selection is scoped by what the frame drew, not by the screen**
+  - Runner-provided drag selection streamed across the whole cell grid, so a
+    drag inside a sidebar picked up whatever pane sat beside it. Panels are the
+    unit a reader means: a bordered `Boxed` now records its inner rect while
+    rendering, and the gesture is confined to the innermost region under the
+    press. See [Architecture](specs/architecture.md).
+  - Worth keeping because it sets a precedent: render-time regions (like the
+    text sources behind copy) are how the selection layer learns structure a
+    flat cell buffer has thrown away.
+
 - **A link's underline is a whitespace question, not a link question**
   - The reported bug was a bold bare URL whose underline ran past the URL. The
     cause was in the wrap pass: the space re-inserted between two words inherited

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -118,6 +118,15 @@ rather than beside it.
   52 on release. Wheel input still routes to the application. A handled gesture
   returns `UpdateResult::Consumed` or `Dirty`; custom-loop hosts keep using the
   public selection primitives directly.
+- **A drag belongs to the panel it starts in.** A bordered `Boxed` records its
+  inner rect as a selection region while rendering; the runner resolves the
+  press cell to the innermost region and confines the whole gesture there, so a
+  linear selection wraps at the panel's edges and the copied text is that
+  panel's text. The screen remains the region when a drag starts outside every
+  panel. Regions come from the previously painted frame, which is what the
+  pointer was actually aimed at; a range is always resolved against the area it
+  is given, so geometry that changed underneath it can only narrow the
+  selection, never reach a cell outside.
 - **Runners own application state directly**: `Application` (and its awaiting
   counterpart `AsyncApplication`) receives signals through `&mut self` and
   builds a `ScopedElement<'_>` through `&self`, so a frame can borrow

--- a/src/components/boxed.rs
+++ b/src/components/boxed.rs
@@ -229,6 +229,13 @@ impl<V: View> View for Boxed<V> {
             }
         }
         let inner = self.inner(area, self.resolved_padding(ctx));
+        if self.has_border() {
+            // A bordered box is a *panel*: a host-provided drag selection stays
+            // inside it rather than streaming across the panes beside it. Only
+            // bordered boxes qualify — a borderless `Boxed` is padding, not a
+            // visually separate surface.
+            ctx.record_selection_region(inner);
+        }
         let mut inner_surface = surface.child(inner);
         self.child.render(inner, &mut inner_surface, ctx);
     }

--- a/src/host.rs
+++ b/src/host.rs
@@ -34,7 +34,7 @@ use super::overlay::Overlay;
 use super::screen::ScreenMode;
 use super::style::{StyleSheet, Theme};
 use super::surface::Surface;
-use super::view::{RenderCtx, SelectionSources, View};
+use super::view::{RenderCtx, SelectionFrame, View};
 
 /// RAII guard for the alternate screen.
 pub struct AltScreen {
@@ -440,20 +440,20 @@ pub fn paint_with_context(
     root: &dyn View,
     overlays: &[Overlay],
 ) {
-    let sources = SelectionSources::default();
-    paint_with_context_and_sources(buffer, area, ctx, root, overlays, &sources);
+    let selection = SelectionFrame::default();
+    paint_with_context_and_selection(buffer, area, ctx, root, overlays, &selection);
 }
 
-pub(crate) fn paint_with_context_and_sources(
+pub(crate) fn paint_with_context_and_selection(
     buffer: &mut Buffer,
     area: Rect,
     ctx: &RenderCtx,
     root: &dyn View,
     overlays: &[Overlay],
-    sources: &SelectionSources,
+    selection: &SelectionFrame,
 ) {
-    sources.clear();
-    let ctx = ctx.clone().with_selection_sources(sources);
+    selection.clear();
+    let ctx = ctx.clone().with_selection(selection);
     // Base background so the alternate screen is fully owned (no stale cells).
     {
         let mut surface = Surface::new(buffer, area);

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -55,9 +55,11 @@ impl SelectionRange {
     }
 
     /// The inclusive `[left, right]` selected column span on `row`, clamped to
-    /// `area`. Rows outside the selection return `None`.
+    /// `area`. Rows outside the selection — or outside `area`, so a range that
+    /// outlived the geometry it was made in can never reach a cell the caller
+    /// did not offer — return `None`.
     fn row_span(&self, row: u16, area: Rect) -> Option<(u16, u16)> {
-        if row < self.start.1 || row > self.end.1 {
+        if row < self.start.1 || row > self.end.1 || row < area.y || row >= area.bottom() {
             return None;
         }
         let left = if row == self.start.1 {
@@ -85,8 +87,10 @@ impl SelectionRange {
 /// Tracks click-drag and double-click text selection across mouse events.
 ///
 /// Left `Down` starts (and clears any previous selection); `Drag` extends;
-/// `Up` finishes. Two plain clicks on the same cell within the double-click
-/// interval queue a word selection. Call [`Self::resolve`] after rendering so
+/// `Up` finishes. [`confine`](Self::confine) restricts a gesture to one panel:
+/// positions are clamped into that rect, so dragging out of the panel selects
+/// to its edge rather than across whatever is beside it. Two plain clicks on
+/// the same cell within the double-click interval queue a word selection. Call [`Self::resolve`] after rendering so
 /// word boundaries can be read from the current buffer.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SelectionState {
@@ -96,6 +100,7 @@ pub struct SelectionState {
     selecting: bool,
     last_click: Option<((u16, u16), Instant)>,
     pending_word: Option<(u16, u16)>,
+    region: Option<Rect>,
 }
 
 impl SelectionState {
@@ -116,10 +121,11 @@ impl SelectionState {
     /// double-click timing deterministic in tests, replay systems, and hosts
     /// with a virtual clock.
     pub fn handle_with_clock(&mut self, m: &Mouse, clock: &dyn Clock) -> bool {
+        let (column, row) = clamp_to_region(self.region, m.column, m.row);
         match m.kind {
             MouseKind::Down(MouseButton::Left) => {
-                self.anchor = (m.column, m.row);
-                self.cursor = (m.column, m.row);
+                self.anchor = (column, row);
+                self.cursor = (column, row);
                 self.pressed = true;
                 let had = self.selecting;
                 self.selecting = false;
@@ -127,14 +133,14 @@ impl SelectionState {
                 had
             }
             MouseKind::Drag(MouseButton::Left) if self.pressed => {
-                self.cursor = (m.column, m.row);
+                self.cursor = (column, row);
                 self.selecting = self.cursor != self.anchor;
                 self.last_click = None;
                 self.pending_word = None;
                 true
             }
             MouseKind::Up(MouseButton::Left) if self.pressed => {
-                self.cursor = (m.column, m.row);
+                self.cursor = (column, row);
                 self.pressed = false;
                 self.selecting = self.cursor != self.anchor;
                 if self.selecting {
@@ -172,6 +178,23 @@ impl SelectionState {
         true
     }
 
+    /// Confine the gesture to `region` — a panel, list viewport, or any other
+    /// rect the host considers one selectable surface.
+    ///
+    /// Set it on the `Down` that starts a gesture: every position is clamped
+    /// into the rect, and [`region`](Self::region) reports it back so painting
+    /// and text extraction use the same bounds (pass it as their `area`, so a
+    /// multi-row selection wraps at the panel edge). `None` restores whole-screen
+    /// selection.
+    pub fn confine(&mut self, region: Option<Rect>) {
+        self.region = region.filter(|r| r.width > 0 && r.height > 0);
+    }
+
+    /// The panel the current gesture is confined to, if any.
+    pub fn region(&self) -> Option<Rect> {
+        self.region
+    }
+
     /// Clear the selection (e.g. on Esc or a new turn).
     pub fn clear(&mut self) {
         *self = Self::default();
@@ -187,6 +210,29 @@ impl SelectionState {
     pub fn is_active(&self) -> bool {
         self.selecting
     }
+}
+
+/// Clamp a cell into `region` (a no-op when the gesture is unconfined).
+fn clamp_to_region(region: Option<Rect>, column: u16, row: u16) -> (u16, u16) {
+    let Some(r) = region else {
+        return (column, row);
+    };
+    (
+        column.clamp(r.x, r.right().saturating_sub(1)),
+        row.clamp(r.y, r.bottom().saturating_sub(1)),
+    )
+}
+
+/// The innermost region of `regions` containing `(column, row)`.
+///
+/// Regions are recorded parent-before-child while rendering, so the last match
+/// is the innermost panel at that cell.
+pub(crate) fn region_at(regions: &[Rect], column: u16, row: u16) -> Option<Rect> {
+    regions
+        .iter()
+        .rev()
+        .find(|r| in_rect(**r, column, row))
+        .copied()
 }
 
 const DOUBLE_CLICK_INTERVAL: Duration = Duration::from_millis(500);
@@ -663,6 +709,64 @@ mod tests {
         assert_eq!(range.start, (1, 0));
         assert_eq!(range.end, (4, 0));
         assert!(sel.is_active());
+    }
+
+    #[test]
+    fn a_range_reaching_past_its_area_paints_nothing_outside_it() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 2));
+        let area = buffer.area;
+        let sel = SelectionRange {
+            start: (0, 0),
+            end: (9, 6), // outlived the geometry it was made in
+        };
+
+        // Reading and hit-testing stay inside the offered area instead of
+        // indexing a cell the buffer does not have.
+        selected_text(&buffer, area, sel);
+        assert!(!sel.contains(1, 5, area));
+        paint_selection(&mut buffer, area, sel, Style::default().bg(Color::Red));
+        for row in 0..2 {
+            for column in 0..4 {
+                assert_eq!(buffer[(column, row)].bg, Color::Red);
+            }
+        }
+    }
+
+    #[test]
+    fn a_confined_drag_clamps_to_its_panel() {
+        let panel = Rect::new(2, 1, 6, 2);
+        let mut sel = SelectionState::new();
+        sel.confine(Some(panel));
+        sel.handle(&down(3, 1));
+        sel.handle(&drag(19, 9)); // far outside the panel
+
+        let range = sel.range().expect("a drag selects");
+        assert_eq!(range.start, (3, 1));
+        assert_eq!(range.end, (7, 2));
+        assert_eq!(sel.region(), Some(panel));
+        // Row 2 of the selection starts at the panel's left edge, not the screen's.
+        assert!(!range.contains(1, 2, panel));
+        assert!(range.contains(2, 2, panel));
+    }
+
+    #[test]
+    fn a_zero_sized_region_leaves_the_gesture_unconfined() {
+        let mut sel = SelectionState::new();
+        sel.confine(Some(Rect::new(4, 4, 0, 0)));
+        assert_eq!(sel.region(), None);
+        sel.handle(&down(0, 0));
+        sel.handle(&drag(9, 0));
+        assert_eq!(sel.range().map(|r| r.end), Some((9, 0)));
+    }
+
+    #[test]
+    fn the_innermost_region_wins_at_a_cell() {
+        let outer = Rect::new(0, 0, 10, 4);
+        let inner = Rect::new(2, 1, 4, 2);
+        let regions = [outer, inner];
+        assert_eq!(region_at(&regions, 3, 1), Some(inner));
+        assert_eq!(region_at(&regions, 8, 1), Some(outer));
+        assert_eq!(region_at(&regions, 12, 1), None);
     }
 
     #[test]

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -72,10 +72,10 @@ use super::{
     FrameGraphics, FrameGraphicsCleanup, PaintRoot, RESIZE_FRAME_INTERVAL, RunnerAction,
     RunnerCore, RunnerSelection, Signal,
 };
-use crate::host::paint_with_context_and_sources;
+use crate::host::paint_with_context_and_selection;
 use crate::live::RedrawHandle;
 use crate::screen::{Scrollback, close_footer, pin_footer};
-use crate::view::{ScopedElement, SelectionSources};
+use crate::view::{ScopedElement, SelectionFrame};
 use crate::{
     Element, Event, RenderCtx, RunnerConfig, SystemClock, TerminalSession, Theme, UpdateResult,
     translate_event,
@@ -753,26 +753,21 @@ where
     S: AsyncFrameSource<M>,
 {
     let mut copied = None;
-    let sources = SelectionSources::default();
+    let selection_frame = SelectionFrame::default();
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
         frames.frame(frame, &mut |root| {
-            paint_with_context_and_sources(
+            paint_with_context_and_selection(
                 terminal_frame.buffer_mut(),
                 area,
                 &ctx,
                 root,
                 &[],
-                &sources,
+                &selection_frame,
             );
         });
-        copied = selection.finish_frame(
-            terminal_frame.buffer_mut(),
-            area,
-            theme,
-            &sources.snapshot(),
-        );
+        copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme, &selection_frame);
     })?;
     Ok(copied)
 }

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -100,13 +100,13 @@ use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
 use ratatui_core::terminal::{Terminal, TerminalOptions};
 
-use crate::host::paint_with_context_and_sources;
+use crate::host::paint_with_context_and_selection;
 use crate::live::RedrawHandle;
 use crate::mouse::{SelectionState, paint_selection, selected_text_from_sources};
 use crate::screen::{ScreenMode, Scrollback, close_footer, pin_footer};
 use crate::term::clipboard;
 use crate::term::image::{ImageLayer, ImageSupport};
-use crate::view::SelectionSources;
+use crate::view::SelectionFrame;
 use crate::{
     Clock, Element, Event, RenderCtx, ScopedElement, SystemClock, TerminalSession, Theme, View,
     translate_event,
@@ -920,26 +920,21 @@ where
     F: FrameSource,
 {
     let mut copied = None;
-    let sources = SelectionSources::default();
+    let selection_frame = SelectionFrame::default();
     terminal.draw(|terminal_frame| {
         let area = terminal_frame.area();
         let ctx = graphics.map_or_else(|| RenderCtx::new(theme), |g| g.render_context(theme));
         frames.frame(frame, &mut |root| {
-            paint_with_context_and_sources(
+            paint_with_context_and_selection(
                 terminal_frame.buffer_mut(),
                 area,
                 &ctx,
                 root,
                 &[],
-                &sources,
+                &selection_frame,
             );
         });
-        copied = selection.finish_frame(
-            terminal_frame.buffer_mut(),
-            area,
-            theme,
-            &sources.snapshot(),
-        );
+        copied = selection.finish_frame(terminal_frame.buffer_mut(), area, theme, &selection_frame);
     })?;
     Ok(copied)
 }
@@ -948,6 +943,8 @@ struct RunnerSelection {
     enabled: bool,
     state: SelectionState,
     pending_copy: bool,
+    /// Panel regions from the last painted frame, resolved on the next `Down`.
+    regions: Vec<Rect>,
 }
 
 impl RunnerSelection {
@@ -956,6 +953,7 @@ impl RunnerSelection {
             enabled,
             state: SelectionState::new(),
             pending_copy: false,
+            regions: Vec::new(),
         }
     }
 
@@ -997,6 +995,14 @@ impl RunnerSelection {
             return self.clear();
         }
 
+        if matches!(mouse.kind, crate::MouseKind::Down(crate::MouseButton::Left)) {
+            // A gesture belongs to the panel it starts in, for its whole life.
+            self.state.confine(crate::mouse::region_at(
+                &self.regions,
+                mouse.column,
+                mouse.row,
+            ));
+        }
         let changed = self.state.handle_with_clock(mouse, clock);
         if changed
             && matches!(mouse.kind, crate::MouseKind::Up(crate::MouseButton::Left))
@@ -1012,11 +1018,23 @@ impl RunnerSelection {
         buffer: &mut Buffer,
         area: Rect,
         theme: &Theme,
-        sources: &[crate::view::SelectionSource],
+        frame: &crate::view::SelectionFrame,
     ) -> Option<String> {
         if !self.enabled {
             return None;
         }
+        self.regions = frame.take_regions();
+        let sources = frame.take_sources();
+        // A confined gesture reads, wraps, and paints inside its panel. The
+        // region was recorded by the previous frame, so intersect it with this
+        // one: a layout change between the press and this paint must not point
+        // the selection at geometry that no longer exists.
+        let area = self
+            .state
+            .region()
+            .map(|panel| panel.intersection(area))
+            .filter(|panel| panel.width > 0 && panel.height > 0)
+            .unwrap_or(area);
         if self.state.resolve(buffer, area) {
             self.pending_copy = true;
         }
@@ -1026,7 +1044,7 @@ impl RunnerSelection {
         };
         let copied = self
             .pending_copy
-            .then(|| selected_text_from_sources(buffer, area, range, sources));
+            .then(|| selected_text_from_sources(buffer, area, range, &sources));
         self.pending_copy = false;
         paint_selection(buffer, area, range, theme.selection_style());
         copied
@@ -1132,11 +1150,108 @@ mod tests {
         assert!(selection.handle_event(&Event::Mouse(drag), UpdateResult::Clean, &clock));
         assert!(selection.handle_event(&Event::Mouse(up), UpdateResult::Clean, &clock));
 
-        let copied = selection.finish_frame(&mut buffer, area, &Theme::default(), &[]);
+        let copied = selection.finish_frame(
+            &mut buffer,
+            area,
+            &Theme::default(),
+            &crate::view::SelectionFrame::default(),
+        );
         assert_eq!(copied.as_deref(), Some("hello"));
         for column in 0..=4 {
             assert_eq!(buffer[(column, 0)].bg, Theme::default().selection_bg);
         }
+    }
+
+    /// Two bordered panels side by side, each with its own text.
+    struct TwoPanels;
+
+    impl crate::View for TwoPanels {
+        fn measure(&self, available: crate::Size, _ctx: &crate::RenderCtx) -> crate::Size {
+            available
+        }
+
+        fn render(&self, _area: Rect, surface: &mut crate::Surface, ctx: &crate::RenderCtx) {
+            for (rect, label) in [
+                (Rect::new(0, 0, 10, 3), "alpha"),
+                (Rect::new(10, 0, 10, 3), "bravo"),
+            ] {
+                let panel = crate::components::Boxed::new(crate::element(Text::raw(label)));
+                let mut child = surface.child(rect);
+                crate::View::render(&panel, rect, &mut child, ctx);
+            }
+        }
+    }
+
+    fn paint_panels(selection: &mut RunnerSelection, theme: &Theme) -> (Buffer, Option<String>) {
+        let area = Rect::new(0, 0, 20, 3);
+        let mut buffer = Buffer::empty(area);
+        let frame = crate::view::SelectionFrame::default();
+        crate::host::paint_with_context_and_selection(
+            &mut buffer,
+            area,
+            &crate::RenderCtx::new(theme),
+            &TwoPanels,
+            &[],
+            &frame,
+        );
+        let copied = selection.finish_frame(&mut buffer, area, theme, &frame);
+        (buffer, copied)
+    }
+
+    #[test]
+    fn selection_stays_inside_the_panel_it_started_in() {
+        let clock = FixedClock(Instant::now());
+        let theme = Theme::default();
+        let mut selection = RunnerSelection::new(true);
+        // A first frame publishes the panels' regions.
+        paint_panels(&mut selection, &theme);
+
+        // Press inside the left panel, drag deep into the right one.
+        for mouse in [
+            crate::Mouse::at(crate::MouseKind::Down(crate::MouseButton::Left), 2, 1),
+            crate::Mouse::at(crate::MouseKind::Drag(crate::MouseButton::Left), 16, 1),
+            crate::Mouse::at(crate::MouseKind::Up(crate::MouseButton::Left), 16, 1),
+        ] {
+            selection.handle_event(&Event::Mouse(mouse), UpdateResult::Clean, &clock);
+        }
+
+        let (buffer, copied) = paint_panels(&mut selection, &theme);
+        assert_eq!(copied.as_deref(), Some("alpha"));
+        for column in 2..8 {
+            assert_eq!(
+                buffer[(column, 1)].bg,
+                theme.selection_bg,
+                "left panel cell {column} is selected"
+            );
+        }
+        for column in 8..20 {
+            assert_ne!(
+                buffer[(column, 1)].bg,
+                theme.selection_bg,
+                "cell {column} outside the panel is untouched"
+            );
+        }
+    }
+
+    #[test]
+    fn selection_outside_every_panel_still_spans_the_screen() {
+        let clock = FixedClock(Instant::now());
+        let theme = Theme::default();
+        let mut selection = RunnerSelection::new(true);
+        paint_panels(&mut selection, &theme);
+
+        // Row 0 is the panels' borders — no region covers it.
+        for mouse in [
+            crate::Mouse::at(crate::MouseKind::Down(crate::MouseButton::Left), 1, 0),
+            crate::Mouse::at(crate::MouseKind::Drag(crate::MouseButton::Left), 15, 0),
+            crate::Mouse::at(crate::MouseKind::Up(crate::MouseButton::Left), 15, 0),
+        ] {
+            selection.handle_event(&Event::Mouse(mouse), UpdateResult::Clean, &clock);
+        }
+
+        assert!(selection.state.region().is_none());
+        let (buffer, _) = paint_panels(&mut selection, &theme);
+        assert_eq!(buffer[(15, 0)].bg, theme.selection_bg);
     }
 
     #[test]

--- a/src/view.rs
+++ b/src/view.rs
@@ -136,20 +136,42 @@ pub(crate) struct SelectionSource {
     pub(crate) text: String,
 }
 
+/// Per-frame selection metadata collected while rendering: the original text
+/// behind rendered paragraphs, and the panel regions a drag selection is
+/// confined to.
 #[derive(Debug, Default)]
-pub(crate) struct SelectionSources(RefCell<Vec<SelectionSource>>);
+pub(crate) struct SelectionFrame {
+    sources: RefCell<Vec<SelectionSource>>,
+    regions: RefCell<Vec<Rect>>,
+}
 
-impl SelectionSources {
+impl SelectionFrame {
     pub(crate) fn clear(&self) {
-        self.0.borrow_mut().clear();
+        self.sources.borrow_mut().clear();
+        self.regions.borrow_mut().clear();
     }
 
-    pub(crate) fn push(&self, area: Rect, text: String) {
-        self.0.borrow_mut().push(SelectionSource { area, text });
+    pub(crate) fn push_source(&self, area: Rect, text: String) {
+        self.sources
+            .borrow_mut()
+            .push(SelectionSource { area, text });
     }
 
-    pub(crate) fn snapshot(&self) -> Vec<SelectionSource> {
-        self.0.borrow().clone()
+    /// Record a selectable panel. Regions are pushed parent-before-child, so
+    /// the *last* one containing a cell is the innermost panel there.
+    pub(crate) fn push_region(&self, area: Rect) {
+        self.regions.borrow_mut().push(area);
+    }
+
+    /// Take the frame's text sources, leaving it empty (the next paint clears
+    /// it anyway, so nothing needs a copy).
+    pub(crate) fn take_sources(&self) -> Vec<SelectionSource> {
+        std::mem::take(&mut self.sources.borrow_mut())
+    }
+
+    /// Take the frame's panel regions, leaving it empty.
+    pub(crate) fn take_regions(&self) -> Vec<Rect> {
+        std::mem::take(&mut self.regions.borrow_mut())
     }
 }
 
@@ -169,7 +191,7 @@ pub struct RenderCtx<'a> {
     style_resolver: Option<&'a dyn StyleResolver>,
     /// Graphics protocol and per-frame placement collector supplied by a host.
     image_graphics: Option<(ImageSupport, &'a ImageLayer)>,
-    selection_sources: Option<&'a SelectionSources>,
+    selection: Option<&'a SelectionFrame>,
     /// Whether the focused component of the frame is this one. Containers pass
     /// this down unchanged; focus-aware leaves use it to highlight borders.
     pub focused: bool,
@@ -183,7 +205,7 @@ impl<'a> RenderCtx<'a> {
             sheet: StyleSheet::from_theme(theme),
             style_resolver: None,
             image_graphics: None,
-            selection_sources: None,
+            selection: None,
             focused: false,
         }
     }
@@ -211,14 +233,22 @@ impl<'a> RenderCtx<'a> {
         self
     }
 
-    pub(crate) fn with_selection_sources(mut self, sources: &'a SelectionSources) -> Self {
-        self.selection_sources = Some(sources);
+    pub(crate) fn with_selection(mut self, selection: &'a SelectionFrame) -> Self {
+        self.selection = Some(selection);
         self
     }
 
     pub(crate) fn record_selection_source(&self, area: Rect, source: String) {
-        if let Some(sources) = self.selection_sources {
-            sources.push(area, source);
+        if let Some(selection) = self.selection {
+            selection.push_source(area, source);
+        }
+    }
+
+    /// Mark `area` as a selectable panel: a drag that starts inside it selects
+    /// only within it, instead of streaming across the whole screen.
+    pub(crate) fn record_selection_region(&self, area: Rect) {
+        if let Some(selection) = self.selection {
+            selection.push_region(area);
         }
     }
 
@@ -252,7 +282,7 @@ impl<'a> RenderCtx<'a> {
             sheet: self.sheet,
             style_resolver: self.style_resolver,
             image_graphics: self.image_graphics,
-            selection_sources: self.selection_sources,
+            selection: self.selection,
             focused,
         }
     }

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -478,6 +478,34 @@ fn runner_drag_selection_copies_the_rendered_cells() {
 }
 
 #[test]
+fn runner_drag_selection_stops_at_the_panel_edge() {
+    // Press on `H` inside the bordered panel (zero-based cell (3, 2)), then
+    // drag to the bottom-right corner of an 8x40 screen — past the panel on
+    // both axes, across the footer line outside it. SGR coordinates are
+    // one-based.
+    let drag_out_of_the_panel = b"\x1b[<0;4;3M\x1b[<32;40;8M\x1b[<0;40;8m";
+    let run = Script::new("hello")
+        .arg("--mouse")
+        .size(8, 40)
+        .settle(Duration::from_millis(500))
+        .key(drag_out_of_the_panel, Duration::from_millis(500))
+        .run();
+
+    assert!(run.exited_ok, "hello should exit cleanly after selection");
+    assert!(
+        contains(
+            &run.output,
+            b"\x1b]52;c;SGVsbG8gZnJvbSB0aGUgdGVybWluYWw=\x1b\\"
+        ),
+        "a drag out of the panel copies only the panel's own line"
+    );
+    assert!(
+        !contains(&run.output, b"cSBvciBlc2MgdG8gcXVpdA=="),
+        "the footer outside the panel must never join the selection"
+    );
+}
+
+#[test]
 fn gallery_can_opt_into_mouse_capture_without_leaking_terminal_state() {
     let run = Script::new("gallery")
         .arg("--mouse")


### PR DESCRIPTION
## What changed

Runner-provided drag selection is now **per panel**. A left drag that starts
inside a bordered `Boxed` selects only within that panel: positions clamp to its
inner rect, a multi-row selection wraps at the panel's edges instead of the
screen's, and the OSC 52 copy contains that panel's text — not the border, the
blank rows beside it, or the pane next door. A drag that starts outside every
panel still streams across the whole screen, as before.

`Boxed` records its inner rect as a *selection region* while rendering (bordered
boxes only — a borderless `Boxed` is padding, not a separate surface). The runner
resolves the press cell to the innermost region and confines the whole gesture
there for its lifetime.

**API change (additive, non-breaking).** New public items:

- `mouse::SelectionState::confine(Option<Rect>)` — restrict a gesture to a rect.
- `mouse::SelectionState::region() -> Option<Rect>` — read it back, so a
  custom-loop host can pass the same bounds to `resolve`, `selected_text`, and
  `paint_selection`.

`SelectionState` stays `Copy`; no signature changed and nothing was removed.

Also hardened, since the new region can outlive the geometry it was made in:
`SelectionRange::row_span` now ignores rows outside the `area` it is given, so
`paint_selection` / `selected_text` / `contains` narrow instead of indexing the
buffer out of bounds.

## Why

Reported from a real screen: dragging to copy a line out of the editor pane ran
straight through the metrics and status panels beside it, and the clipboard came
back with box-drawing characters and unrelated text. A panel is the unit a reader
means when they drag; a flat cell grid has thrown that structure away by the time
the selection layer sees it, so the frame has to record it.

## Before / After

Real terminal, `examples/hello --mouse` under a PTY (8×40), pressing on `H`
inside the panel and dragging to the bottom-right corner of the screen. The
decoded OSC 52 payload:

**Before**

```
Hello from the terminal            │
 ╰──────────────────────────────────╯


 q or esc to quit
```

**After**

```
Hello from the terminal
```

That is `tests/pty_smoke.rs::runner_drag_selection_stops_at_the_panel_edge`,
which fails on `main` (asserts the copy is the panel's line, and that the footer
text never joins the payload).

## Risk

- Low
- A host that relied on a drag streaming across panels loses that; the behavior
  only changes inside bordered `Boxed`, and unconfined drags are untouched.
- Regions come from the previously painted frame. A layout change between the
  press and the paint is handled: the region is intersected with the live frame
  area and ranges are clamped to the area they are given, so a stale rect can
  only narrow a selection.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

## Knowledge

`knowledge/specs/architecture.md` — new bullet under the host/runner section: a
drag belongs to the panel it starts in, regions come from the previously painted
frame, and a range is always resolved against the area it is given.
`knowledge/log.md` — entry on render-time regions as how the selection layer
learns structure the cell buffer discarded. `docs/features.md` and `CHANGELOG.md`
updated (the changelog's stale `[Unreleased]` compare link, still at v0.10.0, is
fixed to v0.11.0 in passing).

Validation: `cargo fmt --all -- --check`, `cargo clippy --workspace
--all-targets --all-features -D warnings`, `cargo test --workspace
--all-features`, `cargo run --example demo -- check` (42 scenes in sync),
`python3 scripts/validate_okf.py knowledge --check-links` (0 errors),
`cargo +1.88 check -p tuika --all-targets` (MSRV).

Tests: unit coverage for clamping, a zero-sized region, innermost-region
resolution, and an out-of-area range; runner coverage for a drag from one panel
into another (only the first panel's cells highlight, `"alpha"` copied) and for a
drag outside every panel still spanning the screen; plus the PTY smoke above.

No demo recording was regenerated: no component's appearance changed — selection
is runtime behavior a still recording cannot show. No iai baseline refresh:
neither benched path (`markdown_iai`, `scroll_iai`) renders a `Boxed`, and the
added work is one branch plus a `Vec` push per bordered box on frames that
collect selection metadata.

## Security

Reviewed against the repository's threat model.

- **TM-ESC** — no new escape emission. The OSC 52 path is unchanged and now
  carries strictly less text; nothing caller-supplied reaches the terminal
  unencoded.
- **TM-STATE** — no change to enter/restore of alternate screen, cursor, mouse
  capture, or progress.
- **TM-PARSE** — no parsing changed; regions are rects produced by tuika's own
  layout, never by content.
- **TM-CLIP** — the category this change actually touches. Confinement narrows
  the painted area to a sub-rect of the frame; `confine` rejects zero-sized
  rects, clamping uses saturating arithmetic, the runner intersects a
  previous-frame region with the live frame area, and `row_span` now rejects
  rows outside the area — closing a pre-existing sharp edge where a range from
  stale geometry could index outside the buffer.
- **TM-DEP** — no dependency added.

## Follow-ups

- Only bordered `Boxed` registers a region. Other natural surfaces (a scroll
  viewport, a `SelectList`, a dock pane without a border) still fall through to
  whole-screen selection. Deferred: it needs a decision on whether region
  recording becomes a public opt-in for components outside tuika, which is a
  wider API question than this fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7WVee1dzNJGQRPKrPbcpS)_