### PR TITLE
feat(examples): render in terminals by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,10 +311,11 @@ cells shared across frames, only the moving region duplicated). Handy when VHS
 isn't available, or for a vector asset.
 
 ```bash
-cargo run --example screenshot            # write an SVG (default path)
-cargo run --example screenshot -- out.svg # custom path
-cargo run --example screenshot -- --dump  # print one frame as text
-cargo run --example screenshot -- run     # animate it (what VHS records)
+cargo run --example screenshot                         # animate in a terminal
+cargo run --example screenshot -- out.svg              # write an SVG
+cargo run --example screenshot -- docs/hero.svg        # write the doc asset
+cargo run --example screenshot -- --theme gruvbox-dark # themed terminal
+cargo run --example screenshot -- --dump               # print one frame as text
 ```
 
 ### The check invariant
@@ -389,9 +390,9 @@ and writes an animated SVG. Nothing it produces is committed; use it when
 VHS/ttyd is unavailable, or for the text dump.
 
 ```bash
-cargo build --example split_footer          # the subject, either way
-cargo run --example split_footer_demo       # writes target/split-footer.svg
-cargo run --example split_footer_demo -- --dump   # the frames as text
+cargo run --example split_footer_demo                 # run in a real terminal
+cargo run --example split_footer_demo -- out.svg      # write an SVG
+cargo run --example split_footer_demo -- --dump       # the frames as text
 ```
 
 Being a whole-terminal recording rather than a registry scene, it is outside the
@@ -411,8 +412,9 @@ standalone generated asset, it is outside the registry-based `demo -- check`
 invariant, so it needs no `DEMOS` scene.
 
 ```bash
-cargo run --example image_demo            # writes docs/demos/image.svg
-cargo run --example image_demo -- out.svg # custom path
+cargo run --example image_demo                         # run in a real terminal
+cargo run --example image_demo -- out.svg              # write an SVG
+cargo run --example image_demo -- docs/demos/image.svg # write the doc asset
 ```
 
 ## Cross-terminal checks

--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ rendering; an explicit `Boxed::padding` remains the per-instance override.
 
 Each takes over the terminal — the alternate screen, or a pinned footer for
 [`split_footer`](examples/split_footer.rs); press `q` (or `esc`) to quit.
+Pass `--theme <name>` after Cargo's `--` to run any example with a bundled
+palette, for example `cargo run --example gallery -- --theme gruvbox-dark`.
 
 | Example    | Command                                   | Shows                                              |
 | ---------- | ----------------------------------------- | -------------------------------------------------- |

--- a/crates/tuika-charts/README.md
+++ b/crates/tuika-charts/README.md
@@ -57,6 +57,7 @@ application normally. To try the complete gallery (`q` or `Esc` quits):
 
 ```bash
 cargo run -p tuika-charts --example charts
+cargo run -p tuika-charts --example charts -- --theme gruvbox-dark
 ```
 
 ## Every series, both ways

--- a/crates/tuika-charts/examples/charts.rs
+++ b/crates/tuika-charts/examples/charts.rs
@@ -7,6 +7,8 @@ use tuika::prelude::*;
 use tuika::testing::{grid, render};
 use tuika_charts::{Axis, Chart, Point, Series, Stack};
 
