### PR TITLE
fix(site): publish routing guide

### DIFF
--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -2,6 +2,13 @@
 
 ## 2026-08-22
 
+- **Published guides share one checked route inventory**
+  - The input-routing guide existed in `docs/` but remained unreachable on
+    tuika.dev because separate worker, link-rewrite, verification, and deployment
+    allowlists omitted it. The worker, link rewriting, and build verification
+    now share one inventory, checked against every public guide and
+    component-family source; a regression test pins deployment routing to it.
+
 - **Selection is scoped by what the frame drew, not by the screen**
   - Runner-provided drag selection streamed across the whole cell grid, so a
     drag inside a sidebar picked up whatever pane sat beside it. Panels are the

--- a/knowledge/specs/documentation.md
+++ b/knowledge/specs/documentation.md
@@ -50,6 +50,9 @@ terminal UI with tuika without requiring knowledge of repository internals.
   X/Twitter large-image cards in tuika's terminal-grid identity. These
   discovery surfaces are part of the documentation contract: browsers, search
   engines, and coding agents should reach the same current content.
+  One checked route inventory feeds the worker, link rewriting, and build
+  verification; it must match every top-level guide and component-family source
+  below `docs/`, so adding a guide cannot silently publish an unreachable page.
 - rustdoc is public documentation too. The crate-level `//!` header in `lib.rs`
   is what docs.rs renders as the front page; component demos are embedded inline
   on the relevant type via `raw.githubusercontent.com` URLs so they resolve

--- a/site/.nimbus/routes.json
+++ b/site/.nimbus/routes.json
@@ -18,6 +18,7 @@
     "/keymap",
     "/layout",
     "/markdown",
+    "/routing",
     "/showcases",
     "/styling",
     "/themes"

--- a/site/scripts/sync-docs.mjs
+++ b/site/scripts/sync-docs.mjs
@@ -1,23 +1,13 @@
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { GUIDE_SLUGS } from "../src/lib/routes.js";
 
 const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const sourceDir = resolve(siteRoot, "../docs");
 const targetDir = resolve(siteRoot, "src/content/docs");
 const componentDir = resolve(sourceDir, "components");
