### PR TITLE
docs(readme): track current demo assets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,9 +209,10 @@ The root package's public `docs/` tree and alternate logo/demo assets are
 repository-only: `Cargo.toml`'s `exclude` keeps them (and the generated `site/`
 bundle plus repository machinery — `knowledge/`, `.agents/`, `.github/`,
 `scripts/`) out of tuika's published `.crate`, and `tests/packaging.rs` guards
-that split. The root README's guide links and three image embeds use
-release-tag-pinned absolute URLs, and the split-footer recording lives only in
-the focused guide, so no `docs/` file ships in tuika.
+that split. The root README's guide links and logo use release-tag-pinned
+absolute URLs; the hero and image demo track `main` so regenerated visuals show
+up immediately. The split-footer recording lives only in the focused guide, so
+no `docs/` file ships in tuika.
 
 Every published member owns the same rule, and how its README embeds a recording
 decides the answer: `tuika-mermaid`'s small recording ships, because its README

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,9 @@ categories = ["command-line-interface"]
 # 1. The public `docs/` tree, alternate logo exports, and recordings beside the
 #    in-repo application showcases are consumed from the tagged repository by
 #    public pages or tooling. rustdoc/docs.rs references none of them from its
-#    crate front page, and the crates.io README uses release-tag-pinned absolute
-#    URLs for guides and images, so packaged copies would be incomplete and
-#    unreachable.
+#    crate front page, and the crates.io README uses absolute URLs for guides and
+#    images, so packaged copies would be incomplete and unreachable. Guide and
+#    logo URLs are release-pinned; regenerated demo assets track `main`.
 # 2. Benchmark result snapshots. Benchmark sources remain reproducible, but the
 #    committed IAI baseline is a CI input rather than a consumer file.
 # 3. Repository machinery. Since tuika is the root package, everything beside it

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 </div>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
+  <img src="https://raw.githubusercontent.com/everruns/tuika/main/docs/hero.gif" width="880" alt="Animated tuika gallery: a terminal window with tabs, an activity panel of spinners, progress bars and a loader, a command palette, a commit-message input, and a status bar — all animating.">
 </p>
 
 <div align="center">
@@ -839,7 +839,7 @@ cells it reserves, using whichever terminal graphics protocol
 **iTerm2**, or **Sixel** (foot, xterm +sixel, mlterm, contour). Terminals with
 none show the alt text, so the same view tree renders everywhere.
 
-<img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
+<img src="https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/image.svg" width="880" alt="Two terminal windows side by side: on a Kitty/Ghostty/WezTerm/Konsole terminal an Image view renders a red/green gradient in place; on every other terminal the same view shows a dimmed italic '[image: a red/green gradient]' placeholder.">
 
 Decoding stays in the host — a heavy dependency, kept out like the highlighter
 boundary — so you hand in raw RGBA via `ImageData::from_rgba` and `tuika` owns the

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -45,6 +45,12 @@
     external showcases retain their host application's real palette. Interactive
     example defaults are unchanged; this is a documentation identity choice.
 
