### PR TITLE
chore(release): prepare v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,24 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
-## [Unreleased]
+## [0.11.1] - 2026-08-25
+
+`tuika` only. The companion crates carry a caret requirement on tuika 0.11, so
+`tuika-charts` 0.1.2, `tuika-codeformatters` 0.5.0, `tuika-html` 0.1.4, and
+`tuika-mermaid` 0.3.2 pick this up without a republish.
+
+### Highlights
+
+**Drag selection stays in the panel it started in** — a left drag that begins
+inside a bordered `Boxed` now selects only within that panel: positions clamp to
+its inner rect, a multi-row selection wraps at the panel's edges instead of the
+screen's, and the copied text never picks up the pane beside it. A drag that
+starts outside every panel still spans the screen as before.
+
+![mouse demo](https://raw.githubusercontent.com/everruns/tuika/v0.11.1/docs/demos/mouse.gif)
+
+- **Robustness**: a `SelectionRange` that outlived the geometry it was made in
+  can no longer index the buffer out of bounds.
 
 ### Changed
 
@@ -20,17 +37,33 @@ described in the release process begins with the entry below.
   inner rect, a multi-row selection wraps at the panel's edges instead of the
   screen's, and the copied text never picks up the pane beside it. A drag that
   starts outside every panel still spans the screen as before.
+- Examples render in a real terminal by default rather than printing a frame.
 
 ### Fixed
 
 - A `SelectionRange` that reaches past the `area` handed to
   `mouse::paint_selection`, `mouse::selected_text`, or `SelectionRange::contains`
   now stops at that area's rows instead of indexing the buffer out of bounds.
+- The routing guide is published on the website again.
 
 ### Added
 
 - `mouse::SelectionState::confine` / `region` — restrict a gesture to a rect and
   read it back, for hosts driving the selection primitives from their own loop.
+- `app_shell` and `workbench_demo` examples, with recordings.
+
+### What's Changed
+
+* fix(release): ignore dev-dependencies when ordering the publish
+* docs(demos): add interactive AppShell recording
+* feat(examples): add AppShell application
+* fix(site): publish routing guide
+* docs(demos): restore Workbench palette (#123)
+* docs(readme): track current demo assets
+* docs(demos): adopt Solarized Dark capture theme
+* feat(examples): add native workbench showcase
+* feat(examples): render in terminals by default
+* feat(mouse): confine drag selection to the panel it starts in (#118)
 
 ## [0.11.0] - 2026-08-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "tuika"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "criterion",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ repository = "https://github.com/everruns/tuika"
 
 [package]
 name = "tuika"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.0/logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
+  <img src="https://raw.githubusercontent.com/everruns/tuika/v0.11.1/logo.svg" width="144" alt="tuika logo: two offset rounded interface panels intersect at a gold anchor point">
 </p>
 
 <h1 align="center">tuika</h1>
@@ -11,13 +11,13 @@
 [![downloads](https://img.shields.io/crates/d/tuika.svg)](https://crates.io/crates/tuika)
 [![license](https://img.shields.io/crates/l/tuika.svg)](https://github.com/everruns/tuika/blob/main/LICENSE)
 ![msrv](https://img.shields.io/badge/rust-1.88%2B-blue.svg) \
-[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](https://github.com/everruns/tuika/blob/v0.11.0/docs/getting-started.md) · [Components](https://github.com/everruns/tuika/blob/v0.11.0/docs/components.md) · [Layout](https://github.com/everruns/tuika/blob/v0.11.0/docs/layout.md) ·
-[Markdown](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) · [Charts](https://github.com/everruns/tuika/blob/v0.11.0/docs/charts.md) ·
-[Terminal features](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md) ·
-[Keymap](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md) · [Input routing](https://github.com/everruns/tuika/blob/v0.11.0/docs/routing.md) ·
-[Styling](https://github.com/everruns/tuika/blob/v0.11.0/docs/styling.md) ·
-[Themes](https://github.com/everruns/tuika/blob/v0.11.0/docs/themes.md) \
-[Showcases](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) · [Examples](#runnable-examples) ·
+[Website](https://tuika.dev) · [Rust API](https://docs.rs/tuika) · [Getting started](https://github.com/everruns/tuika/blob/v0.11.1/docs/getting-started.md) · [Components](https://github.com/everruns/tuika/blob/v0.11.1/docs/components.md) · [Layout](https://github.com/everruns/tuika/blob/v0.11.1/docs/layout.md) ·
+[Markdown](https://github.com/everruns/tuika/blob/v0.11.1/docs/markdown.md) · [Charts](https://github.com/everruns/tuika/blob/v0.11.1/docs/charts.md) ·
+[Terminal features](https://github.com/everruns/tuika/blob/v0.11.1/docs/features.md) ·
+[Keymap](https://github.com/everruns/tuika/blob/v0.11.1/docs/keymap.md) · [Input routing](https://github.com/everruns/tuika/blob/v0.11.1/docs/routing.md) ·
+[Styling](https://github.com/everruns/tuika/blob/v0.11.1/docs/styling.md) ·
+[Themes](https://github.com/everruns/tuika/blob/v0.11.1/docs/themes.md) \
+[Showcases](https://github.com/everruns/tuika/blob/v0.11.1/docs/showcases.md) · [Examples](#runnable-examples) ·
 [Changelog](CHANGELOG.md) · [Contributing](CONTRIBUTING.md) ·
 [Report a bug](https://github.com/everruns/tuika/issues)
 
@@ -29,7 +29,7 @@
 
 <div align="center">
 
-### tuika's goal is to become the default TUI [application](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) framework for Rust
+### tuika's goal is to become the default TUI [application](https://github.com/everruns/tuika/blob/v0.11.1/docs/showcases.md) framework for Rust
 
 **Build the app, not the render loop.**
 
@@ -71,14 +71,14 @@ You write views; tuika owns the rest:
 
 - **A whole app, not a widget set** — [flexbox layout](#model), anchored
   [overlays](#owned-scenes-dialogs-and-forms), focus, a declarative
-  [keymap](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md), [themes and stylesheets](#theming), and a
+  [keymap](https://github.com/everruns/tuika/blob/v0.11.1/docs/keymap.md), [themes and stylesheets](#theming), and a
   [runner](#screen-modes-lifecycle-and-runner) that owns raw mode, the alternate
   screen (or a [split footer](#screen-modes-lifecycle-and-runner) over live
   scrollback), and event translation.
 - **Batteries the terminal era expects** — [30+ components](#components)
-  including streaming [Markdown](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) with pluggable syntax
+  including streaming [Markdown](https://github.com/everruns/tuika/blob/v0.11.1/docs/markdown.md) with pluggable syntax
   highlighting, [images](#images) over Kitty/iTerm2/Sixel, adaptive
-  [charts](https://github.com/everruns/tuika/blob/v0.11.0/docs/charts.md), mermaid diagrams,
+  [charts](https://github.com/everruns/tuika/blob/v0.11.1/docs/charts.md), mermaid diagrams,
   [mouse selection and clipboard](#mouse-selection-and-clipboard), and
   [native OSC 9;4 progress](#native-terminal-progress).
 - **No lock-in** — it is additive to ratatui, not a replacement: wrap any
@@ -105,7 +105,7 @@ ratatui widget it likes (see [Compatibility](#compatibility)). (The optional
 `async` feature adds Tokio for [`AsyncRunner`](#screen-modes-lifecycle-and-runner);
 it is off by default.)
 
-See what that buys in practice: the [showcases](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) are
+See what that buys in practice: the [showcases](https://github.com/everruns/tuika/blob/v0.11.1/docs/showcases.md) are
 recordings of real applications running on tuika (also listed under
 [Used in](#used-in)), and the [`codex` example](examples/codex) is a whole
 coding-agent UI built with nothing else.
@@ -133,7 +133,7 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Live data** (`Live` / `LiveView`) is shared application state read at render
   time. Updates request a redraw from the runner; Tuika does not spawn data
   sources or reconcile a retained widget tree.
-- **Layout** is an [integer-native flexbox subset](https://github.com/everruns/tuika/blob/v0.11.0/docs/layout.md) (`layout`): wrapped flex lines,
+- **Layout** is an [integer-native flexbox subset](https://github.com/everruns/tuika/blob/v0.11.1/docs/layout.md) (`layout`): wrapped flex lines,
   independent basis/grow/shrink/min/max child styles, cross-line alignment, and
   exact boundary rounding over one direction-agnostic solver. `Flow` packages
   intrinsic wrapping; `Grid` is the smaller equal-column, row-major alternative
@@ -141,21 +141,21 @@ with tuika's surfaces (see [Compatibility](#compatibility)).
 - **Overlays** (`overlay`) anchor a view over the base tree; the **host**
   (`host`) owns the alternate screen, translates crossterm input, and
   composites the frame.
-- **Keymap** ([`keymap`](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md)) resolves declarative key bindings to
+- **Keymap** ([`keymap`](https://github.com/everruns/tuika/blob/v0.11.1/docs/keymap.md)) resolves declarative key bindings to
   named commands: chords (`ctrl+r`) and multi-stroke sequences (`g g`) grouped
   into prioritized, mode-gated `Layer`s, dispatched from a translated `Key` and
   queryable for help/`KeyHints` surfaces. Character chords are exact logical
   text (`A`, `?`, `ж`), so the active keyboard layout is applied before
   matching; Shift stays explicit for non-character keys such as `Shift+Enter`.
   Host-agnostic, so it unit-tests without a terminal. See the
-  [keymap guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/keymap.md).
-- **Input routing** ([`routing`](https://github.com/everruns/tuika/blob/v0.11.0/docs/routing.md)) delivers an event to the
+  [keymap guide](https://github.com/everruns/tuika/blob/v0.11.1/docs/keymap.md).
+- **Input routing** ([`routing`](https://github.com/everruns/tuika/blob/v0.11.1/docs/routing.md)) delivers an event to the
   surface that owns input this frame — every event kind through one
   registration, so a paste cannot take a different path from a key. `Router`
   reads the focus registry an overlay-bearing `Scene` already synchronized, and
   reports through `Delivery` which surface received what, including the case
   where nothing did. See the
-  [routing guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/routing.md).
+  [routing guide](https://github.com/everruns/tuika/blob/v0.11.1/docs/routing.md).
 - **Motion** (`anim`, `components::{Spinner, ProgressBar, Loader}`,
   `term::progress::TerminalProgress`) animates from a host-supplied frame counter and
   can drive the terminal's own OSC 9;4 progress indicator. `anim::Timeline` adds
@@ -190,50 +190,50 @@ path always means "you will use this constantly".
 
 ## Components
 
-See the [component gallery](https://github.com/everruns/tuika/blob/v0.11.0/docs/components.md) for an animated demo of each
+See the [component gallery](https://github.com/everruns/tuika/blob/v0.11.1/docs/components.md) for an animated demo of each
 component. Linked names below jump straight to their demo.
 
 | Component | Purpose |
 | --- | --- |
-| [`Text`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
+| [`Text`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/text.md#text) / `Paragraph` | Literal styled lines / word-wrapped prose with bare web links |
 | `Wrap` | Word-wraps pre-styled lines, preserving per-span styles |
-| [`Markdown`](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md) |
-| [`CodeBlock`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
-| [`Html`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
+| [`Markdown`](https://github.com/everruns/tuika/blob/v0.11.1/docs/markdown.md) (+ `MarkdownState`) | CommonMark → styled lines; `MarkdownState` streams incrementally — see the [markdown guide](https://github.com/everruns/tuika/blob/v0.11.1/docs/markdown.md) |
+| [`CodeBlock`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/markdown-code.md#codeblock) | Themed, framed code block with a pluggable `Highlighter` and optional line-number gutter |
+| [`Html`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/markdown-code.md#html) | HTML fragment → styled lines (companion crate [`tuika-html`](crates/tuika-html/)) |
 | `Diff` | Line diff (LCS), unified or side-by-side, with `+`/`-` gutters and line numbers |
 | `AsciiFont` | Large "figlet-style" block-letter banner text |
 | `QrCode` (+ `QrEcc`) | QR code (byte-mode v1–4 encoder) rendered with half-blocks |
-| [`Rule`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/text.md#rule) | Horizontal separator: optional title + fill glyph to width |
-| [`Flex`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#flex) | Flexbox container (the composition primitive) |
-| [`Flow`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#flow) | Intrinsic-width items wrapped into flex lines |
-| [`Grid`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#grid) | Small equal-column, row-major terminal grid |
+| [`Rule`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/text.md#rule) | Horizontal separator: optional title + fill glyph to width |
+| [`Flex`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#flex) | Flexbox container (the composition primitive) |
+| [`Flow`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#flow) | Intrinsic-width items wrapped into flex lines |
+| [`Grid`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#grid) | Small equal-column, row-major terminal grid |
 | `Responsive` / `Constrained` | Breakpoint selection and min/max measurement |
-| [`Boxed`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#boxed) | Border + padding + title, focus-aware |
+| [`Boxed`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#boxed) | Border + padding + title, focus-aware |
 | `Scene` / `ScopedScene` / `Dialog` | Owned or frame-borrowed root + anchored overlays |
-| [`ConfirmDialog`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#dialog-presets) / `ChoiceDialog` / `MultiChoiceDialog` / `InputDialog` | Stateful presets for common modal flows |
+| [`ConfirmDialog`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#dialog-presets) / `ChoiceDialog` / `MultiChoiceDialog` / `InputDialog` | Stateful presets for common modal flows |
 | `Spacer` | Flexible filler |
-| [`Scroll`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
-| [`ItemScroll`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
+| [`Scroll`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#scroll--scrollstate) (+ `ScrollState`) | Vertical scroll viewport + scrollbar over lines |
+| [`ItemScroll`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#itemscroll) | The same viewport over laid-out items (panels, tables, nested layouts) |
 | `Viewport` | Two-dimensional clipping/panning over any child view |
-| [`Scrollbar`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#scrollbar--virtualwindow) / `VirtualWindow` | Reusable bars and clamped ranges for virtualized collections |
+| [`Scrollbar`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#scrollbar--virtualwindow) / `VirtualWindow` | Reusable bars and clamped ranges for virtualized collections |
 | `Form` / `FormField` (+ `FormState`) | Responsive labeled controls and validation |
 | `DrawView` / `CanvasView` | Closure-based custom cell drawing |
-| [`SelectList`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
-| [`TreeList`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#treelist--treestate) (+ `TreeState`) | Stable-id expandable tree over host-provided rows |
-| [`SelectionScreen`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#selectionscreen) | Responsive full-screen action/agent/permission pickers |
-| [`KeyedTable`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
-| [`CompletionPalette`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
+| [`SelectList`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#selectlist--selectstate) (+ `SelectState`) | Selectable list, including host-windowed collections |
+| [`TreeList`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#treelist--treestate) (+ `TreeState`) | Stable-id expandable tree over host-provided rows |
+| [`SelectionScreen`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#selectionscreen) | Responsive full-screen action/agent/permission pickers |
+| [`KeyedTable`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#keyedtable--keyedselectstate) (+ keyed single/multi-selection) | Borrowed, virtualized slice or projected rows whose selection follows stable application keys |
+| [`CompletionPalette`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#completionpalette--completionstate) (+ `CompletionState`, `CompletionItem`) | Filter-ranked command and token completion |
 | `Slider` (+ `SliderState`) | One-row value picker over a numeric range |
-| [`TextInput`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |
-| [`StatusBar`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/layout.md#statusbar) | One-row left/right status segments |
-| [`Tabs`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/interactive.md#tabs--tabsstate) / `KeyHints` | Host-state tab navigation and command hints |
+| [`TextInput`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#textinput--textinputstate) (+ `TextInputState`) | Multi-line composer: soft-wrap, placeholder, highlighted ranges, `@`/`/` tokens |
+| [`StatusBar`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/layout.md#statusbar) | One-row left/right status segments |
+| [`Tabs`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/interactive.md#tabs--tabsstate) / `KeyHints` | Host-state tab navigation and command hints |
 | `TabSelect` (+ `TabSelectState`) | Value-selecting segmented control |
 | `Toasts` / `ToastList` | Transient notification stack with frame-driven expiry |
 | `Console` (+ `ConsoleLog`) | Captured stdout/log ring buffer + tailing overlay view |
-| [`Spinner`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#spinner) | Frame-cycled activity glyph |
-| [`ProgressBar`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#progressbar) | Determinate (sub-cell) / indeterminate bar |
-| [`ActivityList`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#activitylist) | Multi-step lifecycle status with optional per-step progress |
-| [`Loader`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/motion.md#loader) | Spinner + message + hint row |
+| [`Spinner`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/motion.md#spinner) | Frame-cycled activity glyph |
+| [`ProgressBar`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/motion.md#progressbar) | Determinate (sub-cell) / indeterminate bar |
+| [`ActivityList`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/motion.md#activitylist) | Multi-step lifecycle status with optional per-step progress |
+| [`Loader`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/motion.md#loader) | Spinner + message + hint row |
 
 ## Example
 
@@ -493,10 +493,10 @@ HTML parser is a dependency tuika will not carry. Attach a
 same ordered renderer chain handles fenced diagrams and block HTML with one
 context, including the active stylesheet.
 [`tuika-html`](crates/tuika-html/) is the ready-made one, and it also supplies
-the [`Html`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#html) component for markup that is not inside
+the [`Html`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/markdown-code.md#html) component for markup that is not inside
 markdown at all. See the markdown guide for
-[inline HTML](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md#inline-html) and
-[block HTML](https://github.com/everruns/tuika/blob/v0.11.0/docs/markdown.md#block-html).
+[inline HTML](https://github.com/everruns/tuika/blob/v0.11.1/docs/markdown.md#inline-html) and
+[block HTML](https://github.com/everruns/tuika/blob/v0.11.1/docs/markdown.md#block-html).
 
 ## Theming
 
@@ -515,7 +515,7 @@ let b = tuika::Theme::gruvbox_dark();                  // named constructor
 let c = tuika::themes::by_name("gruvbox-dark").unwrap(); // config / --theme
 ```
 
-See the [theme gallery](https://github.com/everruns/tuika/blob/v0.11.0/docs/themes.md) for a screenshot of each bundled
+See the [theme gallery](https://github.com/everruns/tuika/blob/v0.11.1/docs/themes.md) for a screenshot of each bundled
 palette, or `themes::PRESETS` to enumerate them for a picker.
 
 An app can also inherit the palette the user already configured in their
@@ -523,7 +523,7 @@ terminal, rather than bringing its own — either implicitly with `themes::TERMI
 (ANSI slots, no I/O) or by asking the terminal for its actual colors and deriving
 a full theme from the reply. It is opt-in: tuika never probes unless a host asks
 it to. The query lives with the other out-of-band escapes, in `term::palette`. See
-[inheriting the terminal's colors](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md#inheriting-the-terminals-colors).
+[inheriting the terminal's colors](https://github.com/everruns/tuika/blob/v0.11.1/docs/features.md#inheriting-the-terminals-colors).
 
 Where a `Theme` is the color *tokens*, a `StyleSheet` is the *rules* — a mapping
 from a semantic role (heading, link, inline code, a panel's border and fill, …)
@@ -531,7 +531,7 @@ onto the style it draws with. Override a role in one place and every element wit
 that role restyles at once; markdown, toast severities, diff rows, and key hints
 are role-driven too. Companion crates and applications can define namespaced
 `StyleRole`s and install a `StyleResolver` without expanding tuika's closed data
-model. See the [styling guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/styling.md). `StyleBundle::padding` is layout, not a
+model. See the [styling guide](https://github.com/everruns/tuika/blob/v0.11.1/docs/styling.md). `StyleBundle::padding` is layout, not a
 paint-only hint: `Boxed` resolves panel padding during both measurement and
 rendering; an explicit `Boxed::padding` remains the per-instance override.
 
@@ -671,7 +671,7 @@ threads, tasks, retries, and lifecycle.
   shape for a long-running tool with a live composer, status line, or progress
   panel over output the user wants to keep.
 
-The [screen-modes guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md#screen-modes-alternate-screen--split-footer)
+The [screen-modes guide](https://github.com/everruns/tuika/blob/v0.11.1/docs/features.md#screen-modes-alternate-screen--split-footer)
 shows the mode in motion and covers its terminal contract in detail.
 
 In split-footer mode a host must not `println!` — the footer owns the cursor.
@@ -924,7 +924,7 @@ selection — so a host should act on `plain()` left-drags.
 `Down`+`Up` and a swipe to scroll or a drag, so touch flows through this same
 path — there is no separate touch event to handle.
 
-> See the [terminal features guide](https://github.com/everruns/tuika/blob/v0.11.0/docs/features.md) for these
+> See the [terminal features guide](https://github.com/everruns/tuika/blob/v0.11.1/docs/features.md) for these
 > terminal-integration capabilities — OSC 8 hyperlinks, mouse selection and
 > clicks, OSC 52 clipboard, OSC 9;4 progress, and Kitty/iTerm2/Sixel images —
 > plus `Capabilities` detection, with demos and runnable examples.
@@ -966,7 +966,7 @@ not enter raw mode, capture input, hide the cursor, or own a screen.
 - [**LLMSim**](https://github.com/chaliy/llmsim) — an LLM traffic simulator whose
   live stats dashboard is a tuika screen.
 
-See the [showcases](https://github.com/everruns/tuika/blob/v0.11.0/docs/showcases.md) for a recording of each. Building
+See the [showcases](https://github.com/everruns/tuika/blob/v0.11.1/docs/showcases.md) for a recording of each. Building
 something on tuika? Open a PR adding it here.
 
 ## Compatibility
@@ -1018,7 +1018,7 @@ The separately published companion crates live in this repository:
   terminal diagrams through mmdflux.
 - [`tuika-html`](crates/tuika-html/) lays out block-level HTML with html5ever —
   inside Markdown through the `MarkdownBlockRenderer` boundary, or standalone
-  through its own [`Html`](https://github.com/everruns/tuika/blob/v0.11.0/docs/components/markdown-code.md#html) component.
+  through its own [`Html`](https://github.com/everruns/tuika/blob/v0.11.1/docs/components/markdown-code.md#html) component.
 
 All four keep specialized rendering and heavier parsers or grammars out of
 tuika core.

--- a/knowledge/processes/release.md
+++ b/knowledge/processes/release.md
@@ -73,9 +73,12 @@ because their published manifests pin a compatible tuika version. Update that
 requirement in the same change or the companion will resolve against old tuika.
 
 `publish.yml` derives the dependency-first order from Cargo metadata
-(`scripts/publish_order.py` — currently `tuika`, then its three companions) and
+(`scripts/publish_order.py` — currently `tuika`, then its four companions) and
 skips versions already live, so a workspace member cannot be silently omitted
-or published out of order.
+or published out of order. Only normal and build dependencies constrain that
+order: `cargo publish` strips dev-dependencies, and the root package
+dev-depends on companions that depend back on it, so counting those would
+report a cycle that publishing never has.
 
 ## Release Flow
 

--- a/scripts/publish_order.py
+++ b/scripts/publish_order.py
@@ -8,6 +8,11 @@ publishing — or publish it before the crate it depends on.
 Unlike a root-rooted traversal, this walks *every* workspace member: the root
 package (`tuika`) is a dependency of the member crate, not the other way round,
 so starting from the root would never reach `tuika-codeformatters`.
+
+Dev-dependencies are ignored. `cargo publish` strips them from the packaged
+manifest, so they impose no publish order — and the root package dev-depends on
+companions that depend back on it (examples render real charts and highlighted
+code), which would otherwise read as a cycle.
 """
 
 from __future__ import annotations
@@ -45,6 +50,8 @@ def publish_order(metadata: Mapping[str, Any]) -> list[str]:
         package = packages[name]
         dependencies: Sequence[Mapping[str, Any]] = package.get("dependencies", [])
         for dependency in dependencies:
+            if dependency.get("kind") == "dev":
+                continue
             dependency_name = dependency["name"]
             if dependency.get("path") and dependency_name in packages:
                 visit(dependency_name)

--- a/scripts/test_publish_order.py
+++ b/scripts/test_publish_order.py
@@ -91,6 +91,32 @@ class PublishOrderTests(unittest.TestCase):
 
         self.assertEqual(publish_order(metadata), ["tuika"])
 
+    def test_ignores_dev_dependency_back_edge(self) -> None:
+        # The real shape: `tuika`'s examples dev-depend on a companion that
+        # depends back on `tuika`. `cargo publish` strips dev-dependencies, so
+        # this is not a cycle and must not be treated as one.
+        metadata = {
+            "workspace_members": ["tuika-id", "charts-id"],
+            "packages": [
+                {
+                    "id": "charts-id",
+                    "name": "tuika-charts",
+                    "publish": None,
+                    "dependencies": [{"name": "tuika", "path": ".."}],
+                },
+                {
+                    "id": "tuika-id",
+                    "name": "tuika",
+                    "publish": None,
+                    "dependencies": [
+                        {"name": "tuika-charts", "path": "crates/tuika-charts", "kind": "dev"}
+                    ],
+                },
+            ],
+        }
+
+        self.assertEqual(publish_order(metadata), ["tuika", "tuika-charts"])
+
     def test_detects_dependency_cycle(self) -> None:
         metadata = {
             "workspace_members": ["a-id", "b-id"],


### PR DESCRIPTION
## [0.11.1] - 2026-08-25

`tuika` only. The companion crates carry a caret requirement on tuika 0.11, so
`tuika-charts` 0.1.2, `tuika-codeformatters` 0.5.0, `tuika-html` 0.1.4, and
`tuika-mermaid` 0.3.2 pick this up without a republish.

### Highlights

**Drag selection stays in the panel it started in** — a left drag that begins
inside a bordered `Boxed` now selects only within that panel: positions clamp to
its inner rect, a multi-row selection wraps at the panel's edges instead of the
screen's, and the copied text never picks up the pane beside it. A drag that
starts outside every panel still spans the screen as before.

![mouse demo](https://raw.githubusercontent.com/everruns/tuika/v0.11.1/docs/demos/mouse.gif)

- **Robustness**: a `SelectionRange` that outlived the geometry it was made in
  can no longer index the buffer out of bounds.

### Changed

- **Runner drag selection is per panel.** A left drag that starts inside a
  bordered `Boxed` selects only within that panel: positions clamp to its
  inner rect, a multi-row selection wraps at the panel's edges instead of the
  screen's, and the copied text never picks up the pane beside it. A drag that
  starts outside every panel still spans the screen as before.
- Examples render in a real terminal by default rather than printing a frame.

### Fixed

- A `SelectionRange` that reaches past the `area` handed to
  `mouse::paint_selection`, `mouse::selected_text`, or `SelectionRange::contains`
  now stops at that area's rows instead of indexing the buffer out of bounds.
- The routing guide is published on the website again.

### Added

- `mouse::SelectionState::confine` / `region` — restrict a gesture to a rect and
  read it back, for hosts driving the selection primitives from their own loop.
- `app_shell` and `workbench_demo` examples, with recordings.

### What's Changed

* fix(release): ignore dev-dependencies when ordering the publish
* docs(demos): add interactive AppShell recording
* feat(examples): add AppShell application
* fix(site): publish routing guide
* docs(demos): restore Workbench palette (#123)
* docs(readme): track current demo assets
* docs(demos): adopt Solarized Dark capture theme
* feat(examples): add native workbench showcase
* feat(examples): render in terminals by default
* feat(mouse): confine drag selection to the panel it starts in (#118)

---

## Publish path was broken on `main`

`feat(examples): add native workbench showcase` (unreleased) added a
`tuika-charts` **dev**-dependency to the root package. `tuika-charts` depends
back on `tuika`, so `scripts/publish_order.py` — which `publish.yml` calls to
derive the publish order — started reporting `workspace dependency cycle
involving tuika` and would have failed this release at the publish step.

`cargo publish` strips dev-dependencies, so they impose no publish order. The
traversal now skips them, with a regression test for the back edge. Order is
back to `tuika, tuika-charts, tuika-codeformatters, tuika-html, tuika-mermaid`.

## Version choice

Two new `pub` items land here (`mouse::SelectionState::confine` / `region`).
The repo rule maps a new `pub` item to a minor bump; `0.11.1` was chosen
deliberately instead, since the additions are purely additive and the companions'
caret requirement on `0.11` keeps resolving without a republish.

## Publish-readiness

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (all suites green, packaging included)
- [x] `cargo run --example demo -- check` — 42 scenes in sync
- [x] `cargo doc --all-features --no-deps`
- [x] `python3 scripts/validate_okf.py knowledge --check-links` — 16 concepts, 0 errors
- [x] `cargo publish --dry-run -p tuika` (companions are validated in CI after tuika publishes)
- [x] `python3 scripts/publish_order.py` starts with `tuika`
- [x] crates.io currently serves `0.11.0` → publishing `0.11.1`
- [x] `Cargo.toml` + `Cargo.lock` agree on `0.11.1`
- [x] every release-pinned root README URL repointed to `v0.11.1`
- [x] highlight demo current (`docs/demos/mouse.gif` re-recorded in this cycle by
      `docs(demos): adopt Solarized Dark capture theme`), embed pinned to `v0.11.1`

VHS/ttyd/ffmpeg are unavailable in this environment, so no scene was re-recorded
here — none needed it: the per-panel confinement is real-mouse behaviour in the
`Runner`, which no registry scene drives, and the `mouse` scene it belongs to was
already re-recorded after `v0.11.0`.

## Post-merge verification

- [ ] `release.yml` created tag `v0.11.1` and the GitHub Release
- [ ] `publish.yml` finished green
- [ ] crates.io serves `0.11.1`
- [ ] docs.rs built `0.11.1`

Do **not** enable auto-merge — a human clicks squash so the changelog gets read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXVodw6AsGKiLC7FXGDfQw)_