-const guideSlugs = new Set([
-  "charts",
-  "components",
-  "features",
-  "getting-started",
-  "keymap",
-  "layout",
-  "markdown",
-  "showcases",
-  "styling",
-  "themes",
-]);
+const guideSlugs = new Set(GUIDE_SLUGS);
 const componentRoutes = new Map();
 
 function headingAnchor(heading) {

--- a/site/scripts/verify-site.mjs
+++ b/site/scripts/verify-site.mjs
@@ -1,27 +1,9 @@
 import { access, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { PAGE_SLUGS } from "../src/lib/routes.js";
 
 const root = resolve(import.meta.dirname, "..");
-const pages = [
-  "",
-  "charts",
-  "components",
-  "components/motion",
-  "components/text",
-  "components/markdown-code",
-  "components/layout",
-  "components/interactive",
-  "components/notifications-console",
-  "components/banners-codes-pixels",
-  "features",
-  "getting-started",
-  "keymap",
-  "layout",
-  "markdown",
-  "showcases",
-  "styling",
-  "themes",
-];
+const pages = PAGE_SLUGS;
 
 const failures = [];
 

--- a/site/src/lib/docs-links.ts
+++ b/site/src/lib/docs-links.ts
@@ -1,14 +1,6 @@
-const guideSlugs = new Set([
-  "charts",
-  "components",
-  "features",
-  "keymap",
-  "layout",
-  "markdown",
-  "showcases",
-  "styling",
-  "themes",
-]);
+import { GUIDE_SLUGS } from "./routes.js";
+
+const guideSlugs = new Set(GUIDE_SLUGS);
 
 export function normalizeMarkdownLinks(markdown: string): string {
   return markdown

--- a/site/src/lib/routes.js
+++ b/site/src/lib/routes.js
@@ -1,0 +1,33 @@
+export const GUIDE_SLUGS = Object.freeze([
+  "charts",
+  "components",
+  "features",
+  "getting-started",
+  "keymap",
+  "layout",
+  "markdown",
+  "routing",
+  "showcases",
+  "styling",
+  "themes",
+]);
+
+export const COMPONENT_SLUGS = Object.freeze([
+  "banners-codes-pixels",
+  "interactive",
+  "layout",
+  "markdown-code",
+  "motion",
+  "notifications-console",
+  "text",
+]);
+
+export const PAGE_SLUGS = Object.freeze([
+  "",
+  ...GUIDE_SLUGS,
+  ...COMPONENT_SLUGS.map((slug) => `components/${slug}`),
+]);
+
+export const PAGE_ROUTES = new Set(
+  PAGE_SLUGS.map((slug) => (slug ? `/${slug}/` : "/")),
+);

--- a/site/src/worker.js
+++ b/site/src/worker.js
@@ -1,23 +1,4 @@
-const PAGE_ROUTES = new Set([
-  "/",
-  "/charts/",
-  "/components/",
-  "/components/motion/",
-  "/components/text/",
-  "/components/markdown-code/",
-  "/components/layout/",
-  "/components/interactive/",
-  "/components/notifications-console/",
-  "/components/banners-codes-pixels/",
-  "/features/",
-  "/getting-started/",
-  "/keymap/",
-  "/layout/",
-  "/markdown/",
-  "/showcases/",
-  "/styling/",
-  "/themes/",
-]);
+import { PAGE_ROUTES } from "./lib/routes.js";
 
 export default {
   async fetch(request, env) {

--- a/site/src/worker.test.js
+++ b/site/src/worker.test.js
@@ -1,16 +1,48 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
 import worker, {
   canonicalPagePath,
   htmlAssetPath,
   markdownAssetPath,
   prefersMarkdown,
 } from "./worker.js";
+import { COMPONENT_SLUGS, GUIDE_SLUGS } from "./lib/routes.js";
+
+test("route inventory matches every public guide", async () => {
+  const docs = new URL("../../docs/", import.meta.url);
+  const guideSlugs = (await readdir(docs, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.slice(0, -3))
+    .sort();
+  const componentSlugs = (await readdir(new URL("components/", docs), {
+    withFileTypes: true,
+  }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => entry.name.slice(0, -3))
+    .sort();
+
+  assert.deepEqual([...GUIDE_SLUGS].sort(), guideSlugs);
+  assert.deepEqual([...COMPONENT_SLUGS].sort(), componentSlugs);
+});
+
+test("deployment sends every guide route through the worker", async () => {
+  const config = JSON.parse(
+    await readFile(new URL("../wrangler.jsonc", import.meta.url), "utf8"),
+  );
+
+  assert.deepEqual(config.assets.run_worker_first, [
+    "/",
+    "/index.html",
+    ...GUIDE_SLUGS.map((slug) => `/${slug}*`),
+  ]);
+});
 
 test("maps public pages to their markdown twins", () => {
   assert.equal(markdownAssetPath("/"), "/index.md");
   assert.equal(markdownAssetPath("/components/"), "/components/index.md");
   assert.equal(markdownAssetPath("/getting-started/"), "/getting-started/index.md");
+  assert.equal(markdownAssetPath("/routing/"), "/routing/index.md");
   assert.equal(
     markdownAssetPath("/components/interactive/"),
     "/components/interactive/index.md",
@@ -24,6 +56,7 @@ test("maps canonical pages to exact static assets", () => {
   assert.equal(canonicalPagePath("/index.html"), "/");
   assert.equal(canonicalPagePath("/components"), "/components/");
   assert.equal(canonicalPagePath("/getting-started"), "/getting-started/");
+  assert.equal(canonicalPagePath("/routing"), "/routing/");
   assert.equal(canonicalPagePath("/components/index.html"), "/components/");
   assert.equal(canonicalPagePath("/components/interactive"), "/components/interactive/");
   assert.equal(

--- a/site/wrangler.jsonc
+++ b/site/wrangler.jsonc
@@ -25,6 +25,7 @@
       "/keymap*",
       "/layout*",
       "/markdown*",
+      "/routing*",
       "/showcases*",
       "/styling*",
       "/themes*"


### PR DESCRIPTION
## What changed
Published the existing input-routing guide at its canonical tuika.dev route. All site consumers now use one checked documentation route inventory, and Cloudflare deployment coverage is pinned to it so future guides cannot silently remain unreachable.

## Why
The guide existed and was built, but separate route allowlists omitted `/routing/`. Cloudflare therefore served the 404 page shown in the report.

## Before / After
Before: `https://tuika.dev/routing/` returned HTTP 404.

After, against the production Worker configuration locally:
- `GET /routing/` → HTTP 200, `text/html`
- `GET /routing` → HTTP 308 to `/routing/`
- `GET /routing/` with `Accept: text/markdown` → HTTP 200, `text/markdown`
- an unknown path still returns HTTP 404

The production build now emits `routing/index.html`, its Markdown/MDX twins, and `og/routing.png`.

## Risk
- Low
- Risk is limited to documentation URL routing. Static assets retain the existing asset-first path, and unknown paths retain the 404 fallback.

## Checklist
- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

No public Rust API change.

Validation:
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec nimbus-docs check --json`
- `pnpm exec wrangler deploy --dry-run`
- `python3 scripts/validate_okf.py knowledge --check-links`
- `cargo fmt --all -- --check`
- local Worker HTTP smoke test

## Knowledge
Updated the documentation contract and knowledge log to require a checked route inventory for every public guide.

## Security
Reviewed Worker and deployment changes for path handling, content negotiation, asset access, secrets, and fallback behavior. The Worker still serves only allowlisted generated documentation assets, unknown paths remain 404, security headers are unchanged, and no auth, secrets, terminal escape handling, or untrusted parser surface changed.

## Follow-ups
No follow-ups.