+mod support;
+
 #[derive(Clone, Copy)]
 enum ChartKind {
     Line,
@@ -220,10 +222,10 @@ fn selected_chart() -> Option<ChartKind> {
 }
 
 fn main() -> io::Result<()> {
-    let theme = Theme::default();
+    let (theme, args) = support::theme_and_args()?;
     let isolated = selected_chart();
     let mut gallery = ChartGallery { isolated };
-    if std::env::args().any(|arg| arg == "--dump") {
+    if args.iter().any(|arg| arg == "--dump") {
         println!(
             "{}",
             grid(&render(gallery_view(isolated).as_ref(), 96, 42, &theme))

--- a/crates/tuika-charts/examples/support/mod.rs
+++ b/crates/tuika-charts/examples/support/mod.rs
@@ -1,0 +1,32 @@
+use std::io;
+
+use tuika::Theme;
+
+pub fn theme_and_args() -> io::Result<(Theme, Vec<String>)> {
+    let mut source = std::env::args().skip(1);
+    let mut args = Vec::new();
+    let mut theme = None;
+    while let Some(arg) = source.next() {
+        let name = if arg == "--theme" {
+            Some(source.next().ok_or_else(|| invalid("missing theme name"))?)
+        } else {
+            arg.strip_prefix("--theme=").map(str::to_owned)
+        };
+        if let Some(name) = name {
+            if theme.is_some() {
+                return Err(invalid("--theme may only be supplied once"));
+            }
+            theme = Some(
+                tuika::themes::by_name(&name)
+                    .ok_or_else(|| invalid(&format!("unknown theme {name:?}")))?,
+            );
+        } else {
+            args.push(arg);
+        }
+    }
+    Ok((theme.unwrap_or_default(), args))
+}
+
+fn invalid(detail: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, detail)
+}

--- a/crates/tuika-codeformatters/README.md
+++ b/crates/tuika-codeformatters/README.md
@@ -30,6 +30,7 @@ A runnable, interactive gallery of highlighted snippets across languages
 
 ```bash
 cargo run -p tuika-codeformatters --example languages
+cargo run -p tuika-codeformatters --example languages -- --theme gruvbox-dark
 ```
 
 <img src="https://raw.githubusercontent.com/everruns/tuika/main/crates/tuika-codeformatters/docs/languages.gif" width="880" alt="Syntax highlighting across languages">
@@ -37,6 +38,7 @@ cargo run -p tuika-codeformatters --example languages
 To open a local source file in a scrollable highlighted viewer:
 
 ```bash
+cargo run -p tuika-codeformatters --example highlight_file
 cargo run -p tuika-codeformatters --example highlight_file -- path/to/file.rs
 ```
 

--- a/crates/tuika-codeformatters/examples/highlight_file.rs
+++ b/crates/tuika-codeformatters/examples/highlight_file.rs
@@ -1,6 +1,7 @@
 //! View a source file with tree-sitter syntax highlighting.
 //!
 //! ```text
+//! cargo run -p tuika-codeformatters --example highlight_file
 //! cargo run -p tuika-codeformatters --example highlight_file -- path/to/file.rs
 //! ```
 
@@ -11,6 +12,8 @@ use std::path::{Path, PathBuf};
 
 use tuika::prelude::*;
 use tuika_codeformatters::TreeSitterHighlighter;
+
+mod support;
 
 static HIGHLIGHTER: TreeSitterHighlighter = TreeSitterHighlighter;
 
@@ -152,10 +155,6 @@ fn language_for_path(path: &Path) -> &'static str {
     }
 }
 
-fn input_path() -> io::Result<PathBuf> {
-    input_path_from(std::env::args_os().skip(1))
-}
-
 fn input_path_from(args: impl IntoIterator<Item = OsString>) -> io::Result<PathBuf> {
     let mut args = args.into_iter();
     let Some(path) = args.next() else {
@@ -178,8 +177,14 @@ fn invalid_usage(extra: Option<OsString>) -> io::Error {
 }
 
 fn main() -> io::Result<()> {
-    let mut viewer = FileViewer::open(input_path()?)?;
-    Runner::new(RunnerConfig::default()).run(&Theme::default(), &mut viewer)
+    let (theme, args) = support::theme_and_args()?;
+    let path = if args.is_empty() {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs")
+    } else {
+        input_path_from(args.into_iter().map(OsString::from))?
+    };
+    let mut viewer = FileViewer::open(path)?;
+    Runner::new(RunnerConfig::default()).run(&theme, &mut viewer)
 }
 
 #[cfg(test)]

--- a/crates/tuika-codeformatters/examples/languages.rs
+++ b/crates/tuika-codeformatters/examples/languages.rs
@@ -17,6 +17,8 @@ use ratatui::{Terminal, TerminalOptions, Viewport};
 use tuika::prelude::*;
 use tuika_codeformatters::TreeSitterHighlighter;
 
+mod support;
+
 /// A `'static` highlighter so the borrowed `CodeBlock` can enter the `view!`
 /// DSL (which boxes children into `'static` elements).
 static HL: TreeSitterHighlighter = TreeSitterHighlighter;
@@ -127,6 +129,7 @@ LIMIT 5;
 ];
 
 fn main() -> io::Result<()> {
+    let (theme, _) = support::theme_and_args()?;
     let mut tabs = TabsState::default();
 
     let _session = TerminalSession::enter()?;
@@ -136,8 +139,6 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Fullscreen,
         },
     )?;
-    let theme = Theme::default();
-
     loop {
         terminal.draw(|f| {
             let area = f.area();

--- a/crates/tuika-codeformatters/examples/support/mod.rs
+++ b/crates/tuika-codeformatters/examples/support/mod.rs
@@ -1,0 +1,32 @@
+use std::io;
+
+use tuika::Theme;
+
+pub fn theme_and_args() -> io::Result<(Theme, Vec<String>)> {
+    let mut source = std::env::args().skip(1);
+    let mut args = Vec::new();
+    let mut theme = None;
+    while let Some(arg) = source.next() {
+        let name = if arg == "--theme" {
+            Some(source.next().ok_or_else(|| invalid("missing theme name"))?)
+        } else {
+            arg.strip_prefix("--theme=").map(str::to_owned)
+        };
+        if let Some(name) = name {
+            if theme.is_some() {
+                return Err(invalid("--theme may only be supplied once"));
+            }
+            theme = Some(
+                tuika::themes::by_name(&name)
+                    .ok_or_else(|| invalid(&format!("unknown theme {name:?}")))?,
+            );
+        } else {
+            args.push(arg);
+        }
+    }
+    Ok((theme.unwrap_or_default(), args))
+}
+
+fn invalid(detail: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, detail)
+}

--- a/crates/tuika-html/README.md
+++ b/crates/tuika-html/README.md
@@ -86,4 +86,5 @@ traversal cannot help; the input has to be refused first.
 ```sh
 cargo run -p tuika-html --example html_view       # the `Html` component (q quits)
 cargo run -p tuika-html --example html_markdown   # HTML blocks inside markdown
+cargo run -p tuika-html --example html_view -- --theme gruvbox-dark
 ```

--- a/crates/tuika-html/examples/html_markdown/main.rs
+++ b/crates/tuika-html/examples/html_markdown/main.rs
@@ -14,6 +14,9 @@ use tuika::prelude::*;
 use tuika::testing::{grid, render};
 use tuika_html::HtmlRenderer;
 
+#[path = "../support/mod.rs"]
+mod support;
+
 /// Shared with the demo generator so the recording cannot drift from the app.
 const DOCUMENT: &str = include_str!("document.md");
 
@@ -46,8 +49,8 @@ impl View for Padded {
 }
 
 fn main() -> std::io::Result<()> {
-    let theme = Theme::default();
-    if std::env::args().any(|a| a == "--dump") {
+    let (theme, args) = support::theme_and_args()?;
+    if args.iter().any(|a| a == "--dump") {
         let buffer = render(scene().as_ref(), 76, 22, &theme);
         for line in grid(&buffer).lines() {
             println!("{}", line.trim_end());

--- a/crates/tuika-html/examples/html_view/main.rs
+++ b/crates/tuika-html/examples/html_view/main.rs
@@ -13,6 +13,9 @@ use tuika::prelude::*;
 use tuika::testing::{grid, render};
 use tuika_html::Html;
 
+#[path = "../support/mod.rs"]
+mod support;
+
 /// Shared with the demo generator so the recording cannot drift from the app.
 const PAGE: &str = include_str!("page.html");
 
@@ -30,8 +33,8 @@ fn scene() -> Element {
 }
 
 fn main() -> std::io::Result<()> {
-    let theme = Theme::default();
-    if std::env::args().any(|a| a == "--dump") {
+    let (theme, args) = support::theme_and_args()?;
+    if args.iter().any(|a| a == "--dump") {
         for line in grid(&render(scene().as_ref(), 78, 44, &theme)).lines() {
             println!("{}", line.trim_end());
         }

--- a/crates/tuika-html/examples/support/mod.rs
+++ b/crates/tuika-html/examples/support/mod.rs
@@ -1,0 +1,32 @@
+use std::io;
+
+use tuika::Theme;
+
+pub fn theme_and_args() -> io::Result<(Theme, Vec<String>)> {
+    let mut source = std::env::args().skip(1);
+    let mut args = Vec::new();
+    let mut theme = None;
+    while let Some(arg) = source.next() {
+        let name = if arg == "--theme" {
+            Some(source.next().ok_or_else(|| invalid("missing theme name"))?)
+        } else {
+            arg.strip_prefix("--theme=").map(str::to_owned)
+        };
+        if let Some(name) = name {
+            if theme.is_some() {
+                return Err(invalid("--theme may only be supplied once"));
+            }
+            theme = Some(
+                tuika::themes::by_name(&name)
+                    .ok_or_else(|| invalid(&format!("unknown theme {name:?}")))?,
+            );
+        } else {
+            args.push(arg);
+        }
+    }
+    Ok((theme.unwrap_or_default(), args))
+}
+
+fn invalid(detail: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, detail)
+}

--- a/crates/tuika-mermaid/README.md
+++ b/crates/tuika-mermaid/README.md
@@ -31,4 +31,5 @@ Run the integration example:
 
 ```sh
 cargo run -p tuika-mermaid --example mermaid_markdown
+cargo run -p tuika-mermaid --example mermaid_markdown -- --theme gruvbox-dark
 ```

--- a/crates/tuika-mermaid/examples/mermaid_markdown/main.rs
+++ b/crates/tuika-mermaid/examples/mermaid_markdown/main.rs
@@ -1,7 +1,8 @@
-use tuika::Theme;
-use tuika::components::Markdown;
-use tuika::testing::{grid, render};
+use tuika::prelude::*;
 use tuika_mermaid::MermaidRenderer;
+
+#[path = "../support/mod.rs"]
+mod support;
 
 const DOCUMENT: &str = "\
 # Native Mermaid
@@ -31,15 +32,37 @@ sequenceDiagram
 ```
 ";
 
-fn main() {
-    let theme = Theme::default();
-    let mermaid = MermaidRenderer::new();
-    let document = Markdown::new(DOCUMENT).block_renderer(&mermaid);
-    let buffer = render(&document, 80, 30, &theme);
-    let output = grid(&buffer)
-        .lines()
-        .map(str::trim_end)
-        .collect::<Vec<_>>()
-        .join("\n");
-    println!("{}", output.trim_end());
+struct App {
+    renderer: MermaidRenderer,
+}
+
+impl Application for App {
+    fn update(&mut self, signal: Signal) -> UpdateResult {
+        match signal {
+            Signal::Event(Event::Key(key))
+                if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+            {
+                UpdateResult::Exit
+            }
+            _ => UpdateResult::Clean,
+        }
+    }
+
+    fn view(&self, _frame: u64) -> ScopedElement<'_> {
+        element(Markdown::new(DOCUMENT).block_renderer(&self.renderer))
+    }
+}
+
+fn main() -> std::io::Result<()> {
+    let (theme, args) = support::theme_and_args()?;
+    if !args.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: cargo run -p tuika-mermaid --example mermaid_markdown [-- --theme NAME]",
+        ));
+    }
+    let mut app = App {
+        renderer: MermaidRenderer::new(),
+    };
+    Runner::new(RunnerConfig::default()).run(&theme, &mut app)
 }

--- a/crates/tuika-mermaid/examples/support/mod.rs
+++ b/crates/tuika-mermaid/examples/support/mod.rs
@@ -1,0 +1,32 @@
+use std::io;
+
+use tuika::Theme;
+
+pub fn theme_and_args() -> io::Result<(Theme, Vec<String>)> {
+    let mut source = std::env::args().skip(1);
+    let mut args = Vec::new();
+    let mut theme = None;
+    while let Some(arg) = source.next() {
+        let name = if arg == "--theme" {
+            Some(source.next().ok_or_else(|| invalid("missing theme name"))?)
+        } else {
+            arg.strip_prefix("--theme=").map(str::to_owned)
+        };
+        if let Some(name) = name {
+            if theme.is_some() {
+                return Err(invalid("--theme may only be supplied once"));
+            }
+            theme = Some(
+                tuika::themes::by_name(&name)
+                    .ok_or_else(|| invalid(&format!("unknown theme {name:?}")))?,
+            );
+        } else {
+            args.push(arg);
+        }
+    }
+    Ok((theme.unwrap_or_default(), args))
+}
+
+fn invalid(detail: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, detail)
+}

--- a/docs/charts.md
+++ b/docs/charts.md
@@ -279,4 +279,5 @@ Run the adaptive gallery with `q` or `Esc` to quit:
 
 ```bash
 cargo run -p tuika-charts --example charts
+cargo run -p tuika-charts --example charts -- --theme gruvbox-dark
 ```

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -213,6 +213,7 @@ scripts/gen-styling-demos.sh vivid    # just one
 To preview a variant live in your own terminal:
 
 ```bash
-cargo run --example styling -- run          # cycle the sheets
+cargo run --example styling                 # cycle the sheets
 cargo run --example styling -- run vivid    # hold one
+cargo run --example styling -- --theme light # cycle under another palette
 ```

--- a/examples/async_dashboard.rs
+++ b/examples/async_dashboard.rs
@@ -17,6 +17,8 @@ use ratatui::widgets::{Block, Borders, Row, Sparkline, Table, Widget};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tuika::prelude::*;
 
+mod support;
+
 /// The dashboard's entire state — owned by the run loop, not shared.
 struct Metrics {
     requests: u64,
@@ -92,6 +94,7 @@ fn dashboard(metrics: &Metrics) -> Element {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> std::io::Result<()> {
+    let cli = support::Cli::parse()?;
     let runner = AsyncRunner::new(RunnerConfig {
         tick_rate: Duration::from_millis(500),
         ..RunnerConfig::default()
@@ -111,7 +114,7 @@ async fn main() -> std::io::Result<()> {
 
     runner
         .run_with_messages(
-            &Theme::default(),
+            &cli.theme,
             async_from_fn(
                 &mut metrics,
                 |metrics, _frame| dashboard(metrics),

--- a/examples/borrowed_app.rs
+++ b/examples/borrowed_app.rs
@@ -7,6 +7,8 @@ use std::io;
 
 use tuika::prelude::*;
 
+mod support;
+
 struct CounterApp {
     title: String,
     count: u64,
@@ -56,9 +58,10 @@ impl Application for CounterApp {
 }
 
 fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
     let mut app = CounterApp {
         title: "Borrowed application state".into(),
         count: 0,
     };
-    Runner::new(RunnerConfig::default()).run(&Theme::default(), &mut app)
+    Runner::new(RunnerConfig::default()).run(&cli.theme, &mut app)
 }

--- a/examples/codex/main.rs
+++ b/examples/codex/main.rs
@@ -35,6 +35,8 @@
 mod agent;
 mod app;
 mod history;
+#[path = "../support/mod.rs"]
+mod support;
 mod ui;
 
 use std::io;
@@ -65,19 +67,25 @@ const FOOTER_ROWS: u16 = tuika::screen::DEFAULT_FOOTER_HEIGHT;
 pub const FRAME_MS: u64 = 60;
 
 fn main() -> io::Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cli = support::Cli::parse()?;
+    let args = cli.args;
+    let theme = if cli.theme_name.is_some() {
+        cli.theme
+    } else {
+        app::codex_theme()
+    };
     match args.first().map(String::as_str) {
         Some("--help" | "-h") => {
             println!("A replica of the Codex CLI's interface, built on tuika.");
             println!("Not the Codex CLI; not affiliated with OpenAI. The agent is scripted:");
             println!("no model, no network, no shell.");
             println!();
-            println!("usage: cargo run --example codex [-- --split-footer]");
+            println!("usage: cargo run --example codex [-- --split-footer] [--theme NAME]");
             Ok(())
         }
-        Some("--dump") => ui::dump(args.get(1).map(String::as_str)),
-        Some("--split-footer") => run_split(),
-        _ => run(),
+        Some("--dump") => ui::dump(args.get(1).map(String::as_str), &theme),
+        Some("--split-footer") => run_split(theme),
+        _ => run(theme),
     }
 }
 
@@ -87,9 +95,8 @@ fn main() -> io::Result<()> {
 /// The loop is the full-screen one plus two steps — publish what settled, and
 /// keep the footer pinned — which is the whole difference between the two modes
 /// for a host that drives its own loop.
-fn run_split() -> io::Result<()> {
+fn run_split(theme: Theme) -> io::Result<()> {
     let mut app = App::new();
-    let theme = app::codex_theme();
     let sheet = StyleSheet::from_theme(&theme);
     let probe = RectProbe::new();
     let mode = ScreenMode::split_footer(FOOTER_ROWS);
@@ -159,9 +166,8 @@ fn published(cell: &mut Cell, width: u16, theme: &Theme, sheet: &StyleSheet) -> 
     )
 }
 
-fn run() -> io::Result<()> {
+fn run(theme: Theme) -> io::Result<()> {
     let mut app = App::new();
-    let theme = app::codex_theme();
     let sheet = StyleSheet::from_theme(&theme);
     let probe = RectProbe::new();
 

--- a/examples/codex/ui.rs
+++ b/examples/codex/ui.rs
@@ -242,10 +242,9 @@ fn footer(app: &App, theme: &Theme) -> Element {
 
 /// Render canned frames as text — no terminal, no recorder. Handy for a PR
 /// before/after, and it keeps the example runnable in CI-shaped environments.
-pub fn dump(scene: Option<&str>) -> io::Result<()> {
+pub fn dump(scene: Option<&str>, theme: &Theme) -> io::Result<()> {
     const SCENES: [&str; 6] = ["welcome", "turn", "approval", "slash", "mention", "status"];
-    let theme = crate::app::codex_theme();
-    let sheet = StyleSheet::from_theme(&theme);
+    let sheet = StyleSheet::from_theme(theme);
     let (w, h) = (96u16, 34u16);
 
     for name in SCENES {
@@ -281,8 +280,8 @@ pub fn dump(scene: Option<&str>) -> io::Result<()> {
             _ => {}
         }
         let probe = RectProbe::new();
-        let root = build(&mut app, Rect::new(0, 0, w, h), &theme, &sheet, &probe);
-        let buffer = tuika::testing::render(root.as_ref(), w, h, &theme);
+        let root = build(&mut app, Rect::new(0, 0, w, h), theme, &sheet, &probe);
+        let buffer = tuika::testing::render(root.as_ref(), w, h, theme);
         println!(
             "── {name} {}",
             "─".repeat((w as usize).saturating_sub(4 + name.len()))

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,6 +5,7 @@
 //! generator, and the integrity check.
 //!
 //! ```text
+//! cargo run --example demo                    # spinner in a real terminal
 //! cargo run --example demo -- spinner          # interactive, records a GIF
 //! cargo run --example demo -- list              # list scene names
 //! cargo run --example demo -- check             # verify the docs assets
@@ -33,6 +34,7 @@ use tuika::view::DrawView;
 
 #[path = "demo_scenes/mod.rs"]
 mod demo_scenes;
+mod support;
 use demo_scenes::*;
 
 /// A tiny self-contained Rust highlighter for the `markdown`/`code_block` scenes.
@@ -538,8 +540,9 @@ const DEMOS: &[Demo] = &[
 ];
 
 fn main() -> io::Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let cmd = args.first().map(String::as_str).unwrap_or("list");
+    let cli = support::Cli::parse()?;
+    let args = cli.args;
+    let cmd = args.first().map(String::as_str).unwrap_or("spinner");
 
     match cmd {
         "list" | "--list" | "-h" | "--help" => {
@@ -563,9 +566,9 @@ fn main() -> io::Result<()> {
                 std::process::exit(2);
             };
             if args.iter().any(|a| a == "--dump") {
-                dump(d)
+                dump(d, &cli.theme)
             } else {
-                run(d)
+                run(d, &cli.theme)
             }
         }
     }
@@ -907,10 +910,9 @@ fn framed(name: &str, blurb: &str, body: Element, theme: &Theme) -> Element {
 ///
 /// Uses the scene's recorded geometry, so a dump is a faithful preview of the
 /// GIF: content that would be clipped out of the recording is clipped here too.
-fn dump(d: &Demo) -> io::Result<()> {
-    let theme = Theme::default();
-    let root = framed(d.title, d.blurb, (d.build)(24, &theme), &theme);
-    let buffer = tuika::testing::render(root.as_ref(), RECORD_COLS, d.rows, &theme);
+fn dump(d: &Demo, theme: &Theme) -> io::Result<()> {
+    let root = framed(d.title, d.blurb, (d.build)(24, theme), theme);
+    let buffer = tuika::testing::render(root.as_ref(), RECORD_COLS, d.rows, theme);
     println!("{}", tuika::testing::grid(&buffer));
     Ok(())
 }
@@ -924,7 +926,7 @@ fn dump(d: &Demo) -> io::Result<()> {
 /// up clipped. Pinning makes the registry the authority instead, and the surplus
 /// (the tape asks for a little more room than the scene needs) is painted in the
 /// theme background, so it reads as margin.
-fn run(d: &Demo) -> io::Result<()> {
+fn run(d: &Demo, theme: &Theme) -> io::Result<()> {
     let _session = tuika::TerminalSession::enter()?;
     let mut terminal = Terminal::with_options(
         ratatui::backend::CrosstermBackend::new(io::stdout()),
@@ -932,7 +934,6 @@ fn run(d: &Demo) -> io::Result<()> {
             viewport: RatatuiViewport::Fullscreen,
         },
     )?;
-    let theme = Theme::default();
     let mut frame = 0u64;
     loop {
         terminal.draw(|f| {
@@ -946,8 +947,8 @@ fn run(d: &Demo) -> io::Result<()> {
             };
             f.buffer_mut()
                 .set_style(area, Style::default().bg(theme.background));
-            let root = framed(d.title, d.blurb, (d.build)(frame, &theme), &theme);
-            paint(f.buffer_mut(), scene, &theme, root.as_ref(), &[]);
+            let root = framed(d.title, d.blurb, (d.build)(frame, theme), theme);
+            paint(f.buffer_mut(), scene, theme, root.as_ref(), &[]);
         })?;
         if event::poll(Duration::from_millis(80))?
             && let CtEvent::Key(key) = event::read()?

--- a/examples/gallery.rs
+++ b/examples/gallery.rs
@@ -20,6 +20,8 @@ use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
+
+mod support;
 use tuika::term::hyperlink::HyperlinkBackend;
 
 fn build(frame: u64, theme: &Theme) -> tuika::Element {
@@ -134,7 +136,8 @@ fn build(frame: u64, theme: &Theme) -> tuika::Element {
 }
 
 fn main() -> io::Result<()> {
-    let capture_mouse = std::env::args().any(|argument| argument == "--mouse");
+    let cli = support::Cli::parse()?;
+    let capture_mouse = cli.args.iter().any(|argument| argument == "--mouse");
     let mode = if capture_mouse {
         ScreenMode::Alternate.with_mouse_capture()
     } else {
@@ -148,7 +151,7 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Fullscreen,
         },
     )?;
-    let theme = Theme::default();
+    let theme = cli.theme;
     let mut progress = tuika::term::progress::TerminalProgress::new();
     progress.indeterminate();
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,9 +6,12 @@ use std::io;
 
 use tuika::prelude::*;
 
+mod support;
+
 fn main() -> io::Result<()> {
-    let theme = Theme::default();
-    let capture_mouse = std::env::args().any(|argument| argument == "--mouse");
+    let cli = support::Cli::parse()?;
+    let theme = cli.theme;
+    let capture_mouse = cli.args.iter().any(|argument| argument == "--mouse");
     let screen_mode = if capture_mouse {
         ScreenMode::Alternate.with_mouse_capture()
     } else {

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -12,73 +12,17 @@
 
 use std::io;
 
-use ratatui::style::Style;
-use ratatui::text::Span;
-
-use tuika::prelude::*;
-use tuika::term::image::{ImageData, ImageSupport};
-
-/// A `w × h` RGBA gradient: red rises left-to-right, green top-to-bottom.
-fn gradient(w: u32, h: u32) -> ImageData {
-    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let r = (x * 255 / w.max(1)) as u8;
-            let g = (y * 255 / h.max(1)) as u8;
-            rgba.extend_from_slice(&[r, g, 128, 255]);
-        }
-    }
-    ImageData::from_rgba(w, h, rgba).expect("gradient is well-formed")
-}
+#[path = "support/image_app.rs"]
+mod image_app;
+mod support;
 
 fn main() -> io::Result<()> {
-    // Cell footprint of the on-screen image, and its source pixel resolution.
-    const COLS: u16 = 40;
-    const ROWS: u16 = 20;
-    let data = gradient(320, 320);
-    let support = ImageSupport::detect();
-    let theme = Theme::default();
-    let mut state = ();
-
-    Runner::new(RunnerConfig::default()).run(
-        &theme,
-        from_fn(
-            &mut state,
-            move |_state, _frame| {
-                let image = Image::new(data.clone(), COLS, ROWS).alt("a red/green gradient");
-                let status = match support {
-                    ImageSupport::Kitty => " graphics: Kitty protocol detected ",
-                    ImageSupport::ITerm2 => " graphics: iTerm2 protocol detected ",
-                    ImageSupport::Sixel => " graphics: Sixel protocol detected ",
-                    ImageSupport::None => " graphics: none — showing text fallback ",
-                };
-                let bar = StatusBar::new()
-                    .left(vec![Span::styled(status, theme.selection_style())])
-                    .right(vec![Span::styled(" q quit ", theme.muted_style())])
-                    .background(Style::default().bg(theme.surface));
-                view! {
-                    col(padding = Padding::all(1), gap = 1) {
-                        grow(1) { node(Spacer) }
-                        fixed(ROWS) {
-                            row {
-                                grow(1) { node(Spacer) }
-                                fixed(COLS) { node(image) }
-                                grow(1) { node(Spacer) }
-                            }
-                        }
-                        grow(1) { node(Spacer) }
-                        fixed(1) { node(bar) }
-                    }
-                }
-            },
-            |_state, signal| match signal {
-                Signal::Event(Event::Key(key))
-                    if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
-                {
-                    UpdateResult::Exit
-                }
-                _ => UpdateResult::Clean,
-            },
-        ),
-    )
+    let cli = support::Cli::parse()?;
+    if !cli.args.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: cargo run --example image [-- --theme NAME]",
+        ));
+    }
+    image_app::run(&cli.theme)
 }

--- a/examples/image_demo.rs
+++ b/examples/image_demo.rs
@@ -13,33 +13,40 @@
 //! Regenerate after changing the look:
 //!
 //! ```text
-//! cargo run --example image_demo            # writes docs/demos/image.svg
-//! cargo run --example image_demo -- out.svg # custom path
+//! cargo run --example image_demo                         # real terminal
+//! cargo run --example image_demo -- out.svg              # write SVG
+//! cargo run --example image_demo -- docs/demos/image.svg # write the doc asset
+//! cargo run --example image_demo -- --theme gruvbox-dark # themed terminal
 //! ```
 
 use std::io;
-use std::path::PathBuf;
 
-use tuika::term::image::ImageData;
+use ratatui::style::Color;
+use tuika::Theme;
+
+#[path = "support/image_app.rs"]
+mod image_app;
+mod support;
 
 /// Source resolution of the embedded gradient. Small on purpose — it's a smooth
 /// gradient, so it upscales cleanly and keeps the committed SVG tiny.
 const IMG_W: u32 = 96;
 const IMG_H: u32 = 48;
 
-/// The exact fallback string `Image` paints when graphics aren't supported (see
-/// `Image::render_fallback`), for the alt text used below.
-const ALT: &str = "a red/green gradient";
-
 fn main() -> io::Result<()> {
-    let out = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("docs/demos/image.svg"));
+    let cli = support::Cli::parse()?;
+    let out = match support::Output::parse(&cli.args)? {
+        support::Output::Terminal => return image_app::run(&cli.theme),
+        support::Output::Svg(out) => out,
+    };
 
-    let data = gradient(IMG_W, IMG_H);
-    let png = png_rgba(data.pixel_width(), data.pixel_height(), &rgba(IMG_W, IMG_H));
-    let svg = render_svg(&png);
+    let data = image_app::gradient(IMG_W, IMG_H);
+    let png = png_rgba(
+        data.pixel_width(),
+        data.pixel_height(),
+        &image_app::rgba(IMG_W, IMG_H),
+    );
+    let svg = render_svg(&png, &cli.theme);
 
     if let Some(parent) = out.parent() {
         std::fs::create_dir_all(parent)?;
@@ -52,37 +59,17 @@ fn main() -> io::Result<()> {
     Ok(())
 }
 
-/// The demo image: red rises left→right, green top→bottom, blue constant — the
-/// same gradient as `examples/image.rs`, kept in sync by hand (both are tiny).
-fn rgba(w: u32, h: u32) -> Vec<u8> {
-    let mut buf = Vec::with_capacity((w * h * 4) as usize);
-    for y in 0..h {
-        for x in 0..w {
-            let r = (x * 255 / w.max(1)) as u8;
-            let g = (y * 255 / h.max(1)) as u8;
-            buf.extend_from_slice(&[r, g, 128, 255]);
-        }
-    }
-    buf
-}
-
-/// Build the real [`ImageData`] so the demo is anchored to the component's own
-/// validation and pixel layout, not an ad-hoc buffer.
-fn gradient(w: u32, h: u32) -> ImageData {
-    ImageData::from_rgba(w, h, rgba(w, h)).expect("gradient is well-formed")
-}
-
 // ---- SVG ------------------------------------------------------------------
 
-// Default-theme colors (see `Theme::default`), so the chrome matches yolop's.
-const BG: &str = "#141214";
-const SURFACE: &str = "#221c1e";
-const TEXT: &str = "#ebe6e6";
-const MUTED: &str = "#968c8e";
-const DIM: &str = "#5a4a4e";
-const ACCENT: &str = "#c83c46";
-
-fn render_svg(png: &[u8]) -> String {
+fn render_svg(png: &[u8], theme: &Theme) -> String {
+    let fallback = Theme::default();
+    let palette = SvgPalette {
+        bg: hex(theme.background, fallback.background),
+        surface: hex(theme.surface, fallback.surface),
+        muted: hex(theme.muted, fallback.muted),
+        dim: hex(theme.dim, fallback.dim),
+        accent: hex(theme.accent, fallback.accent),
+    };
     let b64 = base64(png);
     let mut s = String::new();
     s.push_str(
@@ -90,8 +77,8 @@ fn render_svg(png: &[u8]) -> String {
 "#,
     );
     // Two terminal "cards": left shows the rendered image, right the fallback.
-    card(&mut s, 8.0, "Kitty · Ghostty · WezTerm · Konsole");
-    card(&mut s, 448.0, "every other terminal");
+    card(&mut s, 8.0, "Kitty · Ghostty · WezTerm · Konsole", &palette);
+    card(&mut s, 448.0, "every other terminal", &palette);
 
     // Left card content: the actual gradient pixels, then the app's status line.
     s.push_str(&format!(
@@ -99,57 +86,118 @@ fn render_svg(png: &[u8]) -> String {
 <image x="32" y="64" width="368" height="160" preserveAspectRatio="none" clip-path="url(#pic)" href="data:image/png;base64,{b64}"/>
 "#
     ));
-    status(&mut s, 32.0, ACCENT, " graphics: Kitty protocol detected ");
+    status(
+        &mut s,
+        32.0,
+        &palette.accent,
+        " graphics: Kitty protocol detected ",
+        &palette.surface,
+    );
 
     // Right card content: the exact fallback placeholder, centered and dimmed.
     s.push_str(&format!(
-        r#"<text x="656" y="148" text-anchor="middle" font-size="15" font-style="italic" fill="{MUTED}">[image: {ALT}]</text>
+        r#"<text x="656" y="148" text-anchor="middle" font-size="15" font-style="italic" fill="{muted}">[image: {alt}]</text>
 "#
+        , muted = palette.muted, alt = image_app::ALT
     ));
     status(
         &mut s,
         472.0,
-        MUTED,
+        &palette.muted,
         " graphics: none — showing text fallback ",
+        &palette.surface,
     );
 
     s.push_str("</svg>\n");
     s
 }
 
+struct SvgPalette {
+    bg: String,
+    surface: String,
+    muted: String,
+    dim: String,
+    accent: String,
+}
+
 /// A rounded terminal-window card at `x` with three window dots and a `label`.
-fn card(s: &mut String, x: f32, label: &str) {
+fn card(s: &mut String, x: f32, label: &str, palette: &SvgPalette) {
     s.push_str(&format!(
-        r#"<rect x="{x}" y="8" width="424" height="284" rx="12" fill="{BG}" stroke="{DIM}"/>
-<rect x="{x}" y="8" width="424" height="40" rx="12" fill="{SURFACE}"/>
-<rect x="{x}" y="34" width="424" height="14" fill="{SURFACE}"/>
-"#
+        r#"<rect x="{x}" y="8" width="424" height="284" rx="12" fill="{bg}" stroke="{dim}"/>
+<rect x="{x}" y="8" width="424" height="40" rx="12" fill="{surface}"/>
+<rect x="{x}" y="34" width="424" height="14" fill="{surface}"/>
+"#,
+        bg = palette.bg,
+        dim = palette.dim,
+        surface = palette.surface,
     ));
-    for (i, c) in [ACCENT, "#c9a227", "#3fae6b"].iter().enumerate() {
+    for (i, c) in [palette.accent.as_str(), "#c9a227", "#3fae6b"]
+        .iter()
+        .enumerate()
+    {
         let cx = x + 24.0 + i as f32 * 18.0;
         s.push_str(&format!(r#"<circle cx="{cx}" cy="28" r="5" fill="{c}"/>"#));
         s.push('\n');
     }
     let lx = x + 212.0;
     s.push_str(&format!(
-        r#"<text x="{lx}" y="33" text-anchor="middle" font-size="12" fill="{MUTED}">{label}</text>
-"#
+        r#"<text x="{lx}" y="33" text-anchor="middle" font-size="12" fill="{muted}">{label}</text>
+"#,
+        muted = palette.muted,
     ));
 }
 
 /// The app's status bar line at the bottom of a card, starting at `x`.
-fn status(s: &mut String, x: f32, fg: &str, text: &str) {
+fn status(s: &mut String, x: f32, fg: &str, text: &str, surface: &str) {
     let y = 268.0;
     s.push_str(&format!(
-        r#"<rect x="{x}" y="{}" width="376" height="22" rx="4" fill="{SURFACE}"/>
+        r#"<rect x="{x}" y="{}" width="376" height="22" rx="4" fill="{surface}"/>
 <text x="{}" y="{}" font-size="12" fill="{fg}">{text}</text>
 "#,
         y - 15.0,
         x + 8.0,
         y - 0.0
     ));
-    // Keep TEXT referenced so the palette stays complete for future edits.
-    let _ = TEXT;
+}
+
+fn hex(color: Color, fallback: Color) -> String {
+    match color {
+        Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+        Color::Indexed(index) => indexed_hex(index),
+        Color::Reset => hex(fallback, Color::Black),
+        Color::Black => "#000000".to_owned(),
+        Color::Red | Color::LightRed => "#f14c4c".to_owned(),
+        Color::Green | Color::LightGreen => "#23d18b".to_owned(),
+        Color::Yellow | Color::LightYellow => "#f5f543".to_owned(),
+        Color::Blue | Color::LightBlue => "#3b8eea".to_owned(),
+        Color::Magenta | Color::LightMagenta => "#d670d6".to_owned(),
+        Color::Cyan | Color::LightCyan => "#29b8db".to_owned(),
+        Color::Gray | Color::DarkGray | Color::White => "#e5e5e5".to_owned(),
+    }
+}
+
+fn indexed_hex(index: u8) -> String {
+    const BASE: [&str; 16] = [
+        "#000000", "#cd3131", "#0dbc79", "#e5e510", "#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
+        "#666666", "#f14c4c", "#23d18b", "#f5f543", "#3b8eea", "#d670d6", "#29b8db", "#ffffff",
+    ];
+    match index {
+        0..=15 => BASE[index as usize].to_owned(),
+        16..=231 => {
+            const LEVELS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+            let n = index - 16;
+            format!(
+                "#{:02x}{:02x}{:02x}",
+                LEVELS[(n / 36) as usize],
+                LEVELS[((n % 36) / 6) as usize],
+                LEVELS[(n % 6) as usize]
+            )
+        }
+        _ => {
+            let value = 8 + 10 * (index - 232);
+            format!("#{value:02x}{value:02x}{value:02x}")
+        }
+    }
 }
 
 // ---- Minimal PNG (RFC 2083) + base64, dependency-free ---------------------

--- a/examples/inherit.rs
+++ b/examples/inherit.rs
@@ -37,6 +37,8 @@ use tuika::{
     view,
 };
 
+mod support;
+
 /// How long to wait for the terminal to answer. A real tty replies to the
 /// Device Attributes fence immediately, so this is only reached on a terminal
 /// that ignores the query entirely.
@@ -49,6 +51,8 @@ enum Source {
     Probed,
     /// The terminal said nothing, so the ANSI-slot theme inherits implicitly.
     AnsiSlots,
+    /// A bundled palette was selected explicitly for the shared example CLI.
+    Named,
 }
 
 impl Source {
@@ -56,6 +60,7 @@ impl Source {
         match self {
             Source::Probed => "probed — derived from the colors this terminal reported",
             Source::AnsiSlots => "themes::TERMINAL — the terminal answered nothing, ANSI slots",
+            Source::Named => "bundled theme selected with --theme",
         }
     }
 }
@@ -148,8 +153,13 @@ fn build(theme: &Theme, source: Source) -> tuika::Element {
 }
 
 fn main() -> io::Result<()> {
-    let probe_only = std::env::args().any(|a| a == "--probe");
-    let (theme, source) = probe()?;
+    let cli = support::Cli::parse()?;
+    let probe_only = cli.args.iter().any(|a| a == "--probe");
+    let (theme, source) = if cli.theme_name.is_some() {
+        (cli.theme, Source::Named)
+    } else {
+        probe()?
+    };
 
     if probe_only {
         // Plain text, no alternate screen: usable over a pipe and in a test.

--- a/examples/keyed_table.rs
+++ b/examples/keyed_table.rs
@@ -12,6 +12,8 @@ use ratatui::backend::CrosstermBackend;
 use ratatui_core::terminal::Terminal;
 use tuika::prelude::*;
 
+mod support;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum Agent {
     Claude,
@@ -214,7 +216,8 @@ fn summary_line<'a>(summary: &'a str, positions: &[usize]) -> Line<'a> {
 }
 
 fn main() -> io::Result<()> {
-    let theme = Theme::default();
+    let cli = support::Cli::parse()?;
+    let theme = cli.theme;
     let _session = TerminalSession::enter_with(ScreenMode::Alternate.with_mouse_capture())?;
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
     let mut app = App::new();

--- a/examples/markdown.rs
+++ b/examples/markdown.rs
@@ -39,6 +39,8 @@ use ratatui::text::Span;
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
+
+mod support;
 use tuika::term::hyperlink::{HyperlinkBackend, LinkPolicy, apply_buffer_links};
 
 /// A tiny self-contained Rust highlighter — enough to satisfy the
@@ -171,6 +173,7 @@ fn main() {
 ";
 
 fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
     let highlighter = DemoHighlighter;
     let doc: Vec<char> = SOURCE.chars().collect();
 
@@ -179,7 +182,7 @@ fn main() -> io::Result<()> {
     let mut cursor = 0usize;
     let mut paused = false;
 
-    let capture_mouse = std::env::args().any(|argument| argument == "--mouse");
+    let capture_mouse = cli.args.iter().any(|argument| argument == "--mouse");
     let mode = if capture_mouse {
         ScreenMode::Alternate.with_mouse_capture()
     } else {
@@ -192,7 +195,7 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Fullscreen,
         },
     )?;
-    let theme = Theme::default();
+    let theme = cli.theme;
     let sheet = tuika::StyleSheet::from_theme(&theme);
 
     loop {

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -28,6 +28,8 @@ use ratatui::{Terminal, TerminalOptions, Viewport};
 use tuika::host::AltScreen;
 use tuika::mouse::{ClickTracker, HitMap, SelectionState, paint_selection, selected_text};
 use tuika::prelude::*;
+
+mod support;
 use tuika::term::clipboard;
 
 const SAMPLE: &[&str] = &[
@@ -44,6 +46,7 @@ enum Btn {
 }
 
 fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
     enable_raw_mode()?;
     let mut alt = AltScreen::enter_with_mouse_capture()?;
     let mut term = Terminal::with_options(
@@ -52,7 +55,7 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Fullscreen,
         },
     )?;
-    let theme = Theme::default();
+    let theme = cli.theme;
     let mut sel = SelectionState::new();
     let mut clicks = ClickTracker::new();
     let mut status = String::from("drag to select · click a button · q to quit");

--- a/examples/overlay.rs
+++ b/examples/overlay.rs
@@ -15,9 +15,12 @@ use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
+
+mod support;
 use tuika::probe::RectProbe;
 
 fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
     let mut open = false;
     let mut confirmed = 0u32;
     let trigger = RectProbe::new();
@@ -29,7 +32,7 @@ fn main() -> io::Result<()> {
             viewport: Viewport::Fullscreen,
         },
     )?;
-    let theme = Theme::default();
+    let theme = cli.theme;
 
     loop {
         terminal.draw(|f| {

--- a/examples/primitives.rs
+++ b/examples/primitives.rs
@@ -2,11 +2,19 @@
 
 use ratatui_core::layout::Rect;
 use tuika::prelude::*;
-use tuika::testing::{grid, render};
 use tuika::view::DrawView;
 
-fn main() {
-    let theme = Theme::default();
+mod support;
+
+fn main() -> std::io::Result<()> {
+    let cli = support::Cli::parse()?;
+    if !cli.args.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: cargo run --example primitives [-- --theme NAME]",
+        ));
+    }
+    let theme = cli.theme;
     let scroll = ScrollState::default();
     let form_state = FormState::default();
 
@@ -42,5 +50,14 @@ fn main() {
             .focus_owner("example-form"),
     );
 
-    println!("{}", grid(&render(&scene, 48, 16, &theme)));
+    write_once(
+        &mut std::io::stdout(),
+        &scene,
+        &theme,
+        OneShotOptions {
+            width: 48,
+            max_height: 16,
+            ..OneShotOptions::default()
+        },
+    )
 }

--- a/examples/ratatui_dashboard.rs
+++ b/examples/ratatui_dashboard.rs
@@ -14,6 +14,8 @@ use ratatui::text::Line;
 use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders, Row, Sparkline, Table, Widget};
 use tuika::prelude::*;
 
+mod support;
+
 #[derive(Clone)]
 struct Metrics {
     requests: u64,
@@ -86,6 +88,7 @@ fn dashboard(metrics: &Metrics) -> Element {
 }
 
 fn main() -> std::io::Result<()> {
+    let cli = support::Cli::parse()?;
     let runner = Runner::new(RunnerConfig::default());
     let metrics = Live::with_redraw(
         Metrics {
@@ -115,7 +118,7 @@ fn main() -> std::io::Result<()> {
 
     let live_view = metrics.clone();
     let result = runner.run(
-        &Theme::default(),
+        &cli.theme,
         from_fn(
             &mut (),
             move |(), _frame| element(LiveView::new(live_view.clone(), dashboard)),

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -7,10 +7,11 @@
 //! component's look changes:
 //!
 //! ```text
-//! cargo run --example screenshot            # writes docs/hero.svg
-//! cargo run --example screenshot -- out.svg # custom path
-//! cargo run --example screenshot -- run     # animate it in a real terminal
-//! cargo run --example screenshot -- run gruvbox-dark  # …in a bundled theme
+//! cargo run --example screenshot                         # real terminal
+//! cargo run --example screenshot -- out.svg              # write SVG
+//! cargo run --example screenshot -- docs/hero.svg        # write the doc asset
+//! cargo run --example screenshot -- --theme gruvbox-dark # themed terminal
+//! cargo run --example screenshot -- out.svg --theme light # themed SVG
 //! cargo run --example screenshot -- bg gruvbox-dark   # print its background hex
 //! ```
 //!
@@ -21,15 +22,13 @@
 //! a commit message typing); cells that never change are emitted once in a static
 //! base layer, so only the moving region is duplicated per frame.
 //!
-//! The `run` subcommand animates the same `scene()` in the alternate screen so a
-//! terminal recorder (VHS) can capture it as a GIF — that is how `docs/hero.gif`
-//! is produced (see `scripts/gen-hero.sh`). SVG and GIF therefore share one
-//! source of truth. `run <theme>` animates a bundled palette instead of the
-//! default, which is how the per-theme demos in `docs/themes.md` are recorded
-//! (see `scripts/gen-theme-demos.sh`).
+//! With no output path, the example animates the same `scene()` in the alternate
+//! screen so a terminal recorder (VHS) can capture it as a GIF — that is how
+//! `docs/hero.gif` is produced (see `scripts/gen-hero.sh`). SVG and GIF therefore
+//! share one source of truth. `--theme <name>` applies a bundled palette to
+//! either form, which is how the per-theme demos in `docs/themes.md` are made.
 
 use std::io;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use crossterm::event::{self, Event as CtEvent, KeyCode as CtKeyCode, KeyEventKind};
@@ -39,6 +38,8 @@ use ratatui::text::{Line, Span};
 use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
+
+mod support;
 
 /// Grid size (character cells). Chosen to give the gallery room to breathe while
 /// staying a comfortable README width.
@@ -50,10 +51,28 @@ const ROWS: u16 = 28;
 const FRAMES: usize = 16;
 
 fn main() -> io::Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let theme = Theme::default();
+    let cli = support::Cli::parse()?;
+    let args = &cli.args;
+    let theme = cli.theme;
+
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+    {
+        println!(
+            "usage: cargo run --example screenshot [-- [OUTPUT.svg] [--theme NAME]]\n\
+             no OUTPUT renders in the terminal; an OUTPUT path writes SVG"
+        );
+        return Ok(());
+    }
 
     if args.iter().any(|a| a == "--dump") {
+        if args.len() != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "--dump cannot be combined with an output path",
+            ));
+        }
         // One representative frame, as text, for a quick sanity check.
         let buffer = render_frame(6, &theme);
         println!("{}", tuika::testing::grid(&buffer));
@@ -61,37 +80,37 @@ fn main() -> io::Result<()> {
     }
 
     if args.first().map(String::as_str) == Some("run") {
-        // Animate the scene in a real terminal so a recorder can capture it.
-        // An optional theme name (`run gruvbox-dark`) animates that palette; the
-        // per-theme GIFs are recorded this way.
-        let scene_theme = args
-            .get(1)
-            .and_then(|name| tuika::themes::by_name(name))
-            .unwrap_or(theme);
+        if args.len() > 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "legacy `run` accepts at most one theme name",
+            ));
+        }
+        // Compatibility for the recorder scripts from before terminal rendering
+        // became the default. `run <theme>` remains accepted as well.
+        let scene_theme = legacy_theme(args.get(1), theme)?;
         return run_interactive(&scene_theme);
     }
 
     if args.first().map(String::as_str) == Some("bg") {
+        if args.len() > 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "`bg` accepts at most one theme name",
+            ));
+        }
         // Print a theme's background as `#rrggbb` so the GIF recorder can blend
         // VHS's window padding into the app background. Defaults to the toolkit
-        // theme when the name is unknown.
-        let t = args
-            .get(1)
-            .and_then(|n| tuika::themes::by_name(n))
-            .unwrap_or(theme);
+        // theme when no legacy positional name is supplied.
+        let t = legacy_theme(args.get(1), theme)?;
         println!("{}", hex(t.background));
         return Ok(());
     }
 
-    let out = args
-        .iter()
-        .find(|a| !a.starts_with("--"))
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("docs")
-                .join("hero.svg")
-        });
+    let out = match support::Output::parse(args)? {
+        support::Output::Terminal => return run_interactive(&theme),
+        support::Output::Svg(out) => out,
+    };
 
     let frames: Vec<Buffer> = (0..FRAMES)
         .map(|i| render_frame(i as u64, &theme))
@@ -110,6 +129,18 @@ fn main() -> io::Result<()> {
         svg.len()
     );
     Ok(())
+}
+
+fn legacy_theme(name: Option<&String>, fallback: Theme) -> io::Result<Theme> {
+    match name {
+        Some(name) => tuika::themes::by_name(name).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unknown theme {name:?}"),
+            )
+        }),
+        None => Ok(fallback),
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -14,6 +14,8 @@ use std::io;
 
 use tuika::prelude::*;
 
+mod support;
+
 const ITEMS: [&str; 7] = [
     "Build release",
     "Run test suite",
@@ -114,7 +116,8 @@ fn update(state: &mut PickerState, event: &Event) -> UpdateResult {
 }
 
 fn main() -> io::Result<()> {
-    let theme = Theme::default();
+    let cli = support::Cli::parse()?;
+    let theme = cli.theme;
     let runner = Runner::new(RunnerConfig {
         screen_mode: ScreenMode::Alternate.with_mouse_capture(),
         ..RunnerConfig::default()

--- a/examples/selection_screen.rs
+++ b/examples/selection_screen.rs
@@ -8,6 +8,8 @@ use std::io;
 
 use tuika::prelude::*;
 
+mod support;
+
 fn hints() -> KeyHints {
     KeyHints::new([("↑/↓", "move"), ("enter", "select"), ("esc", "cancel")])
 }
@@ -35,6 +37,7 @@ fn after<'rows>(rows: &'rows [Line<'static>], state: &SelectState) -> SelectionS
 }
 
 fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
     let rows = [
         Line::from("Run command"),
         Line::from("Delegate to agent"),
@@ -47,7 +50,7 @@ fn main() -> io::Result<()> {
     write_once(
         &mut io::stdout(),
         &after(&rows, &state),
-        &Theme::default(),
+        &cli.theme,
         OneShotOptions {
             width: 54,
             max_height: 9,

--- a/examples/split_footer.rs
+++ b/examples/split_footer.rs
@@ -23,6 +23,8 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use tuika::prelude::*;
 
+mod support;
+
 /// Rows the footer reserves. Everything above is the terminal's.
 const FOOTER_ROWS: u16 = 5;
 
@@ -89,9 +91,16 @@ fn publish(scrollback: &Scrollback, seq: u64, theme: &Theme) {
 }
 
 fn main() -> std::io::Result<()> {
+    let cli = support::Cli::parse()?;
     // Opt-in mouse capture: off by default so the terminal keeps the wheel and
     // drag-selection over the scrollback this mode preserves.
-    let capture_mouse = std::env::args().any(|arg| arg == "--mouse");
+    let capture_mouse = cli.args.iter().any(|arg| arg == "--mouse");
+    if cli.args.iter().any(|arg| arg != "--mouse") {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: cargo run --example split_footer [-- --mouse] [--theme NAME]",
+        ));
+    }
     let mode = ScreenMode::split_footer(FOOTER_ROWS);
     let mode = if capture_mouse {
         mode.with_mouse_capture()
@@ -99,7 +108,7 @@ fn main() -> std::io::Result<()> {
         mode
     };
 
-    let theme = Theme::default();
+    let theme = cli.theme;
     let runner = Runner::new(RunnerConfig {
         tick_rate: Duration::from_millis(80),
         screen_mode: mode,

--- a/examples/split_footer_demo.rs
+++ b/examples/split_footer_demo.rs
@@ -25,13 +25,14 @@
 //! recording toolchain is unavailable or when a vector asset is wanted.
 //!
 //! ```text
-//! cargo build --example split_footer          # the subject, either way
-//! cargo run --example split_footer_demo       # writes target/split-footer.svg
-//! cargo run --example split_footer_demo -- out.svg
+//! cargo run --example split_footer_demo                         # real terminal
+//! cargo run --example split_footer_demo -- out.svg              # write SVG
+//! cargo run --example split_footer_demo -- --theme gruvbox-dark # themed terminal
 //! ```
 
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
+use std::process::Command;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -39,6 +40,8 @@ use std::time::Duration;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use ratatui::style::Color;
 use tuika::prelude::Theme;
+
+mod support;
 
 /// Recorded grid. Wide enough for the footer's key hints, tall enough to show
 /// several published blocks plus the shell line that started the session.
@@ -53,13 +56,26 @@ const SAMPLES: usize = 5;
 const SETTLE: Duration = Duration::from_millis(500);
 
 fn main() -> io::Result<()> {
-    let arg = std::env::args().nth(1);
-    let dump = arg.as_deref() == Some("--dump");
-    let out = arg.filter(|_| !dump).map(PathBuf::from).unwrap_or_else(|| {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/split-footer.svg")
-    });
+    let cli = support::Cli::parse()?;
+    let dump = cli.args.iter().any(|arg| arg == "--dump");
+    let args = cli
+        .args
+        .iter()
+        .filter(|arg| arg.as_str() != "--dump")
+        .cloned()
+        .collect::<Vec<_>>();
+    if dump && !args.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--dump cannot be combined with an output path",
+        ));
+    }
+    let output = support::Output::parse(&args)?;
+    if !dump && output == support::Output::Terminal {
+        return run_interactive(cli.theme_name.as_deref());
+    }
 
-    let frames = record()?;
+    let frames = record(&cli.theme, cli.theme_name.as_deref())?;
     if dump {
         // What the recorder saw as text, for checking the generated asset.
         for (i, frame) in frames.iter().enumerate() {
@@ -71,7 +87,10 @@ fn main() -> io::Result<()> {
         }
         return Ok(());
     }
-    let svg = render_svg(&frames);
+    let support::Output::Svg(out) = output else {
+        unreachable!("non-dump terminal mode returned before recording")
+    };
+    let svg = render_svg(&frames, &cli.theme);
     if let Some(dir) = out.parent() {
         std::fs::create_dir_all(dir)?;
     }
@@ -83,6 +102,21 @@ fn main() -> io::Result<()> {
         svg.len() as f32 / 1024.0
     );
     Ok(())
+}
+
+fn run_interactive(theme_name: Option<&str>) -> io::Result<()> {
+    let mut command = Command::new(example_bin()?);
+    if let Some(name) = theme_name {
+        command.args(["--theme", name]);
+    }
+    let status = command.status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "split_footer exited with {status}"
+        )))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -99,16 +133,21 @@ fn example_bin() -> io::Result<PathBuf> {
         .map(|dir| dir.join("split_footer"))
         .unwrap_or_default();
     if !bin.is_file() {
-        return Err(io::Error::other(format!(
-            "the `split_footer` example is not built at {} — run \
-             `cargo build --example split_footer` first",
-            bin.display()
-        )));
+        let status = Command::new(env!("CARGO"))
+            .args(["build", "--example", "split_footer"])
+            .current_dir(env!("CARGO_MANIFEST_DIR"))
+            .status()?;
+        if !status.success() || !bin.is_file() {
+            return Err(io::Error::other(format!(
+                "could not build the `split_footer` example at {}",
+                bin.display()
+            )));
+        }
     }
     Ok(bin)
 }
 
-fn record() -> io::Result<Vec<Frame>> {
+fn record(theme: &Theme, theme_name: Option<&str>) -> io::Result<Vec<Frame>> {
     let bin = example_bin()?;
     let pty = NativePtySystem::default();
     let pair = pty
@@ -125,18 +164,25 @@ fn record() -> io::Result<Vec<Frame>> {
     let mut cmd = CommandBuilder::new("/bin/sh");
     // The prompt's own color comes from the theme too, so the one line the
     // shell contributes does not sit outside the palette of everything below it.
-    let prompt = match Theme::default().accent_alt {
+    let prompt = match theme.accent_alt {
         Color::Rgb(r, g, b) => format!("\x1b[38;2;{r};{g};{b}m"),
         _ => String::new(),
     };
+    let theme_suffix = theme_name
+        .map(|name| format!(" --theme {name}"))
+        .unwrap_or_default();
     cmd.args([
         "-c",
         &format!(
-            "printf '{prompt}~/src/tuika\\033[0m $ cargo run --example split_footer\\n'; \
-             exec {}",
-            bin.display()
+            "printf '{prompt}~/src/tuika\\033[0m $ cargo run --example split_footer{theme_suffix}\\n'; \
+             exec \"$@\""
         ),
+        "split-footer-demo",
     ]);
+    cmd.arg(&bin);
+    if let Some(name) = theme_name {
+        cmd.args(["--theme", name]);
+    }
     cmd.env("TERM", "xterm-256color");
     let mut child = pair.slave.spawn_command(cmd).map_err(io::Error::other)?;
     drop(pair.slave);
@@ -172,7 +218,7 @@ fn record() -> io::Result<Vec<Frame>> {
 
     let sample = || -> Frame {
         let parser = parser.lock().expect("lock parser");
-        capture(parser.screen())
+        capture(parser.screen(), theme)
     };
 
     thread::sleep(SETTLE);
@@ -199,13 +245,13 @@ fn record() -> io::Result<Vec<Frame>> {
 }
 
 /// Resolve every cell of `screen` into what the SVG paints.
-fn capture(screen: &vt100::Screen) -> Frame {
+fn capture(screen: &vt100::Screen, theme: &Theme) -> Frame {
     let mut frame = Vec::with_capacity(COLS as usize * ROWS as usize);
     for row in 0..ROWS {
         for col in 0..COLS {
             frame.push(match screen.cell(row, col) {
-                Some(cell) => Paint::of(cell),
-                None => Paint::blank(),
+                Some(cell) => Paint::of(cell, theme),
+                None => Paint::blank(theme),
             });
         }
     }
@@ -230,19 +276,14 @@ const SCREEN_MARGIN: f32 = 14.0;
 const GRID_PAD: f32 = 12.0;
 const TITLE_BAR: f32 = 40.0;
 
-/// The session's palette is `Theme::default()` — tuika's own identity, and the
-/// palette every other generated asset in `docs/` is captured against (the VHS
-/// generators pass the same pair as `Set Theme`). Deriving it here instead of
-/// hand-picking a second one keeps this asset from reading as a different
-/// product beside the rest of the gallery: `background`/`text` are what the
-/// terminal paints a default-colored cell with, `surface`/`border`/`muted` are
-/// the window chrome around it.
-fn term_bg() -> String {
-    hex(Theme::default().background)
+/// Derive the terminal defaults and window chrome from the selected theme so
+/// the real-terminal and SVG paths are the same scene in the same palette.
+fn term_bg(theme: &Theme) -> String {
+    hex(theme.background)
 }
 
-fn term_fg() -> String {
-    hex(Theme::default().text)
+fn term_fg(theme: &Theme) -> String {
+    hex(theme.text)
 }
 
 /// The fully resolved appearance of one cell in one frame.
@@ -274,10 +315,10 @@ impl Paint {
             && self.underline == other.underline
     }
 
-    fn blank() -> Self {
+    fn blank(theme: &Theme) -> Self {
         Self {
             sym: String::new(),
-            fg: term_fg(),
+            fg: term_fg(theme),
             bg: None,
             bold: false,
             dim: false,
@@ -286,7 +327,7 @@ impl Paint {
         }
     }
 
-    fn of(cell: &vt100::Cell) -> Self {
+    fn of(cell: &vt100::Cell, theme: &Theme) -> Self {
         let raw_fg = color_hex(cell.fgcolor());
         let raw_bg = color_hex(cell.bgcolor());
         // Reverse video swaps the pair, defaulting each side to the terminal's
@@ -294,11 +335,11 @@ impl Paint {
         // would paint invisible text.
         let (fg, bg) = if cell.inverse() {
             (
-                raw_bg.unwrap_or_else(term_bg),
-                Some(raw_fg.unwrap_or_else(term_fg)),
+                raw_bg.unwrap_or_else(|| term_bg(theme)),
+                Some(raw_fg.unwrap_or_else(|| term_fg(theme))),
             )
         } else {
-            (raw_fg.unwrap_or_else(term_fg), raw_bg)
+            (raw_fg.unwrap_or_else(|| term_fg(theme)), raw_bg)
         };
         Self {
             sym: cell.contents().to_string(),
@@ -312,7 +353,7 @@ impl Paint {
     }
 }
 
-fn render_svg(frames: &[Frame]) -> String {
+fn render_svg(frames: &[Frame], theme: &Theme) -> String {
     let cols = COLS as usize;
     let rows = ROWS as usize;
     let grid_w = COLS as f32 * CELL_W;
@@ -401,7 +442,6 @@ the program exits.\">\n"
 <feDropShadow dx=\"0\" dy=\"10\" stdDeviation=\"16\" flood-color=\"#000\" flood-opacity=\"0.45\"/>\
 </filter></defs>\n",
     );
-    let theme = Theme::default();
     s.push_str(&format!(
         "<rect x=\"{m:.1}\" y=\"{m:.1}\" width=\"{w:.1}\" height=\"{h:.1}\" rx=\"12\" \
 fill=\"{chrome}\" stroke=\"{stroke}\" stroke-width=\"1\" filter=\"url(#sh)\"/>\n",
@@ -428,7 +468,7 @@ fill=\"{muted}\">tuika · split-footer screen mode</text>\n",
     s.push_str(&format!(
         "<rect x=\"{x:.1}\" y=\"{y:.1}\" width=\"{w:.1}\" height=\"{h:.1}\" rx=\"6\" \
 fill=\"{bg}\"/>\n",
-        bg = term_bg(),
+        bg = term_bg(theme),
         x = SCREEN_MARGIN,
         y = TITLE_BAR,
         w = screen_w,

--- a/examples/styling.rs
+++ b/examples/styling.rs
@@ -29,6 +29,8 @@ use ratatui::{Terminal, TerminalOptions, Viewport};
 
 use tuika::prelude::*;
 
+mod support;
+
 /// Grid size (character cells).
 const COLS: u16 = 82;
 const ROWS: u16 = 26;
@@ -95,8 +97,9 @@ fn variants(theme: &Theme) -> Vec<(&'static str, StyleSheet)> {
 }
 
 fn main() -> io::Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let theme = Theme::default();
+    let cli = support::Cli::parse()?;
+    let args = cli.args;
+    let theme = cli.theme;
 
     if args.first().map(String::as_str) == Some("bg") {
         // The theme background as `#rrggbb`, so a GIF recorder can blend its
@@ -114,14 +117,20 @@ fn main() -> io::Result<()> {
         return Ok(());
     }
 
+    if args.is_empty() {
+        return run_interactive(&theme, None);
+    }
+
     if args.first().map(String::as_str) == Some("run") {
         // A fixed variant name holds one sheet; otherwise the scene cycles.
         let held = args.get(1).cloned();
         return run_interactive(&theme, held.as_deref());
     }
 
-    eprintln!("usage: styling (run [variant] | bg)\nvariants: default, vivid, mono");
-    Ok(())
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "usage: styling [run [variant] | bg] [--theme NAME]\nvariants: default, vivid, mono",
+    ))
 }
 
 /// The sheet named `name` (falling back to `default`), with its label.

--- a/examples/support/image_app.rs
+++ b/examples/support/image_app.rs
@@ -1,0 +1,76 @@
+use std::io;
+
+use ratatui::style::Style;
+use ratatui::text::Span;
+use tuika::prelude::*;
+use tuika::term::image::{ImageData, ImageSupport};
+
+pub const ALT: &str = "a red/green gradient";
+
+pub fn rgba(w: u32, h: u32) -> Vec<u8> {
+    let mut rgba = Vec::with_capacity((w * h * 4) as usize);
+    for y in 0..h {
+        for x in 0..w {
+            let r = (x * 255 / w.max(1)) as u8;
+            let g = (y * 255 / h.max(1)) as u8;
+            rgba.extend_from_slice(&[r, g, 128, 255]);
+        }
+    }
+    rgba
+}
+
+pub fn gradient(w: u32, h: u32) -> ImageData {
+    ImageData::from_rgba(w, h, rgba(w, h)).expect("gradient is well-formed")
+}
+
+pub fn run(theme: &Theme) -> io::Result<()> {
+    const COLS: u16 = 40;
+    const ROWS: u16 = 20;
+
+    let data = gradient(320, 320);
+    let support = ImageSupport::detect();
+    let theme = *theme;
+    let mut state = ();
+
+    Runner::new(RunnerConfig::default()).run(
+        &theme,
+        from_fn(
+            &mut state,
+            move |_state, _frame| {
+                let image = Image::new(data.clone(), COLS, ROWS).alt(ALT);
+                let status = match support {
+                    ImageSupport::Kitty => " graphics: Kitty protocol detected ",
+                    ImageSupport::ITerm2 => " graphics: iTerm2 protocol detected ",
+                    ImageSupport::Sixel => " graphics: Sixel protocol detected ",
+                    ImageSupport::None => " graphics: none — showing text fallback ",
+                };
+                let bar = StatusBar::new()
+                    .left(vec![Span::styled(status, theme.selection_style())])
+                    .right(vec![Span::styled(" q quit ", theme.muted_style())])
+                    .background(Style::default().bg(theme.surface));
+                view! {
+                    col(padding = Padding::all(1), gap = 1) {
+                        grow(1) { node(Spacer) }
+                        fixed(ROWS) {
+                            row {
+                                grow(1) { node(Spacer) }
+                                fixed(COLS) { node(image) }
+                                grow(1) { node(Spacer) }
+                            }
+                        }
+                        grow(1) { node(Spacer) }
+                        fixed(1) { node(bar) }
+                    }
+                }
+            },
+            |_state, signal| match signal {
+                Signal::Event(Event::Key(key))
+                    if key.plain() && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc) =>
+                {
+                    UpdateResult::Exit
+                }
+                _ => UpdateResult::Clean,
+            },
+        ),
+    )
+}

--- a/examples/support/mod.rs
+++ b/examples/support/mod.rs
@@ -1,0 +1,89 @@
+use std::io;
+use std::path::PathBuf;
+
+use tuika::Theme;
+
+/// Common command-line options shared by the runnable examples.
+pub struct Cli {
+    pub theme: Theme,
+    #[allow(dead_code)]
+    pub theme_name: Option<String>,
+    #[allow(dead_code)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum Output {
+    Terminal,
+    Svg(PathBuf),
+}
+
+impl Output {
+    #[allow(dead_code)]
+    pub fn parse(args: &[String]) -> io::Result<Self> {
+        match args {
+            [] => Ok(Self::Terminal),
+            [path] if !path.starts_with('-') => Ok(Self::Svg(PathBuf::from(path))),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "expected at most one SVG output path",
+            )),
+        }
+    }
+}
+
+impl Cli {
+    pub fn parse() -> io::Result<Self> {
+        Self::parse_from(std::env::args().skip(1))
+    }
+
+    pub(crate) fn parse_from(args: impl IntoIterator<Item = String>) -> io::Result<Self> {
+        let mut args = args.into_iter();
+        let mut rest = Vec::new();
+        let mut theme_name = None;
+
+        while let Some(arg) = args.next() {
+            if arg == "--theme" {
+                let name = args
+                    .next()
+                    .ok_or_else(|| invalid_theme("missing theme name"))?;
+                set_theme_name(&mut theme_name, name)?;
+            } else if let Some(name) = arg.strip_prefix("--theme=") {
+                set_theme_name(&mut theme_name, name.to_owned())?;
+            } else {
+                rest.push(arg);
+            }
+        }
+
+        let theme = match theme_name.as_deref() {
+            Some(name) => tuika::themes::by_name(name)
+                .ok_or_else(|| invalid_theme(&format!("unknown theme {name:?}")))?,
+            None => Theme::default(),
+        };
+        Ok(Self {
+            theme,
+            theme_name,
+            args: rest,
+        })
+    }
+}
+
+fn set_theme_name(current: &mut Option<String>, name: String) -> io::Result<()> {
+    if current.replace(name).is_some() {
+        return Err(invalid_theme("--theme may only be supplied once"));
+    }
+    Ok(())
+}
+
+fn invalid_theme(detail: &str) -> io::Error {
+    let names = tuika::themes::PRESETS
+        .iter()
+        .map(|preset| preset.name)
+        .collect::<Vec<_>>()
+        .join(", ");
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("{detail}; available themes: {names}"),
+    )
+}

--- a/examples/tree_list.rs
+++ b/examples/tree_list.rs
@@ -8,6 +8,8 @@ use std::io;
 
 use tuika::prelude::*;
 
+mod support;
+
 const TREE_Y: u16 = 2;
 
 struct TreeApp {
@@ -146,11 +148,12 @@ impl Application for TreeApp {
 }
 
 fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
     Runner::new(RunnerConfig {
         screen_mode: ScreenMode::Alternate.with_mouse_capture(),
         ..RunnerConfig::default()
     })
-    .run(&Theme::default(), &mut TreeApp::new())
+    .run(&cli.theme, &mut TreeApp::new())
 }
 
 #[cfg(test)]

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -22,6 +22,11 @@
   - Worth keeping because the symptom and the cause sat in different concepts:
     nothing about link handling was wrong.
 
+- **Runnable-first example commands**
+  - Standardized examples that also generate assets: their no-argument form now
+    renders in a real terminal, an explicit SVG path selects offline output, and
+    `--theme <name>` applies to both paths. Demo generators pass committed output
+    paths explicitly.
 
 ## 2026-08-21
 

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -193,12 +193,15 @@ Generated demos follow the rule that the *scene registry is the source of truth*
   built from a registry scene. `examples/split_footer_demo.rs` is the
   recorder-free path to the same picture (a pseudo-terminal, vt100, an animated
   SVG), the way `examples/screenshot.rs` is for the hero: useful without a VHS
-  toolchain and for a text dump, but what it writes is not committed.
-- The image demo is rendered directly by `examples/image_demo.rs` rather than
-  recorded, because VHS captures through `ttyd` + `xterm.js`, which implements
-  no graphics protocol and would only ever show the text fallback. This is the
-  one asset a recorder genuinely *cannot* produce; the split footer only looked
-  like one until the toolchain was available.
+  toolchain and for a text dump, but what it writes is not committed. Both run
+  their real terminal scene by default and only write an SVG when given an
+  explicit output path.
+- The image demo is rendered directly by `examples/image_demo.rs` when given an
+  SVG output path, and otherwise runs the same real terminal scene as `image`,
+  rather than recorded, because VHS captures through `ttyd` + `xterm.js`, which
+  implements no graphics protocol and would only ever show the text fallback.
+  This is the one asset a recorder genuinely *cannot* produce; the split footer
+  only looked like one until the toolchain was available.
 - Release notes embed demos too — see [Release](../processes/release.md#changelog-format) —
   and they reuse the same `DEMOS` scenes rather than adding one-off assets. They
   are the one place that pins the raw URL to a release tag instead of `main`, so

--- a/scripts/gen-all-demos.sh
+++ b/scripts/gen-all-demos.sh
@@ -31,7 +31,7 @@ scripts/gen-styling-demos.sh
 scripts/gen-split-footer-demo.sh
 
 echo "Generating image SVG…"
-cargo run -q --example image_demo
+cargo run -q --example image_demo -- docs/demos/image.svg
 
 
 scripts/gen-codex-demo.sh

--- a/scripts/gen-hero.sh
+++ b/scripts/gen-hero.sh
@@ -4,8 +4,8 @@
 #
 # The composite gallery scene in examples/screenshot.rs is the
 # single source of truth (the same `scene()` also renders docs/hero.svg). This
-# script builds that example, records its `run` mode under VHS, and writes the
-# GIF. The tape is generated here, not committed.
+# script builds that example, records its default terminal mode under VHS, and
+# writes the GIF. The tape is generated here, not committed.
 #
 # Requirements: vhs (https://github.com/charmbracelet/vhs), which needs ttyd and
 # ffmpeg on PATH. Run from anywhere:
@@ -47,7 +47,7 @@ Set Theme { "background": "#141214", "foreground": "#ebe6e6" }
 Set Framerate 24
 
 Hide
-Type "TERM=xterm-256color ${bin} run"
+Type "TERM=xterm-256color ${bin}"
 Enter
 Sleep 900ms
 Show

--- a/scripts/gen-mermaid-demo.sh
+++ b/scripts/gen-mermaid-demo.sh
@@ -44,6 +44,8 @@ Enter
 Sleep 500ms
 Show
 Sleep 3s
+Type "q"
+Sleep 300ms
 EOF
 
 echo "Recording Mermaid Markdown demo…"

--- a/scripts/gen-styling-demos.sh
+++ b/scripts/gen-styling-demos.sh
@@ -36,7 +36,7 @@ fg="#ebe6e6"
 
 # Each held variant plus one live-cycling capture. `run <name>` holds a sheet;
 # `run` alone cycles through every variant.
-records=("default:run default" "vivid:run vivid" "mono:run mono" "cycle:run")
+records=("default:run default" "vivid:run vivid" "mono:run mono" "cycle:")
 
 record() {
   local name="$1" cmd="$2" sleep_for="$3"

--- a/scripts/gen-theme-demos.sh
+++ b/scripts/gen-theme-demos.sh
@@ -57,7 +57,7 @@ Set Theme { "background": "${bg}", "foreground": "${fg}" }
 Set Framerate 24
 
 Hide
-Type "TERM=xterm-256color ${bin} run ${name}"
+Type "TERM=xterm-256color ${bin} --theme ${name}"
 Enter
 Sleep 900ms
 Show

--- a/tests/example_cli.rs
+++ b/tests/example_cli.rs
@@ -1,0 +1,45 @@
+#[path = "../examples/support/mod.rs"]
+mod support;
+
+use support::{Cli, Output};
+
+#[test]
+fn theme_is_removed_from_example_specific_arguments() {
+    let _environment_entry_point: fn() -> std::io::Result<Cli> = Cli::parse;
+    let cli = Cli::parse_from([
+        "out.svg".to_owned(),
+        "--theme".to_owned(),
+        "gruvbox-dark".to_owned(),
+        "--dump".to_owned(),
+    ])
+    .unwrap();
+
+    assert_eq!(cli.theme, tuika::themes::GRUVBOX_DARK);
+    assert_eq!(cli.theme_name.as_deref(), Some("gruvbox-dark"));
+    assert_eq!(cli.args, ["out.svg", "--dump"]);
+}
+
+#[test]
+fn equals_syntax_selects_a_theme() {
+    let cli = Cli::parse_from(["--theme=light".to_owned()]).unwrap();
+
+    assert_eq!(cli.theme, tuika::themes::LIGHT);
+    assert!(cli.args.is_empty());
+}
+
+#[test]
+fn unknown_and_repeated_themes_are_rejected() {
+    assert!(Cli::parse_from(["--theme=nope".to_owned()]).is_err());
+    assert!(Cli::parse_from(["--theme=light".to_owned(), "--theme=dracula".to_owned(),]).is_err());
+}
+
+#[test]
+fn no_output_path_selects_the_terminal_and_a_path_selects_svg() {
+    assert_eq!(Output::parse(&[]).unwrap(), Output::Terminal);
+    assert_eq!(
+        Output::parse(&["docs/hero.svg".to_owned()]).unwrap(),
+        Output::Svg("docs/hero.svg".into())
+    );
+    assert!(Output::parse(&["--dump".to_owned()]).is_err());
+    assert!(Output::parse(&["one.svg".to_owned(), "two.svg".to_owned()]).is_err());
+}


### PR DESCRIPTION
## What changed

- Make every workspace example render in a real terminal by default.
- Add shared `--theme NAME` / `--theme=NAME` parsing to root and companion-crate examples.
- Make recorder-free generators write SVG only when given an explicit output path.
- Turn the Mermaid Markdown example into a quit-able terminal application and make `highlight_file` useful without arguments.
- Update demo generators and public/durable documentation to match the runnable-first commands.

## Why

Examples should be immediately useful with `cargo run --example …`. Asset generation is now an explicit operation, so an ordinary no-argument run never silently writes a file.

## Before / After

Before, `cargo run --example screenshot` wrote `docs/hero.svg`; `image_demo` and `split_footer_demo` also defaulted to files, and the Mermaid example printed a plain grid.

After:

```text
cargo run --example screenshot                         # real terminal
cargo run --example screenshot -- out.svg              # explicit SVG
cargo run --example screenshot -- docs/hero.svg        # explicit doc asset
cargo run --example screenshot -- --theme gruvbox-dark # themed terminal
```

The same terminal-first and theme behavior applies across the workspace. Verified interactively with themed `screenshot` and `mermaid_markdown` sessions, and generated all three SVG forms to temporary paths.

## Risk

Low. This changes example CLIs and generator scripts only; it adds no dependency or published library API. Legacy screenshot recorder forms remain accepted. The shared parser rejects unknown/repeated themes and ambiguous output arguments.

## Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `env -u NO_COLOR TERM=xterm-256color cargo test --workspace --all-features`
- [x] `cargo run -q --example demo -- check`
- [x] `python3 scripts/validate_okf.py knowledge --strict --check-links`
- [x] Manual themed terminal smoke and explicit SVG smoke
- [x] Signed commit verified locally

## Knowledge

Updated `knowledge/specs/documentation.md` and `knowledge/log.md` to record the runnable-first example contract and the explicit asset-output rule.

## Security

- Terminal control and teardown still use the existing `Runner`/`TerminalSession` paths.
- Theme names resolve only through bundled presets; invalid and repeated values fail.
- The split-footer recorder passes executable paths and arguments positionally across its shell boundary instead of interpolating them.
- No dependency, network, secret, or published API changes.

## Follow-ups

None.
