### PR TITLE
feat(examples): add AppShell application

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ palette, for example `cargo run --example gallery -- --theme gruvbox-dark`.
 | [`tree_list`](examples/tree_list.rs) | `cargo run --example tree_list` | expandable stable-id tree, refresh, mouse selection, and persistent scrolling |
 | [`overlay`](examples/overlay.rs)  | `cargo run --example overlay`    | Target-following popover + input routing           |
 | [`primitives`](examples/primitives.rs) | `cargo run --example primitives` | owned dialog scene + form + arbitrary-child viewport |
+| [`app_shell`](examples/app_shell.rs) | `cargo run --example app_shell` | responsive header/body/status/footer shell with host-owned selection |
 | [`ratatui_dashboard`](examples/ratatui_dashboard.rs) | `cargo run --example ratatui_dashboard` | mixed Ratatui widgets + responsive live data |
 | [`workbench_demo`](examples/workbench_demo) | `cargo run --example workbench_demo` | native tuika editor/dashboard shell with keyboard and mouse navigation |
 | [`async_dashboard`](examples/async_dashboard.rs) | `cargo run --example async_dashboard --features async` | typed background messages waking `AsyncRunner`, no shared mutable state |

--- a/docs/components/layout.md
+++ b/docs/components/layout.md
@@ -37,6 +37,25 @@ let screen = AppShell::new(content)
     .footer(KeyHints::from_keymap(&keymap));
 ```
 
+The [complete runnable example](https://github.com/everruns/tuika/blob/main/examples/app_shell.rs)
+keeps selection and input in application state while rebuilding the borrowed
+shell view each frame. Run it with `cargo run --example app_shell`; resize the
+terminal to see rules and secondary chrome yield before the main body and
+footer.
+
+#### `AppShell` or `Flex`?
+
+Use `AppShell` when the application has one growing body surrounded by
+intrinsic header, status, rule, and footer rows. It supplies that vertical
+allocation and its short-terminal collapse policy; it does not own navigation,
+input routing, or application state.
+
+Use `Flex` directly when several regions need to grow, split an axis, or change
+shape responsively — sidebars, editor panes, dashboards, and nested panel
+grids. The [Workbench example](../showcases.md#workbench-demo-in-repo-example)
+uses nested `Flex` for that multi-pane shape. The two compose normally: an
+`AppShell` main body can itself be a `Flex` tree.
+
 ### `SelectionScreen`
 
 A responsive full-screen picker for the repeated action, agent, permission,

--- a/examples/app_shell.rs
+++ b/examples/app_shell.rs
@@ -1,0 +1,184 @@
+//! Interactive `AppShell` example.
+//!
+//! Run with `cargo run --example app_shell`. Use `↑`/`↓` to move, `Enter` to
+//! open the selected file, and `q`/`Esc` to quit. Resize the terminal to see
+//! secondary chrome collapse before the main content and footer. Pass `--dump`
+//! after Cargo's `--` to print a deterministic frame instead.
+
+use std::io;
+
+use tuika::prelude::*;
+
+mod support;
+
+const FILES: [&str; 6] = [
+    "src/components/app_shell.rs",
+    "src/components/flex.rs",
+    "src/components/selection_screen.rs",
+    "examples/app_shell.rs",
+    "docs/components/layout.md",
+    "README.md",
+];
+
+struct App {
+    selection: SelectState,
+    message: String,
+    theme: Theme,
+}
+
+impl App {
+    fn new(theme: Theme) -> Self {
+        Self {
+            selection: SelectState::new(),
+            message: "Ready".into(),
+            theme,
+        }
+    }
+
+    fn selected(&self) -> &'static str {
+        self.selection
+            .selected()
+            .and_then(|index| FILES.get(index))
+            .copied()
+            .unwrap_or("no file")
+    }
+}
+
+impl Application for App {
+    fn update(&mut self, signal: Signal) -> UpdateResult {
+        let Signal::Event(event) = signal else {
+            return UpdateResult::Clean;
+        };
+        if let Event::Key(key) = &event
+            && key.plain()
+            && key.code == KeyCode::Char('q')
+        {
+            return UpdateResult::Exit;
+        }
+
+        match self.selection.handle(&event, FILES.len()) {
+            InputOutcome::Changed => {
+                self.message = format!("Selected {}", self.selected());
+                UpdateResult::Dirty
+            }
+            InputOutcome::Submitted => {
+                self.message = format!("Opened {}", self.selected());
+                UpdateResult::Dirty
+            }
+            InputOutcome::Cancelled => UpdateResult::Exit,
+            InputOutcome::Ignored | InputOutcome::Consumed => UpdateResult::Clean,
+        }
+    }
+
+    fn view(&self, _frame: u64) -> ScopedElement<'_> {
+        let rows = FILES
+            .iter()
+            .map(|path| Line::from(Span::styled(*path, self.theme.text_style())))
+            .collect();
+        let body = Boxed::new(element(SelectList::new(rows, &self.selection)))
+            .title(" workspace ")
+            .padding(Padding::symmetric(1, 0));
+        let header = Text::new(vec![Line::from(vec![
+            Span::styled("▲ tuika explorer  ", self.theme.accent_style()),
+            Span::styled(
+                "one growing body · intrinsic chrome",
+                self.theme.muted_style(),
+            ),
+        ])]);
+        let status = StatusBar::new()
+            .left(vec![
+                Span::styled(" READY ", self.theme.selection_style()),
+                Span::styled(format!("  {}", self.message), self.theme.text_style()),
+            ])
+            .right(vec![Span::styled(
+                format!("{}  ", self.selected()),
+                self.theme.muted_style(),
+            )]);
+
+        element(
+            AppShell::new(body)
+                .header(header)
+                .top_rule()
+                .status(status)
+                .bottom_rule()
+                .footer(KeyHints::new([
+                    ("↑/↓", "move"),
+                    ("enter", "open"),
+                    ("q/esc", "quit"),
+                ])),
+        )
+    }
+}
+
+fn dump_frame(app: &App) -> String {
+    let root = app.view(0);
+    let buffer = tuika::testing::render(root.as_ref(), 72, 12, &app.theme);
+    tuika::testing::grid(&buffer)
+}
+
+fn main() -> io::Result<()> {
+    let cli = support::Cli::parse()?;
+    let dump = match cli.args.as_slice() {
+        [] => false,
+        [arg] if arg == "--dump" => true,
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "usage: cargo run --example app_shell [-- --theme NAME] [--dump]",
+            ));
+        }
+    };
+    let theme = cli.theme;
+    let mut app = App::new(theme);
+    if dump {
+        println!("{}", dump_frame(&app));
+        return Ok(());
+    }
+    Runner::new(RunnerConfig::default()).run(&theme, &mut app)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_contains_every_shell_region() {
+        let theme = Theme::default();
+        let app = App::new(theme);
+        let grid = dump_frame(&app);
+
+        for landmark in [
+            "tuika explorer",
+            "workspace",
+            "app_shell.rs",
+            "READY",
+            "enter",
+            "open",
+        ] {
+            assert!(grid.contains(landmark), "missing {landmark:?}\n{grid}");
+        }
+    }
+
+    #[test]
+    fn navigation_submission_and_exit_update_the_app() {
+        let mut app = App::new(Theme::default());
+
+        assert_eq!(
+            app.update(Signal::Event(Event::Key(Key::new(KeyCode::Down)))),
+            UpdateResult::Dirty
+        );
+        assert_eq!(app.selection.selected(), Some(1));
+        assert!(app.message.contains("flex.rs"));
+
+        assert_eq!(
+            app.update(Signal::Event(Event::Key(Key::new(KeyCode::Enter)))),
+            UpdateResult::Dirty
+        );
+        assert!(app.message.starts_with("Opened"));
+
+        assert_eq!(
+            app.update(Signal::Event(Event::Key(Key::new(KeyCode::Esc)))),
+            UpdateResult::Exit
+        );
+    }
+}

--- a/src/components/app_shell.rs
+++ b/src/components/app_shell.rs
@@ -77,6 +77,10 @@ impl Region<'_> {
 /// footer also keeps one row when there is room beside the main content.
 /// Separators use the active stylesheet's [`Role::Rule`] style.
 ///
+/// Run the [complete interactive example](https://github.com/everruns/tuika/blob/main/examples/app_shell.rs)
+/// with `cargo run --example app_shell`. The focused component image below is
+/// recorded with `cargo run --example demo -- app_shell`.
+///
 /// ![application shell demo](https://raw.githubusercontent.com/everruns/tuika/main/docs/demos/app_shell.png)
 pub struct AppShell<'view> {
     before_main: Vec<Region<'view>>,


### PR DESCRIPTION
## What changed

Adds a complete, interactive `AppShell` application that demonstrates a growing body with intrinsic header, status, rule, and footer regions. The example owns selection and input state, supports theme selection and a deterministic `--dump`, and exits cleanly through `Runner`.

Public README, component-guide, and rustdoc links now make the example discoverable. The layout guide also explains when to choose `AppShell` versus a direct or nested `Flex` layout, with Workbench as the multi-pane contrast.

## Why

The public component gallery showed `AppShell`, but users had no dedicated runnable application and no explicit guidance for choosing it over `Flex`.

## Before / After

Before: there was no `cargo run --example app_shell` target, and the public layout guide did not describe the `AppShell`/`Flex` boundary.

After: `cargo run --example app_shell -- --theme solarized-dark --dump` produces the same structured shell used by the interactive example:

```text
▲ tuika explorer  one growing body · intrinsic chrome
────────────────────────────────────────────────────────────────────────
╭ workspace ───────────────────────────────────────────────────────────╮
│ › src/components/app_shell.rs                                      █ │
│   src/components/flex.rs                                           █ │
│   src/components/selection_screen.rs                               █ │
│   examples/app_shell.rs                                            █ │
│   docs/components/layout.md                                        │ │
╰──────────────────────────────────────────────────────────────────────╯
 READY   Ready                             src/components/app_shell.rs
