### PR TITLE
feat(runner): make mouse input explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ those `.crate` files. Their sources remain on
 [crates.io](https://crates.io/crates/tuika/versions); the tag and release history
 described in the release process begins with the entry below.
 
+## Unreleased
+
+### Added
+
+- `MouseInput`, plus `Runner::with_mouse_input` / `mouse_input` and matching
+  `AsyncRunner` methods, lets a host declare and inspect application mouse input
+  independently of its screen mode. Existing `ScreenMode` and
+  `TerminalSessionConfig` capture APIs remain compatible.
+
 ## [0.11.1] - 2026-08-25
 
 `tuika` only. The companion crates carry a caret requirement on tuika 0.11, so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,12 +178,8 @@ ratatui = "0.30.2"
 # The in-repo application-shell showcase exercises the published companion
 # components as a consumer would: adaptive charts and Rust syntax highlighting.
 tuika-charts = { version = "0.1.2", path = "crates/tuika-charts" }
-tuika-codeformatters = {
-    version = "0.5.0",
-    path = "crates/tuika-codeformatters",
-    default-features = false,
-    features = ["rust"],
-}
+# Cargo 1.88 rejects multiline inline tables; this syntax is part of the MSRV.
+tuika-codeformatters = { version = "0.5.0", path = "crates/tuika-codeformatters", default-features = false, features = ["rust"] }
 # Benchmark harness. default-features off drops the plotters/rayon HTML-report
 # stack (heavy, and an MSRV liability) while keeping `cargo bench` working;
 # Criterion still writes machine-readable `estimates.json` for archiving.

--- a/README.md
+++ b/README.md
@@ -876,9 +876,17 @@ To check support across every terminal feature in one place — `graphics`,
 
 Mouse handling stays with the terminal by default, including in alternate-screen
 mode. That preserves native OSC 8 link activation, click-drag selection, and
-terminal scrolling. An app that needs pointer or wheel events opts into capture
-with `ScreenMode::Alternate.with_mouse_capture()`,
-`ScreenMode::split_footer(rows).with_mouse_capture()`, an enabled
+terminal scrolling. A runner-based app that needs pointer or wheel events
+declares that input requirement independently of its viewport:
+
+```rust
+let runner = AsyncRunner::new(RunnerConfig::default())
+    .with_mouse_input(MouseInput::Captured);
+assert_eq!(runner.mouse_input(), MouseInput::Captured);
+```
+
+The declaration is the same for alternate-screen and split-footer modes.
+Custom-loop hosts use `ScreenMode::with_mouse_capture`, an enabled
 `TerminalSessionConfig::mouse_capture`, or
 `AltScreen::enter_with_mouse_capture()`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -252,7 +252,10 @@ must be enabled: `set -g allow-passthrough on`.
 
 Tuika leaves mouse handling to the terminal by default, preserving native OSC 8
 activation, selection, and scrolling. Capture is explicit through
-`ScreenMode::with_mouse_capture`, `MouseCapture::Enabled`, or
+`Runner::with_mouse_input(MouseInput::Captured)` (and its `AsyncRunner`
+counterpart). The runner's `mouse_input()` reports the effective policy, so a
+host can pin the assembled runtime configuration in a test. Custom-loop hosts
+use `ScreenMode::with_mouse_capture`, `MouseCapture::Enabled`, or
 `AltScreen::enter_with_mouse_capture`.
 
 Once an app opts into capture, the terminal stops handling links and selection.

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -12,15 +12,15 @@ fn main() -> io::Result<()> {
     let cli = support::Cli::parse()?;
     let theme = cli.theme;
     let capture_mouse = cli.args.iter().any(|argument| argument == "--mouse");
-    let screen_mode = if capture_mouse {
-        ScreenMode::Alternate.with_mouse_capture()
-    } else {
-        ScreenMode::Alternate
-    };
     let runner = Runner::new(RunnerConfig {
-        screen_mode,
+        screen_mode: ScreenMode::Alternate,
         ..RunnerConfig::default()
     });
+    let runner = if capture_mouse {
+        runner.with_mouse_input(MouseInput::Captured)
+    } else {
+        runner
+    };
 
     runner.run(
         &theme,

--- a/examples/select.rs
+++ b/examples/select.rs
@@ -119,9 +119,10 @@ fn main() -> io::Result<()> {
     let cli = support::Cli::parse()?;
     let theme = cli.theme;
     let runner = Runner::new(RunnerConfig {
-        screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+        screen_mode: ScreenMode::Alternate,
         ..RunnerConfig::default()
-    });
+    })
+    .with_mouse_input(MouseInput::Captured);
     let mut state = PickerState::new();
     runner.run(
         &theme,

--- a/examples/split_footer.rs
+++ b/examples/split_footer.rs
@@ -102,17 +102,17 @@ fn main() -> std::io::Result<()> {
         ));
     }
     let mode = ScreenMode::split_footer(FOOTER_ROWS);
-    let mode = if capture_mouse {
-        mode.with_mouse_capture()
-    } else {
-        mode
-    };
 
     let theme = cli.theme;
     let runner = Runner::new(RunnerConfig {
         tick_rate: Duration::from_millis(80),
         screen_mode: mode,
     });
+    let runner = if capture_mouse {
+        runner.with_mouse_input(MouseInput::Captured)
+    } else {
+        runner
+    };
     let scrollback = runner.scrollback();
     let status = Live::with_redraw(
         Status {

--- a/examples/tree_list.rs
+++ b/examples/tree_list.rs
@@ -150,9 +150,10 @@ impl Application for TreeApp {
 fn main() -> io::Result<()> {
     let cli = support::Cli::parse()?;
     Runner::new(RunnerConfig {
-        screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+        screen_mode: ScreenMode::Alternate,
         ..RunnerConfig::default()
     })
+    .with_mouse_input(MouseInput::Captured)
     .run(&cli.theme, &mut TreeApp::new())
 }
 

--- a/examples/workbench_demo/main.rs
+++ b/examples/workbench_demo/main.rs
@@ -143,7 +143,7 @@ fn main() -> std::io::Result<()> {
         return Ok(());
     }
 
-    let runner = Runner::new(runner_config());
+    let runner = Runner::new(runner_config()).with_mouse_input(MouseInput::Captured);
     let files = RectProbe::new();
     let render_files = files.clone();
     runner.run(
@@ -162,7 +162,7 @@ fn main() -> std::io::Result<()> {
 fn runner_config() -> RunnerConfig {
     RunnerConfig {
         tick_rate: Duration::from_millis(100),
-        screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+        screen_mode: ScreenMode::Alternate,
     }
 }
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,5 +1,19 @@
 # Knowledge Log
 
+## 2026-08-25
+
+- **Input requirements must survive viewport changes**
+  - A host can fully test click, drag, and wheel handlers by injecting
+    `Event::Mouse` through `run_driven_by` while its real runner session never
+    enables terminal mouse reporting. Both runners now accept an explicit,
+    inspectable `MouseInput` policy independently of `ScreenMode`; their PTY
+    coverage proves the assembled session emits and consumes real mouse input.
+    See [Screen modes](specs/screen-modes.md) and
+    [Architecture](specs/architecture.md).
+  - Worth keeping because a compile-clean viewport migration can otherwise
+    disable every pointer path at once, beyond the reach of component and
+    in-memory loop tests.
+
 ## 2026-08-22
 
 - **Published guides share one checked route inventory**

--- a/knowledge/specs/api-surface.md
+++ b/knowledge/specs/api-surface.md
@@ -67,9 +67,10 @@ module path would do for free.
 
 ### A startup decision can still earn the root
 
-`ScreenMode` and `Scrollback` sit at the crate root even though a host names the
-first once, at startup: the mode is a field of `RunnerConfig`, which is already
-there, and `TerminalSession` — also a once-per-run type — set the precedent. The
+`ScreenMode`, `MouseInput`, and `Scrollback` sit at the crate root even though a
+host names the first once, at startup: the mode is a field of `RunnerConfig`,
+which is already there, mouse input configures both runner types, and
+`TerminalSession` — also a once-per-run type — set the precedent. The
 rest of `screen` stays behind its module path, because `pin_footer`,
 `close_footer`, and `publish_block` are for hosts that drive their own loop, and
 an explicit `screen::` documents that call better than a bare name would.

--- a/knowledge/specs/architecture.md
+++ b/knowledge/specs/architecture.md
@@ -158,6 +158,14 @@ rather than beside it.
   extended to the run loop. The synchronous side gets its input through an
   `EventSource` because it blocks on a timeout rather than selecting on a
   stream; that trait is the boundary a scripted or custom input implements.
+- **Mouse input is a requirement, not a viewport property.** Runner hosts opt
+  into application mouse events with `MouseInput::Captured`, and can inspect
+  the effective policy before entering the terminal. `ScreenMode` still carries
+  its compatible low-level capture defaults for custom session hosts, but a
+  runner-level declaration survives a switch between alternate-screen and
+  split-footer geometry. This makes assembled runtime policy directly testable;
+  an in-memory `run_driven_by` test cannot prove that a real terminal was asked
+  to emit the mouse events it injects.
 - **The frame source is an argument, not a method name.** `FrameSource` has two
   implementors — `&mut app` for an `Application`, and `from_fn` over a state
   value and closures — so a run method never has to name which one it takes.

--- a/knowledge/specs/screen-modes.md
+++ b/knowledge/specs/screen-modes.md
@@ -30,11 +30,13 @@ until it happens.
 | `SplitFooter { height }` | `height` rows at the bottom of the main screen | the terminal's, live | off by default |
 
 Both modes preserve the terminal's native OSC 8 activation, selection, and
-scrolling by default. A host that needs pointer or wheel events opts into mouse
-capture with `with_mouse_capture`; capture necessarily takes those native
-behaviors away from the terminal. When a runner captures, it restores plain
-drag selection over its final cell frame while continuing to route wheel events
-to the application. Custom-loop hosts opt into capture and selection independently.
+scrolling by default. A runner host that needs pointer or wheel events declares
+`MouseInput::Captured` with `with_mouse_input`, independently of its viewport;
+the effective policy is inspectable through `mouse_input`. A custom-loop host
+opts into mouse capture through its screen or session policy. Capture necessarily
+takes native mouse behaviors away from the terminal. When a runner captures, it
+restores plain drag selection over its final cell frame while continuing to route
+wheel events to the application.
 
 A split footer renders into a ratatui `Viewport::Inline`. The pieces around it:
 
@@ -49,9 +51,10 @@ A split footer renders into a ratatui `Viewport::Inline`. The pieces around it:
   into the loop from elsewhere; `publish_block` commits one view straight from
   inside the loop, with no `Send` bound.
 
-Both runners drive all of this from `RunnerConfig::screen_mode`; hosts with
-their own loop compose the same pieces. The `codex` example runs either way
-(`--split-footer`), which is what keeps the hand-rolled path honest.
+Both runners drive viewport ownership from `RunnerConfig::screen_mode` and
+application mouse input from a runner-level policy; hosts with their own loop
+compose the same pieces. The `codex` example runs either way (`--split-footer`),
+which is what keeps the hand-rolled path honest.
 
 ## Design
 
@@ -78,6 +81,12 @@ Both screen modes therefore leave mouse handling to the emulator. A mode that
 needs application pointer or wheel input opts in with `with_mouse_capture`,
 accepting that native link activation, selection, and scrolling stop until the
 session restores the terminal state.
+
+Screen ownership and input requirements change for different reasons. A host
+may switch between an alternate screen and a split footer without ceasing to be
+mouse-driven, so runner APIs keep `MouseInput` separate from `ScreenMode` and
+let tests inspect the effective result. `ScreenMode::with_mouse_capture` remains
+the lower-level convenience for hosts that construct their own session.
 
 ### The footer is pinned, not merely inline
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -122,7 +122,27 @@ pub struct TerminalSession {
     cursor_hidden: bool,
 }
 
+/// Which side receives pointer and wheel input during a runner session.
+///
+/// [`Native`](Self::Native) leaves mouse handling to the terminal emulator,
+/// preserving its link activation, selection, and scrolling.
+/// [`Captured`](Self::Captured) asks the terminal to report mouse events to the
+/// application instead.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MouseInput {
+    /// The terminal emulator handles pointer and wheel input.
+    #[default]
+    Native,
+    /// The application receives pointer and wheel events.
+    Captured,
+}
+
 /// Mouse-capture policy for a [`TerminalSessionConfig`].
+///
+/// Runner hosts normally use [`MouseInput`] through
+/// [`Runner::with_mouse_input`](crate::Runner::with_mouse_input). This
+/// three-state policy remains for custom session configuration that wants to
+/// follow or override a [`ScreenMode`] default.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum MouseCapture {
     /// Follow the selected [`ScreenMode`].
@@ -136,6 +156,10 @@ pub enum MouseCapture {
 }
 
 /// Independently configurable terminal lifecycle policy.
+///
+/// [`with_mouse_input`](Self::with_mouse_input) is the explicit two-state
+/// convenience; [`mouse_input`](Self::mouse_input) exposes the effective result
+/// after resolving [`MouseCapture::ModeDefault`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TerminalSessionConfig {
     /// Screen ownership and viewport mode.
@@ -165,6 +189,24 @@ impl TerminalSessionConfig {
             enhanced_keyboard: true,
             mouse_capture: MouseCapture::ModeDefault,
             hide_cursor: true,
+        }
+    }
+
+    /// Set who receives mouse input, independently of the screen mode.
+    pub const fn with_mouse_input(mut self, mouse_input: MouseInput) -> Self {
+        self.mouse_capture = match mouse_input {
+            MouseInput::Native => MouseCapture::Disabled,
+            MouseInput::Captured => MouseCapture::Enabled,
+        };
+        self
+    }
+
+    /// The effective mouse-input behavior after resolving the mode default.
+    pub fn mouse_input(self) -> MouseInput {
+        if self.captures_mouse() {
+            MouseInput::Captured
+        } else {
+            MouseInput::Native
         }
     }
 
@@ -568,6 +610,26 @@ mod tests {
             ..TerminalSessionConfig::for_mode(ScreenMode::split_footer(3))
         };
         assert!(footer.captures_mouse());
+    }
+
+    #[test]
+    fn session_reports_the_effective_mouse_input() {
+        assert_eq!(
+            TerminalSessionConfig::for_mode(ScreenMode::Alternate).mouse_input(),
+            MouseInput::Native,
+        );
+        assert_eq!(
+            TerminalSessionConfig::for_mode(ScreenMode::split_footer(3))
+                .with_mouse_input(MouseInput::Captured)
+                .mouse_input(),
+            MouseInput::Captured,
+        );
+        assert_eq!(
+            TerminalSessionConfig::for_mode(ScreenMode::Alternate.with_mouse_capture())
+                .with_mouse_input(MouseInput::Native)
+                .mouse_input(),
+            MouseInput::Native,
+        );
     }
 
     /// A representative tree: a scrollable bordered body, a progress bar, and a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,8 @@ pub use dock::{DockEdge, DockLayout, DockPlacement, DockSpec, DockState};
 pub use event::{Event, EventFlow, InputOutcome, Key, KeyCode, Mouse, MouseButton, MouseKind};
 pub use geometry::{Padding, Size};
 pub use host::{
-    MouseCapture, TerminalSession, TerminalSessionConfig, paint, paint_scene, paint_with_context,
-    paint_with_sheet, translate_event,
+    MouseCapture, MouseInput, TerminalSession, TerminalSessionConfig, paint, paint_scene,
+    paint_with_context, paint_with_sheet, translate_event,
 };
 pub use layout::{
     Align, AlignContent, Dimension, Direction, FlexItemStyle, FlexLine, FlexWrap, Item, Justify,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -44,7 +44,7 @@ pub use crate::{
     Align, AlignContent, Application, AvailableSpace, Backdrop, Clock, Delivery, Dimension,
     Direction, DockEdge, DockLayout, DockPlacement, DockSpec, DockState, Element, Event, EventFlow,
     EventSource, FlexItemStyle, FlexWrap, FrameSource, InputOutcome, InputTarget, Justify, Key,
-    KeyCode, LayoutStyle, MeasureRequest, Mouse, MouseButton, MouseCapture, MouseKind,
+    KeyCode, LayoutStyle, MeasureRequest, Mouse, MouseButton, MouseCapture, MouseInput, MouseKind,
     OneShotOptions, Overlay, OverlaySpec, Padding, RenderCtx, RouteStage, Router, Runner,
     RunnerAction, RunnerConfig, RunnerCore, Scene, SceneOverlay, ScopedElement, ScopedScene,
     ScreenMode, Scrollback, SemanticRole, Signal, Size, StyleSheet, Surface, SystemClock,

--- a/src/runner/asynchronous.rs
+++ b/src/runner/asynchronous.rs
@@ -254,6 +254,27 @@ impl AsyncRunner {
         self
     }
 
+    /// Choose whether mouse input stays with the terminal or reaches the app.
+    ///
+    /// This is independent of [`ScreenMode`](crate::ScreenMode), so changing
+    /// the viewport does not accidentally change an application's input
+    /// requirements. The last call to this method or
+    /// [`with_session_config`](Self::with_session_config) wins.
+    pub fn with_mouse_input(self, mouse_input: crate::MouseInput) -> Self {
+        let config = self
+            .session_config
+            .unwrap_or_else(|| crate::TerminalSessionConfig::for_mode(self.config.screen_mode))
+            .with_mouse_input(mouse_input);
+        self.with_session_config(config)
+    }
+
+    /// The effective mouse-input behavior for this runner's terminal session.
+    pub fn mouse_input(&self) -> crate::MouseInput {
+        self.session_config
+            .unwrap_or_else(|| crate::TerminalSessionConfig::for_mode(self.config.screen_mode))
+            .mouse_input()
+    }
+
     /// Enable or disable runner-provided drag selection over the final cell
     /// frame. It is enabled by default whenever the terminal session captures
     /// the mouse. Applications claim a gesture by returning
@@ -264,11 +285,7 @@ impl AsyncRunner {
     }
 
     fn selects_text(&self) -> bool {
-        self.text_selection
-            && self.session_config.map_or_else(
-                || self.config.screen_mode.captures_mouse(),
-                crate::TerminalSessionConfig::captures_mouse,
-            )
+        self.text_selection && self.mouse_input() == crate::MouseInput::Captured
     }
 
     /// Return a handle for publishing content above a
@@ -927,8 +944,10 @@ mod tests {
     async fn clean_mouse_drag_uses_selection_when_mouse_is_captured() {
         let runner = AsyncRunner::new(RunnerConfig {
             tick_rate: Duration::from_secs(3600),
-            screen_mode: ScreenMode::Alternate.with_mouse_capture(),
-        });
+            screen_mode: ScreenMode::Alternate,
+        })
+        .with_mouse_input(crate::MouseInput::Captured);
+        assert_eq!(runner.mouse_input(), crate::MouseInput::Captured);
         let mut terminal = terminal(11, 1);
         let mut mouse_events = 0usize;
         let events = stream::iter([

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -6,6 +6,10 @@
 //! place does not have to assemble them itself. Either [`ScreenMode`] works:
 //! pick one in [`RunnerConfig::screen_mode`] and the loop reserves, keeps, and
 //! releases a split footer for you.
+//! Mouse input is a separate application requirement: opt in with
+//! [`Runner::with_mouse_input`] or [`AsyncRunner::with_mouse_input`] and inspect
+//! the assembled policy with `mouse_input()` without coupling it to the chosen
+//! viewport.
 //! On real terminals they also detect image support, supply a per-frame image
 //! layer through [`RenderCtx`], emit it after the cell frame, and bound resize
 //! redraws to one frame every 16 ms.
@@ -171,6 +175,9 @@ impl Drop for FrameGraphicsCleanup<'_> {
 
 #[derive(Clone, Copy, Debug)]
 /// Options for [`Runner`] and [`AsyncRunner`].
+///
+/// Mouse input is a runner-level application requirement rather than a field
+/// here; use `with_mouse_input` on the constructed runner.
 pub struct RunnerConfig {
     /// Maximum time between frames and data-driven redraw checks.
     pub tick_rate: Duration,
@@ -625,6 +632,26 @@ impl Runner {
         self
     }
 
+    /// Choose whether mouse input stays with the terminal or reaches the app.
+    ///
+    /// This is independent of [`ScreenMode`], so changing the viewport does not
+    /// accidentally change an application's input requirements. The last call
+    /// to this method or [`with_session_config`](Self::with_session_config) wins.
+    pub fn with_mouse_input(self, mouse_input: crate::MouseInput) -> Self {
+        let config = self
+            .session_config
+            .unwrap_or_else(|| crate::TerminalSessionConfig::for_mode(self.config.screen_mode))
+            .with_mouse_input(mouse_input);
+        self.with_session_config(config)
+    }
+
+    /// The effective mouse-input behavior for this runner's terminal session.
+    pub fn mouse_input(&self) -> crate::MouseInput {
+        self.session_config
+            .unwrap_or_else(|| crate::TerminalSessionConfig::for_mode(self.config.screen_mode))
+            .mouse_input()
+    }
+
     /// Enable or disable runner-provided drag selection over the final cell
     /// frame. It is enabled by default whenever the terminal session captures
     /// the mouse. Applications claim a gesture by returning
@@ -635,11 +662,7 @@ impl Runner {
     }
 
     fn selects_text(&self) -> bool {
-        self.text_selection
-            && self.session_config.map_or_else(
-                || self.config.screen_mode.captures_mouse(),
-                crate::host::TerminalSessionConfig::captures_mouse,
-            )
+        self.text_selection && self.mouse_input() == crate::MouseInput::Captured
     }
 
     /// Run until the frame source returns [`UpdateResult::Exit`].
@@ -1301,6 +1324,25 @@ mod tests {
                 })
                 .selects_text()
         );
+    }
+
+    #[test]
+    fn runner_mouse_input_is_explicit_and_inspectable() {
+        let native = Runner::new(RunnerConfig::default());
+        assert_eq!(native.mouse_input(), crate::MouseInput::Native);
+
+        let captured =
+            Runner::new(RunnerConfig::default()).with_mouse_input(crate::MouseInput::Captured);
+        assert_eq!(captured.mouse_input(), crate::MouseInput::Captured);
+        assert!(captured.selects_text());
+
+        let native_override = Runner::new(RunnerConfig {
+            screen_mode: ScreenMode::Alternate.with_mouse_capture(),
+            ..RunnerConfig::default()
+        })
+        .with_mouse_input(crate::MouseInput::Native);
+        assert_eq!(native_override.mouse_input(), crate::MouseInput::Native);
+        assert!(!native_override.selects_text());
     }
 
     #[test]

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -131,6 +131,9 @@ impl ScreenMode {
     ///
     /// This is opt-in because terminal mouse reporting takes native OSC 8 link
     /// activation, selection, and scrolling away from the terminal emulator.
+    /// Runner-based hosts should prefer
+    /// [`Runner::with_mouse_input`](crate::Runner::with_mouse_input), which
+    /// keeps the input requirement independent of viewport selection.
     pub fn with_mouse_capture(self) -> Self {
         match self {
             Self::Alternate | Self::AlternateWithMouseCapture => Self::AlternateWithMouseCapture,

--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -472,6 +472,10 @@ fn runner_drag_selection_copies_the_rendered_cells() {
 
     assert!(run.exited_ok, "hello should exit cleanly after selection");
     assert!(
+        contains(&run.output, b"\x1b[?1000h"),
+        "runner-level mouse input should enable terminal reporting"
+    );
+    assert!(
         contains(&run.output, b"\x1b]52;c;SGVsbG8=\x1b\\"),
         "drag release should copy `Hello` through OSC 52"
     );

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -455,18 +455,20 @@ fn the_former_root_collisions_resolve() {
     assert!(grid(&screen).contains("hi"));
 }
 
-/// The screen mode is a host's first decision, so the two names it needs are on
-/// the spine; the rest of `screen` is for hosts driving their own loop and keeps
-/// its module path.
+/// Screen ownership and mouse input are host decisions, so the names a runner
+/// needs are on the spine; the rest of `screen` is for hosts driving their own
+/// loop and keeps its module path.
 #[test]
-fn the_screen_mode_is_reachable_from_the_prelude() {
+fn screen_and_mouse_input_are_reachable_from_the_prelude() {
     // From the prelude alone: pick a mode and hand it to a runner.
     let mode = ScreenMode::split_footer(6);
     assert_eq!(mode.footer_height(), Some(6));
     let runner = Runner::new(RunnerConfig {
         screen_mode: mode,
         ..RunnerConfig::default()
-    });
+    })
+    .with_mouse_input(MouseInput::Captured);
+    assert_eq!(runner.mouse_input(), MouseInput::Captured);
 
     // The publishing handle comes off the runner and takes views.
     let scrollback: Scrollback = runner.scrollback();


### PR DESCRIPTION
## What changed

Runner and AsyncRunner hosts can now declare `MouseInput::Captured` independently of `ScreenMode` and inspect the effective policy through `mouse_input()`. `TerminalSessionConfig` exposes the same explicit/effective vocabulary. Existing screen-mode and session APIs remain compatible.

Interactive runner examples now use the runner-level declaration. The root manifest also keeps the existing `tuika-codeformatters` dev-dependency inline table on one line so Cargo 1.88 can parse the MSRV build; versions and features are unchanged.

This is an additive public API change: `MouseInput`, `TerminalSessionConfig::{with_mouse_input, mouse_input}`, `Runner::{with_mouse_input, mouse_input}`, and the equivalent AsyncRunner methods are new.

## Why

A host could test click, drag, and wheel handlers by injecting `Event::Mouse` through `run_driven_by` while its real terminal session never enabled mouse reporting. Changing viewport configuration could therefore disable every mouse path without a compile error or an inspectable runner policy.

## Before / After

Before: mouse intent was encoded indirectly in `ScreenMode` or an advanced `TerminalSessionConfig`, and assembled runner policy was not observable.

After:

```rust
let runner = AsyncRunner::new(config)
    .with_mouse_input(MouseInput::Captured);
assert_eq!(runner.mouse_input(), MouseInput::Captured);
```

Evidence:

- `runner_drag_selection_copies_the_rendered_cells` runs `hello --mouse` under a PTY, observes mouse-reporting enablement, sends a real SGR drag, and observes the OSC 52 copy of `Hello`.
- `split_footer_captures_the_mouse_only_when_asked` proves the same runner-level policy works without entering the alternate screen and is restored on exit.
- Manual terminal smoke showed capture enablement, highlighted the dragged cells, copied `Hello`, and restored all mouse modes on exit.

## Risk

- Medium: this is additive API around terminal-global mouse state.
- Existing defaults and APIs are unchanged. The new policy resolves to the same `TerminalSessionConfig` path and retains the established RAII restoration behavior.

## Checklist

- [x] Tests added or updated
- [x] Backward compatibility considered
- [x] Knowledge concepts updated, or no update required with a reason

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env -u NO_COLOR cargo test --workspace --all-features`
- focused PTY mouse tests in alternate-screen and split-footer modes
- `cargo +1.88 check --locked --workspace --all-targets`
- `cargo doc --workspace --all-features --no-deps`
- `python3 scripts/validate_okf.py knowledge --check-links`
- manual `cargo run --example hello -- --mouse` terminal smoke

## Knowledge

Updated screen modes, architecture, public API surface, and the knowledge log to record that application input requirements are independent from viewport ownership and that in-memory event injection cannot prove terminal capture.

## Security

- **TM-STATE:** reviewed. The new methods select the existing session capture policy; enter/restore behavior is unchanged. PTY coverage asserts the capture/release pair and manual smoke confirmed cleanup.
- **TM-ESC:** reviewed. No caller string reaches an escape encoder; only the existing typed capture policy is selected.
- **TM-PARSE / TM-CLIP:** not affected; no parsing, rendering, or geometry paths changed.
- **TM-DEP:** no dependency or feature changes. The manifest edit only restores Cargo 1.88-compatible syntax for an existing dev-dependency.

## Follow-ups

No follow-ups.