+- **README demo assets track the current repository captures**
+  - Release-pinning the root README's hero and image demo made every regenerated
+    visual invisible there until the next version tag. Those two embeds now
+    track `main`, while the stable logo and public guide links remain pinned to
+    the release and release-note screenshots remain immutable historical proof.
+
 - **Application-scale examples belong beside the products in the showcase**
   - `workbench_demo` is a deterministic in-repo application shell, recorded from
     its real binary and presented beside host applications rather than split

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -205,7 +205,7 @@ Generated demos follow the rule that the *scene registry is the source of truth*
   only looked like one until the toolchain was available.
 - Release notes embed demos too — see [Release](../processes/release.md#changelog-format) —
   and they reuse the same `DEMOS` scenes rather than adding one-off assets. They
-  are the one place that pins the raw URL to a release tag instead of `main`, so
+  pin the raw URL to a release tag instead of `main`, so
   a later re-recording cannot rewrite what a past release appeared to ship. That
   also puts `CHANGELOG.md` deliberately outside the `demo -- check` reference
   gate: shipped history may name a scene that no longer exists.
@@ -328,8 +328,10 @@ copy without its large recordings adds weight without a usable offline guide.
 Root `Cargo.toml`'s `exclude` keeps them
 — the generated `site/` bundle, and the repository machinery (`knowledge/`,
 `.agents/`, `.github/`, `scripts/`) — out of that tarball. The root README
-reaches every public guide through a GitHub `blob` URL and its logo, hero, and
-image-protocol demo through a raw URL, all pinned to the release tag; the
+reaches every public guide through a release-tag-pinned GitHub `blob` URL and
+its logo through a release-tag-pinned raw URL. The hero and image-protocol demo
+use raw URLs that track `main`, so a regenerated documentation asset appears in
+the repository README immediately instead of waiting for the next release. The
 split-footer recording lives in the focused guide instead of the README. No
 `docs/` file therefore ships in the root crate.
 
@@ -342,10 +344,11 @@ determines whether the packaged copy is ever read:
   examples are here.
 - **Absolute `raw.githubusercontent.com` URL** — the packaged copy is
   unreachable from inside the `.crate` and is pure weight, so it is excluded
-  wherever it lives. The root README pins these URLs to its release tag so a
-  later asset refresh cannot rewrite a published crates.io page;
-  `tuika-codeformatters` and `tuika-charts` use `main` for their repository-owned
-  galleries.
+  wherever it lives. The root README pins its logo to the release tag, while its
+  regenerated hero and image demo track `main`; the companion-crate galleries
+  also use `main`. This keeps current visual evidence current, including on the
+  published crates.io README, while release notes remain the immutable record of
+  what an older release looked like.
 - **Absolute GitHub `blob` URL** — the same rule for public Markdown guides. The
   root README pins all guide links to the release tag, so the complete guide and
   its repository-hosted media remain versioned together outside the crate.

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -178,18 +178,20 @@ fn benchmark_results_are_excluded_from_every_package() {
 }
 
 #[test]
-fn root_readme_assets_are_tag_pinned_and_excluded() {
+fn root_readme_assets_use_their_intended_refs_and_are_excluded() {
     let files = packaged_files("tuika");
     let has = |p: &str| files.iter().any(|f| f == p);
 
     let readme = std::fs::read_to_string("README.md").expect("read root README");
     let version = env!("CARGO_PKG_VERSION");
-    for asset in ["logo.svg", "docs/hero.gif", "docs/demos/image.svg"] {
-        let url = format!("https://raw.githubusercontent.com/everruns/tuika/v{version}/{asset}");
-        assert!(
-            readme.contains(&url),
-            "README must pin {asset} to v{version}"
-        );
+    let logo_url = format!("https://raw.githubusercontent.com/everruns/tuika/v{version}/logo.svg");
+    assert!(
+        readme.contains(&logo_url),
+        "README must pin logo.svg to v{version}"
+    );
+    for asset in ["docs/hero.gif", "docs/demos/image.svg"] {
+        let url = format!("https://raw.githubusercontent.com/everruns/tuika/main/{asset}");
+        assert!(readme.contains(&url), "README must track main for {asset}");
     }
     assert!(
         !readme.contains("docs/split-footer.gif"),


### PR DESCRIPTION
## What changed

The root README now loads its regenerated hero and image demo from `main`, so the Solarized Dark captures shipped in #121 are actually visible on the repository front page. The stable logo and public guide links remain release-pinned.

The packaging guard now locks that split: logo from the crate version tag, regenerated visual evidence from `main`, and all absolute assets excluded from the crate archive.

## Why

The demo assets were regenerated correctly, but the README still referenced `v0.11.0`. That made the README show the old palette until another release tag was cut.

## Before / After

| Before: `v0.11.0` hero | After: current `main` hero |
| --- | --- |
| <img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/docs/hero.gif" width="440" alt="Previous release-tagged tuika hero"> | <img src="https://raw.githubusercontent.com/everruns/tuika/main/docs/hero.gif" width="440" alt="Current Solarized Dark tuika hero"> |

The `main` URL was downloaded during validation and matched the committed `docs/hero.gif` byte-for-byte.

## Risk

- Low.
- Published crates.io README pages will now show the current regenerated hero and image demo. Release-note captures remain tag-pinned as immutable historical evidence.
- No public API or runtime behavior changes.

## Checklist

- [x] Regression test updated and observed failing before the README fix
- [x] Backward compatibility considered; no API change
- [x] Documentation knowledge and maintainer guidance updated

## Knowledge

Updated the documentation asset contract and knowledge log to distinguish stable release-pinned links from current regenerated visual evidence.

## Security

No security-relevant code changes. The diff changes documentation URLs, packaging assertions, and maintainer documentation only; terminal escape, state, parsing, clipping, and dependency surfaces are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env -u NO_COLOR cargo test --workspace --all-features`
- `cargo test --test packaging`
- `cargo run --example demo -- check`
- `python3 scripts/validate_okf.py knowledge --check-links`
- Downloaded the new README hero URL and verified its SHA-256 matches `docs/hero.gif`
- Visually inspected the downloaded hero as Solarized Dark

Docs-only URL/policy correction; terminal smoke testing is not applicable.

## Follow-ups

No follow-ups.