────────────────────────────────────────────────────────────────────────
 ↑/↓  move   enter  open   q/esc  quit
```

The real-terminal smoke also verified Down, Enter, and `q`: selection and status update, then the alternate screen is restored on exit.

## Risk

- Low
- Example and documentation only; no public library API, dependency, or runtime behavior changes.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env -u NO_COLOR cargo test --workspace --all-features`
- `cargo run --example demo -- check`
- `cargo doc --workspace --all-features --no-deps`
- `cargo publish --dry-run -p tuika --allow-dirty`
- site typecheck and production build
- OKF, publish-order, and validator test suites
- real-terminal interaction smoke

## Knowledge

No knowledge update required — this documents and demonstrates the existing `AppShell`/`Flex` boundary without changing behavior, architecture, policy, or public API.

## Security

Reviewed the terminal threat model. The example renders fixed paths and host-owned state through normal views, emits no raw escapes, parses no untrusted input, adds no dependencies or external I/O, and uses `Runner` for terminal restoration. Deterministic rendering and interaction tests cover shell composition and state transitions; the full robustness and PTY suites remain green.

## Follow-ups

The existing workspace manifest contains a multiline inline dependency table that Cargo 1.88 rejects, while the current MSRV workflow resolves the repository's pinned newer toolchain. This predates and is unrelated to the example; it needs a focused manifest/CI correction rather than expanding this PR.